### PR TITLE
fix(masters): stop personas narrating their own setup ("法师风格已立") — v0.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "master-skill",
       "description": "Buddhist Master AI teaching personas — 14 prebuilt masters across 汉传/藏传/南传 plus 3 teaching meta-skills (compare-masters / master-debate / master-curriculum), invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "source": "./",
       "author": {
         "name": "xr843",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "master-skill",
   "description": "Buddhist Master AI teaching personas — 14 prebuilt masters across 汉传/藏传/南传 plus 3 teaching meta-skills (compare-masters / master-debate / master-curriculum), invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "xr843",
     "email": "xr843@users.noreply.github.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "master-skill",
   "displayName": "Master Skill",
   "description": "Buddhist Master AI teaching personas — 14 prebuilt masters across 汉传/藏传/南传 invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "xr843",
     "email": "xr843@users.noreply.github.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-06-30
+
+### Fixed — personas no longer narrate their own setup ("法师风格已立")
+- **Suppressed process-narration leakage across all 15 personas.** When a master ran the offline→live decision (e.g. `/master-xuanzang` answering a question outside its declared `sources:`), it would prepend scaffolding like "法师风格已立。…容我先向 FoJin 检索正典" — the model verbalizing its internal "load `voice.md` / establish persona / now retrieving" steps as user-facing text. Root cause: the decision tree framed "建立人格" as an explicit step and nothing in `输出要求` forbade announcing it. Each persona's `SKILL.md` now (a) annotates the 风格对话 decision-tree branch as **internal-only** ("内化即可，勿向用户复述此步"), and (b) adds an `输出要求` item **不作过程旁白** — answer directly in the master's voice; never recite "加载/建立人格/正在检索" or declare "风格已立"; in-character one-liners for a live lookup are fine, system-style narration is not.
+- Citation honesty and the live-grounding behavior itself are unchanged — this only removes the meta-commentary. Per-master `SKILL.md` minor bump; package 0.9.0 → 0.9.1.
+
 ## [0.9.0] — 2026-06-30
 
 ### Added — FoJin live grounding rolled out to the remaining 14 masters (now all 15)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "master-skill",
   "description": "Buddhist Master AI teaching personas — 14 prebuilt masters across 汉传/藏传/南传 invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism)",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-skill",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "Buddhist Master AI Skills — RAG-grounded, source-cited, fidelity-tested. 15 pre-built masters across 四大传统 invokable via /master-<slug> slash commands: 1 印度 (Nāgārjuna · Madhyamaka root) + 8 汉传 (Xuanzang, Kumārajīva, Huineng, Zhiyi, Fazang, Yinguang, Ouyi, Xuyun) + 3 藏传 (Atiśa, Tsongkhapa, Milarepa) + 3 南传 (Buddhaghosa, Mahasi Sayadaw, Ajahn Chah), plus 3 teaching meta-skills: /compare-masters (parallel), /master-debate (4-round adversarial), /master-curriculum (sequenced study path).",
   "bin": {

--- a/prebuilt/master-ajahn-chah/SKILL.md
+++ b/prebuilt/master-ajahn-chah/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-ajahn-chah
 description: Use when user asks about 南传佛教, 上座部, Theravada, 巴利经典, 正念 sati, 放下, 三法印, 四念处, 出入息念 anapanasati, 戒定慧, 毗婆舍那, 森林禅林派, 巴蓬寺, 阿姜查, 杜多行, 中道, or wants teaching in 阿姜查 Ajahn Chah's voice. Triggers include "阿姜查"、"Ajahn Chah"、"森林禅"、"上座部"、"南传"、"巴利"、"正念"、"放下"、"禅修方法"、"妄念太多"、"打坐坐不住"、"巴蓬寺"、"杜多行"、"心的训练" — invoke whenever user's question touches Theravada / Thai Forest / mindfulness practice or asks about Ajahn Chah, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 南传上座部（泰国森林禅林派 / 巴蓬寺传承）
 dates: 1918-1992
@@ -37,7 +37,7 @@ verified_at: 2026-05-02
 - **戒律 / 出家生活 / 杜多行**（vinaya / dhutanga / 头陀）
   → 读 `references/teaching.md` §戒与森林生活
 - **风格对话**（"想和阿姜查交流"/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -121,6 +121,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-atisha/SKILL.md
+++ b/prebuilt/master-atisha/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-atisha
 description: Use when user asks about 藏传, 噶当派, Kadam, 三士道, 菩提道灯论, Bodhipathapradīpa, 阿底峡, Atiśa, 金洲大师, 七因果, 自他相换, 菩提心, 依止善知识, 暇满, 业果, 噶当六论, 仲敦巴, 热振寺, 藏地后弘期, or wants teaching in 阿底峡尊者 Atiśa's voice. Triggers include "阿底峡"、"觉沃杰"、"Atisha"、"Jowo Je"、"菩提道灯"、"道灯论"、"三士道"、"七因果"、"自他相换"、"金洲"、"噶当"、"仲敦巴"、"热振寺"、"道次第之祖" — invoke whenever user's question touches Kadam / lamrim foundations / bodhicitta cultivation, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 藏传佛教·噶当派 (印藏桥梁)
 dates: 982-1054
@@ -33,7 +33,7 @@ verified_at: 2026-05-02
 - **依止善知识 / 噶当六论**（kalyāṇamitra / 闻思修）
   → 读 `references/teaching.md` §依止善知识
 - **风格对话**（"想和阿底峡尊者请益"/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -121,6 +121,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-buddhaghosa/SKILL.md
+++ b/prebuilt/master-buddhaghosa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-buddhaghosa
 description: Use when user asks about 南传, 上座部, Theravāda, 巴利, 清净道论, Visuddhimagga, 戒定慧, 四十种业处, kammaṭṭhāna, 十遍, kasiṇa, 七清净, 十六观智, 阿毗达摩, Abhidhamma, 觉音尊者, Buddhaghosa, 大寺派, Mahāvihāra, 缘起十二支, 三法印, or wants teaching in 觉音尊者 Buddhaghosa's voice. Triggers include "觉音"、"Buddhaghosa"、"清净道论"、"Visuddhimagga"、"戒定慧三学"、"四十业处"、"七清净"、"十六观智"、"阿毗达摩注释"、"尼柯耶注释"、"上座部论师"、"大寺派" — invoke whenever user's question touches Theravāda commentarial / Visuddhimagga / Abhidhamma exegesis, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 南传上座部·斯里兰卡大寺派 (Mahāvihāra)
 dates: 5世纪
@@ -39,7 +39,7 @@ verified_at: 2026-05-02
 - **阿毗达摩义理**（心 / 心所 / 色 / 涅槃 / 四谛）
   → 读 `references/teaching.md` §阿毗达摩
 - **风格对话**（"想和觉音尊者请益"/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -130,6 +130,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-fazang/SKILL.md
+++ b/prebuilt/master-fazang/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-fazang
 description: Use when user asks about 华严宗, 法界缘起, 四法界, 事事无碍, 十玄门, 六相圆融, 金师子章, 一即一切, 因陀罗网, 华严经, 五教判, or wants teaching in 法藏大师 Fazang's voice. Triggers include phrases like "华严"、"法藏"、"贤首"、"法界"、"事事无碍"、"十玄"、"六相"、"金师子"、"一即一切"、"理事无碍"、"因陀罗网"、"别教一乘"、"五教"、"毗卢遮那"、"一真法界" — invoke whenever user's question touches Huayan doctrine, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 华严宗
 dates: 643-712
@@ -44,7 +44,7 @@ verified_at: 2026-04-06
 - **修行方法**（法界观 / 妄尽还源观 / 普贤行愿）
   → 读 `references/teaching.md` §修行方法 + `sources/wujiao-zhang-excerpts.md`
 - **风格对话**（"想和法藏大师聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -126,6 +126,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-huineng/SKILL.md
+++ b/prebuilt/master-huineng/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-huineng
 description: Use when user asks about 禅宗, 六祖, 坛经, 顿悟, 见性成佛, 直指人心, 不立文字, 自性, 本心, 无念, 无相, 无住, 般若, 定慧一体, 明心见性, 南宗禅, or wants teaching in 慧能大师 Huineng's voice. Triggers include phrases like "禅"、"慧能"、"六祖"、"坛经"、"顿悟"、"见性"、"本来面目"、"菩提本无树"、"风动幡动"、"本来无一物"、"自性"、"机锋"、"烦恼即菩提"、"不二"、"弘忍" — invoke whenever user's question touches Chan/Zen doctrine, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 禅宗（南宗禅）
 dates: 638-713
@@ -36,7 +36,7 @@ verified_at: 2026-04-06
 - **典故公案**（菩提本无树 / 风幡心动 / 猎人队 / 一花五叶）
   → 读 `references/teaching.md` §常用典故
 - **风格对话**（"想和六祖聊聊"/参禅请求/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 上述三部经之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -118,6 +118,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：`cbeta_id` 必须 ∈ 本 master frontmatter `sources:` 声明（T48n2008 / T08n0235 / T14n0475）；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-kumarajiva/SKILL.md
+++ b/prebuilt/master-kumarajiva/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-kumarajiva
 description: Use when user asks about 中观, 三论宗, 般若, 空性, 中道, 八不, 缘起性空, 法华经, 金刚经, 维摩诘, 不二法门, 一佛乘, 大智度论, or wants teaching in 鸠摩罗什 Kumārajīva's voice. Triggers include phrases like "中观"、"三论"、"空"、"般若"、"中道"、"八不"、"缘起性空"、"法华"、"金刚经"、"维摩诘"、"不二"、"实相"、"一佛乘"、"鸠摩罗什"、"罗什"、"会三归一"、"火宅"、"方便"、"中论"、"大智度论"、"百论"、"十二门论" — invoke whenever user's question touches Madhyamaka/Prajñā/Lotus doctrine, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 三论宗/中观
 dates: 344-413
@@ -47,7 +47,7 @@ verified_at: 2026-04-06
 - **翻译理念**（意译 / 旧译 / 嚼饭与人 / 翻译文学性）
   → 读 `references/teaching.md` §翻译理念
 - **风格对话**（"想和罗什大师聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -129,6 +129,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-mahasi-sayadaw/SKILL.md
+++ b/prebuilt/master-mahasi-sayadaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-mahasi-sayadaw
 description: Use when user asks about 南传, 上座部, 缅甸内观, Mahasi Method, 标记法, Noting Method, 腹部起伏, 毗婆舍那, vipassanā, 四念处, 七清净, 十六观智, 刹那定, 行舍智, 马哈希尊者, Mahasi Sayadaw, Mahasi Sasana Yeiktha, IMS, or wants teaching in 马哈希尊者 Mahāsi Sayādaw's voice. Triggers include "马哈希"、"Mahasi"、"Sayadaw"、"标记法"、"腹部起伏"、"缅甸内观"、"密集禅修"、"十六观智"、"刹那定"、"妄念太多" — invoke whenever user's question touches Burmese vipassanā / Mahasi noting method, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 南传上座部·缅甸内观传统 (Mahasi Method)
 dates: 1904-1982
@@ -44,7 +44,7 @@ verified_at: 2026-05-02
 - **'初果可证' / 密集禅修期待**
   → 读 `references/teaching.md` §密集禅修 + ⚠️ **AI 不得作证果判定**
 - **风格对话**（"想和马哈希尊者请益"/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -139,6 +139,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-milarepa/SKILL.md
+++ b/prebuilt/master-milarepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-milarepa
 description: Use when user asks about 藏传佛教, 噶举派, 大手印, phyag chen, 拙火, tummo, 那洛六法, 苦行, 闭关, 道歌, mgur, 米拉日巴, 玛尔巴, 上师瑜伽, 出离, 暇满, 中阴, 气脉明点, 觉受, nyams, 本觉, rig pa, or wants teaching in 米拉日巴尊者 Milarepa's voice. Triggers include "米拉日巴"、"密勒日巴"、"Milarepa"、"道歌"、"十万歌集"、"大手印"、"拙火"、"那洛六法"、"玛尔巴"、"噶举"、"白教"、"山洞修行"、"苦行"、"上师瑜伽"、"中阴"、"明空" — invoke whenever user's question touches Tibetan Kagyu / Mahāmudrā / yogi practice or asks about Milarepa's life and teachings, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 藏传佛教（噶举派 / 达波噶举）
 dates: 1052-1135
@@ -35,7 +35,7 @@ verified_at: 2026-05-02
 - **上师瑜伽 / 玛尔巴 / 信心**（依止善知识 / 译师玛尔巴 / 信心生起）
   → 读 `references/teaching.md` §上师瑜伽
 - **风格对话**（"想和米拉日巴尊者交流"/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -117,6 +117,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-nagarjuna/SKILL.md
+++ b/prebuilt/master-nagarjuna/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-nagarjuna
 description: Use when user asks about 中观, 空性, 缘起性空, 八不中道, 二谛, 世俗谛, 第一义谛, 戏论, 毕竟空, 不可得, 如幻, 离四句, 破自性, 难行道易行道, 龙树, or wants teaching in 龙树菩萨 Nāgārjuna's voice. Triggers include phrases like "空"、"中观"、"缘起"、"性空"、"八不"、"中道"、"二谛"、"世俗谛"、"第一义谛"、"戏论"、"毕竟空"、"不可得"、"如幻"、"离四句"、"涅槃与世间"、"龙树"、"中论"、"大智度论"、"十二门论"、"回诤论"、"易行道" — invoke whenever user's question touches Madhyamaka/emptiness/two-truths doctrine, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 印度·中观
 dates: 约150-250
@@ -46,7 +46,7 @@ verified_at: 2026-06-24
 - **念佛 / 难易二道**（难行道 / 易行道 / 信方便 / 阿惟越致）
   → 读 `sources/shizhu-yixing-excerpts.md` + `references/teaching.md` §难易二道
 - **风格对话**（"想和龙树菩萨聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -131,6 +131,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+7. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-ouyi/SKILL.md
+++ b/prebuilt/master-ouyi/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-ouyi
 description: Use when user asks about 蕅益大师, 教宗天台, 行归净土, 六信, 弥陀要解, 教观纲宗, 灵峰宗论, 性相融会, 禅教律净, 念佛, 事持理持, 现前一念, 一念心性, 净土宗第九祖, 明末四大高僧, 占察忏, or wants teaching in 蕅益 Ouyi's voice. Triggers include "蕅益"、"智旭"、"弥陀要解"、"教宗天台"、"行归净土"、"六信"、"事持"、"理持"、"性相融会"、"禅教律净"、"教观纲宗"、"灵峰"、"现前一念"、"明末四大高僧"、"占察轮相" — invoke whenever user's question touches Ouyi's cross-school synthesis or Tiantai-Pureland integration, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 天台宗/净土宗（跨宗派）
 dates: 1599-1655
@@ -42,7 +42,7 @@ verified_at: 2026-04-06
 - **修行方法**（持名念佛 / 持戒 / 占察忏）
   → 读 `references/teaching.md` §修行方法
 - **风格对话**（"想和蕅益大师聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -124,6 +124,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-tsongkhapa/SKILL.md
+++ b/prebuilt/master-tsongkhapa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-tsongkhapa
 description: Use when user asks about 藏传, 格鲁派, Gelug, 黄教, 三主要道, 菩提道次第广论, lam rim, 密宗道次第广论, 应成中观, 缘起性空, 辨了不了义, 宗喀巴, Tsongkhapa, Je Rinpoche, 甘丹寺, 戒律, 因明, 月称, 入中论, or wants teaching in 宗喀巴大师 Tsongkhapa's voice. Triggers include "宗喀巴"、"杰仁波切"、"Je Rinpoche"、"格鲁"、"黄教"、"道次第"、"广论"、"三主要道"、"应成中观"、"辨了不了义"、"甘丹"、"达赖喇嘛传承根基" — invoke whenever user's question touches Gelug doctrine / lamrim / Madhyamaka prasaṅgika / Tibetan tantra-shastra studies, even without explicit request.
-version: 1.1.0
+version: 1.2.0
 license: MIT
 lineage: 藏传佛教·格鲁派 (新噶当)
 dates: 1357-1419
@@ -40,7 +40,7 @@ verified_at: 2026-05-02
 - **格鲁派传承 / 甘丹寺 / 默朗钦摩 / 达赖班禅**
   → 读 `references/teaching.md` §传承与背景
 - **风格对话**（"想和宗喀巴大师请益"/角色扮演）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -132,6 +132,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-xuanzang/SKILL.md
+++ b/prebuilt/master-xuanzang/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-xuanzang
 description: Use when user asks about 唯识, 法相宗, 阿赖耶识, 末那识, 三性, 遍计所执, 依他起, 圆成实, 五位百法, 因明, 转识成智, 种子, 熏习, 瑜伽师地论, 成唯识论, or wants teaching in 玄奘法师 Xuanzang's voice. Triggers include phrases like "唯识"、"法相"、"玄奘"、"阿赖耶"、"末那"、"三性"、"百法"、"因明"、"转识成智"、"种子"、"遍计所执"、"依他起"、"圆成实"、"五种不翻"、"唯识三十颂"、"瑜伽"、"慈恩" — invoke whenever user's question touches Yogācāra/Vijñānavāda doctrine, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 法相唯识宗
 dates: 602-664
@@ -47,7 +47,7 @@ verified_at: 2026-04-06
 - **般若/心经**（空性 / 心经 / 色空不二）
   → 读 `sources/xinjing-excerpts.md`
 - **风格对话**（"想和玄奘法师聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -129,6 +129,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-xuyun/SKILL.md
+++ b/prebuilt/master-xuyun/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-xuyun
 description: Use when user asks about 虚云, 参禅, 话头, 念佛是谁, 疑情, 开悟, 桶底脱落, 禅七, 行香, 丛林, 五宗兼嗣, 临济, 曹洞, 沩仰, 云门, 法眼, 老实修行, 头陀行, 持戒, 禅净双修, 云居山, 南华寺, or wants teaching in 虚云老和尚 Xuyun's voice. Triggers include "虚云"、"参话头"、"念佛是谁"、"疑情"、"禅七"、"行香"、"丛林规矩"、"桶底脱落"、"五宗"、"杯子扑落地"、"老实修行"、"头陀"、"禅堂"、"坐禅"、"数息" — invoke whenever user's question touches Chan practice, meditation methods, or monastic discipline, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 禅宗（五宗兼嗣）
 dates: 1840-1959
@@ -39,7 +39,7 @@ verified_at: 2026-04-06
 - **禅净关系**（禅净双修 / 念佛与参禅）
   → 读 `references/teaching.md` §禅净双修
 - **风格对话**（"想和虚云老和尚聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -121,6 +121,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-yinguang/SKILL.md
+++ b/prebuilt/master-yinguang/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-yinguang
 description: Use when user asks about 印光大师, 净土, 念佛, 持名念佛, 十念法, 摄耳谛听, 老实念佛, 信愿行, 带业往生, 仗佛慈力, 自力他力, 竖出横超, 往生, 极乐, 阿弥陀佛, 净土三经, 敦伦尽分, 闲邪存诚, 因果报应, 文钞, 一函遍复, or wants teaching in 印光大师 Yinguang's voice. Triggers include "印光"、"文钞"、"老实念佛"、"信愿行"、"带业往生"、"仗佛慈力"、"横超竖出"、"都摄六根"、"净念相继"、"敦伦尽分"、"闲邪存诚"、"因果"、"十念法"、"摄耳谛听"、"一函遍复"、"净土三经"、"往生" — invoke whenever user's question touches Pure Land practice, Amitabha recitation, or faith-vow-practice, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 净土宗
 dates: 1862-1940
@@ -42,7 +42,7 @@ verified_at: 2026-04-06
 - **经典学习**（净土三经 / 阿弥陀经 / 观经 / 无量寿经）
   → 读 `sources/jingtu-sanjing-excerpts.md`
 - **风格对话**（"想和印光大师聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -124,6 +124,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 

--- a/prebuilt/master-zhiyi/SKILL.md
+++ b/prebuilt/master-zhiyi/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: master-zhiyi
 description: Use when user asks about 天台宗, 止观, 一念三千, 三谛圆融, 五时八教, 摩诃止观, 法华经, or wants teaching in 智者大师 Zhiyi's voice. Triggers include phrases like "天台"、"智者大师"、"止观怎么修"、"三谛"、"法华"、"一心三观"、"判教"、"圆教"、"四种三昧" — invoke whenever user's question touches Tiantai doctrine, even without explicit request.
-version: 0.4.0
+version: 0.5.0
 license: MIT
 lineage: 天台宗
 dates: 538-597
@@ -42,7 +42,7 @@ verified_at: 2026-04-06
 - **法华经义理**（开权显实 / 会三归一 / 穷子喻）
   → 读 `sources/fahua-xuanyi-excerpts.md`
 - **风格对话**（"想和智者大师聊聊"/角色扮演请求）
-  → 读 `references/voice.md` 建立人格，再按上述分类响应
+  → 读 `references/voice.md` 建立人格（**内化即可，勿向用户复述此步**），再按上述分类响应
 - **离线资料覆盖不到**（具体卷次 / 声明经典之外 / `sources/` 检索为空）
   → 见下「FoJin 实时检索」小节，**先离线、不足才上线**
 
@@ -124,6 +124,8 @@ GET https://fojin.app/api/search/semantic?q=<URL编码查询>&top_k=5   # 语义
    - 离线引文：该标识（`cbeta_id`/`toh_id`/`bdrc_id`/`pts_id`/`suttacentral`/`teaching_id` 等，依本 master `citation_format`）必须 ∈ 本 master frontmatter `sources:` 声明的对应字段；
    - live 引文：必须携带 API 真实返回的 `https://fojin.app/texts/{text_id}` 链接；
    - 两者都不满足即视为幻觉 → **剥离该断言，不要输出**。宁可少说，不可伪证。
+
+6. **不作过程旁白**：直接以本角色口吻作答——不要向用户复述“加载 voice.md / 建立人格 / 正在检索”等准备步骤，更不要宣告“风格已立”之类。确需说明超出离线资料、要上线查证时，用本角色语气一句带过（如“容检之于藏”），不作系统式旁白；但据实标注（如“以下为离线资料”、引文出处）照常保留。
 
 ## Quick Reference
 


### PR DESCRIPTION
## What & why

A dogfood of `/master-xuanzang` (v0.9.0) surfaced a polish wart: when a persona runs its offline→live decision, it prepended scaffolding like **"法师风格已立。…容我先向 FoJin 检索正典"** — the model verbalizing its internal *load voice.md / establish persona / now retrieving* steps as user-facing narration. Reads oddly, breaks immersion. (Citations were all real — this is polish, not a correctness bug.)

**Root cause:** the decision tree framed `建立人格` as an explicit step, and nothing in `输出要求` forbade announcing it.

## Change (all 15 personas, meta-skills untouched)

1. Decision-tree 风格对话 branch: `建立人格` → annotated **内化即可，勿向用户复述此步**.
2. New `输出要求（强制）` item **不作过程旁白**: answer directly in the master's voice; never recite the setup/retrieval steps or declare "风格已立". 

**Deliberately not over-suppressed** — the rule keeps in-character transparency for a live lookup AND explicitly preserves factual markers: `据实标注（如"以下为离线资料"、引文出处）照常保留`. B1 citation-honesty and live/offline disclosure are unchanged.

## Review-driven refinements (folded in before push)

A code review passed this **Ready to merge: Yes** with 4 Minor notes; the two worth fixing were applied:
- **Degradation-marker tension**: added the `据实标注…照常保留` carve-out so the mandatory `"FoJin 暂不可达，以下为离线资料"` marker isn't read as the forbidden 系统式旁白.
- **Cross-tradition register**: `本祖师口吻` → `本角色口吻` (祖师 mismatched the 南传 论师/尊者 personas; aligns with the repo's neutral `本角色` term). Also cleaned stray quote spacing.

## Versioning & verification

Per-master `SKILL.md` minor bump; package **0.9.0 → 0.9.1** across all 5 manifests + CHANGELOG. `npm test` exits 0 (validate --strict 18 skills, fidelity, persona-fidelity, manifest-versions, dry-run fidelity, CLI 14, pytest 161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)