### PR TITLE
feat(cli): add json runtime output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added `master-skill doctor` to report package version, Node version, prebuilt path, Claude skills path, available skills, installed known skills, and basic local status.
 - Added `master-skill inspect <name>` to show one master's display name, slug, version, tradition, school, install state, live-grounding support, citation format, source IDs, and search keywords.
 - Added `master-skill update --all` as an explicit upgrade path that reinstalls every available skill and clears stale files through the existing reinstall logic.
-- Extended CLI integration coverage from 14 to 21 tests for `doctor`, `inspect`, `update --all`, installed-state detection, and invalid inspect names.
+- Added `--json` output for `list`, `doctor`, and `inspect` so native GUI clients can consume stable machine-readable runtime data.
+- Extended CLI integration coverage from 14 to 24 tests for `doctor`, `inspect`, `update --all`, JSON output, installed-state detection, and invalid inspect names.
 
 ### Changed — compare-masters output contract
 - Upgraded `/compare-masters` to a fixed framework output protocol requiring `共同点`, `核心分歧`, `适用根机`, `分歧雷达`, `分歧分类`, `共通点与宗派背景`, `推荐继续追问`, and `引用来源`.

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -93,15 +93,37 @@ function sourceIds(meta) {
   return meta.sources.map((s) => [s.id, s.title].filter(Boolean).join(" — "));
 }
 
+function printJson(payload) {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
 // --- commands ---
 
-function cmdList() {
+function listData() {
   const masters = availableMasters();
+  return {
+    count: masters.length,
+    masters: masters.map((m) => ({
+      name: m.name,
+      slug: m.name.replace(/^master-/, ""),
+      description: m.description,
+    })),
+  };
+}
+
+function cmdList({ json = false } = {}) {
+  const data = listData();
+  if (json) {
+    printJson(data);
+    return;
+  }
+
+  const masters = data.masters;
   if (!masters.length) {
     console.log("No prebuilt masters found.");
     return;
   }
-  console.log(`\nAvailable masters (${masters.length}):\n`);
+  console.log(`\nAvailable masters (${data.count}):\n`);
   const nameW = Math.max(...masters.map((m) => m.name.length), 4);
   for (const m of masters) {
     const desc = m.description.length > 80 ? m.description.slice(0, 77) + "..." : m.description;
@@ -184,7 +206,7 @@ function cmdUninstall(names) {
   return failed;
 }
 
-function cmdDoctor() {
+function doctorData() {
   const masters = availableMasters();
   const installed = installedSkillDirs();
   const expectedInstalled = masters.filter((m) => installed.includes(m.name));
@@ -192,20 +214,45 @@ function cmdDoctor() {
     const masterDir = path.join(PREBUILT, m.name);
     return !fs.existsSync(path.join(masterDir, "SKILL.md"));
   });
+  const problems = missingSkillMd.map((m) => ({
+    code: "missing-skill-md",
+    name: m.name,
+    message: `${m.name} is missing SKILL.md`,
+  }));
+
+  return {
+    packageVersion: pkgVersion(),
+    nodeVersion: process.version,
+    prebuiltPath: PREBUILT,
+    skillsPath: SKILLS_DIR,
+    availableSkills: masters.length,
+    installedKnownSkills: expectedInstalled.length,
+    otherInstalledSkillDirs: installed.length - expectedInstalled.length,
+    status: problems.length ? "problems" : "ok",
+    problems,
+  };
+}
+
+function cmdDoctor({ json = false } = {}) {
+  const data = doctorData();
+  if (json) {
+    printJson(data);
+    return data.problems.length ? 1 : 0;
+  }
 
   console.log(`master-skill doctor\n`);
-  console.log(`Package version: ${pkgVersion()}`);
-  console.log(`Node version: ${process.version}`);
-  console.log(`Prebuilt path: ${PREBUILT}`);
-  console.log(`Claude skills path: ${SKILLS_DIR}`);
-  console.log(`Available skills: ${masters.length}`);
-  console.log(`Installed known skills: ${expectedInstalled.length}`);
-  console.log(`Other installed skill dirs: ${installed.length - expectedInstalled.length}`);
+  console.log(`Package version: ${data.packageVersion}`);
+  console.log(`Node version: ${data.nodeVersion}`);
+  console.log(`Prebuilt path: ${data.prebuiltPath}`);
+  console.log(`Claude skills path: ${data.skillsPath}`);
+  console.log(`Available skills: ${data.availableSkills}`);
+  console.log(`Installed known skills: ${data.installedKnownSkills}`);
+  console.log(`Other installed skill dirs: ${data.otherInstalledSkillDirs}`);
 
-  if (missingSkillMd.length) {
+  if (data.problems.length) {
     console.log(`\nProblems:`);
-    for (const m of missingSkillMd) {
-      console.log(`  ✗ ${m.name} is missing SKILL.md`);
+    for (const problem of data.problems) {
+      console.log(`  ✗ ${problem.message}`);
     }
     return 1;
   }
@@ -214,7 +261,34 @@ function cmdDoctor() {
   return 0;
 }
 
-function cmdInspect(name) {
+function inspectData(name) {
+  const masterDir = resolveMasterDir(name);
+  if (!masterDir) return null;
+
+  const dirName = path.basename(masterDir);
+  const skillMd = path.join(masterDir, "SKILL.md");
+  const metaPath = path.join(masterDir, "meta.json");
+  const fm = fs.existsSync(skillMd) ? parseFrontmatter(skillMd) : {};
+  const meta = fs.existsSync(metaPath) ? readJson(metaPath) : {};
+  const sources = sourceIds(meta);
+
+  return {
+    name: dirName,
+    displayName: meta.name || null,
+    slug: meta.slug || dirName.replace(/^master-/, ""),
+    version: fm.version || meta.version || null,
+    tradition: meta.tradition || null,
+    school: meta.school || null,
+    era: meta.era || null,
+    installed: fs.existsSync(path.join(SKILLS_DIR, dirName)),
+    liveGrounding: hasLiveGrounding(masterDir),
+    citationFormat: fm.citation_format || null,
+    sources,
+    searchKeywords: meta.search_scope?.keywords || [],
+  };
+}
+
+function cmdInspect(name, { json = false } = {}) {
   if (!name) {
     console.log("Usage: master-skill inspect <name>");
     return 1;
@@ -224,41 +298,38 @@ function cmdInspect(name) {
     return 1;
   }
 
-  const masterDir = resolveMasterDir(name);
-  if (!masterDir) {
+  const data = inspectData(name);
+  if (!data) {
     console.log(`  ✗ ${name} — not found in prebuilt/ (tried "${name}" and "master-${name}")`);
     return 1;
   }
 
-  const dirName = path.basename(masterDir);
-  const skillMd = path.join(masterDir, "SKILL.md");
-  const metaPath = path.join(masterDir, "meta.json");
-  const fm = fs.existsSync(skillMd) ? parseFrontmatter(skillMd) : {};
-  const meta = fs.existsSync(metaPath) ? readJson(metaPath) : {};
-  const installed = fs.existsSync(path.join(SKILLS_DIR, dirName));
-  const sources = sourceIds(meta);
+  if (json) {
+    printJson(data);
+    return 0;
+  }
 
-  console.log(`${dirName}\n`);
-  console.log(`Display name: ${meta.name || "(none)"}`);
-  console.log(`Slug: ${meta.slug || dirName.replace(/^master-/, "")}`);
-  console.log(`Version: ${fm.version || meta.version || "(unknown)"}`);
-  console.log(`Tradition: ${meta.tradition || "(unspecified)"}`);
-  console.log(`School: ${meta.school || "(unspecified)"}`);
-  console.log(`Era: ${meta.era || "(unspecified)"}`);
-  console.log(`Installed: ${installed ? "yes" : "no"}`);
-  console.log(`Live grounding: ${hasLiveGrounding(masterDir) ? "yes" : "no"}`);
-  console.log(`Citation format: ${fm.citation_format || "(not declared in SKILL frontmatter)"}`);
+  console.log(`${data.name}\n`);
+  console.log(`Display name: ${data.displayName || "(none)"}`);
+  console.log(`Slug: ${data.slug}`);
+  console.log(`Version: ${data.version || "(unknown)"}`);
+  console.log(`Tradition: ${data.tradition || "(unspecified)"}`);
+  console.log(`School: ${data.school || "(unspecified)"}`);
+  console.log(`Era: ${data.era || "(unspecified)"}`);
+  console.log(`Installed: ${data.installed ? "yes" : "no"}`);
+  console.log(`Live grounding: ${data.liveGrounding ? "yes" : "no"}`);
+  console.log(`Citation format: ${data.citationFormat || "(not declared in SKILL frontmatter)"}`);
 
-  if (sources.length) {
-    console.log(`\nSources (${sources.length}):`);
-    for (const source of sources) console.log(`  - ${source}`);
+  if (data.sources.length) {
+    console.log(`\nSources (${data.sources.length}):`);
+    for (const source of data.sources) console.log(`  - ${source}`);
   } else {
     console.log(`\nSources: none declared in meta.json`);
   }
 
-  if (meta.search_scope?.keywords?.length) {
-    const keywords = meta.search_scope.keywords.slice(0, 12).join(", ");
-    const suffix = meta.search_scope.keywords.length > 12 ? ", ..." : "";
+  if (data.searchKeywords.length) {
+    const keywords = data.searchKeywords.slice(0, 12).join(", ");
+    const suffix = data.searchKeywords.length > 12 ? ", ..." : "";
     console.log(`\nSearch keywords: ${keywords}${suffix}`);
   }
 
@@ -274,8 +345,11 @@ Usage:
   master-skill install --all       Install all available masters
   master-skill update --all        Reinstall all masters, clearing stale files
   master-skill list                List available masters
+  master-skill list --json         Print available masters as JSON
   master-skill inspect <name>      Show source/runtime metadata for one master
+  master-skill inspect <name> --json
   master-skill doctor              Check local install and runtime paths
+  master-skill doctor --json       Print diagnostics as JSON
   master-skill uninstall <name...> Remove installed masters
   master-skill --version           Print version
   master-skill --help              Show this help
@@ -298,20 +372,22 @@ Examples:
 // --- main ---
 
 const args = process.argv.slice(2);
-const cmd = args[0];
+const json = args.includes("--json");
+const positionalArgs = args.filter((arg) => arg !== "--json");
+const cmd = positionalArgs[0];
 
 if (!cmd || cmd === "--help" || cmd === "-h") {
   showHelp();
 } else if (cmd === "--version" || cmd === "-v") {
   console.log(pkgVersion());
 } else if (cmd === "list") {
-  cmdList();
+  cmdList({ json });
 } else if (cmd === "doctor") {
-  if (cmdDoctor() > 0) process.exitCode = 1;
+  if (cmdDoctor({ json }) > 0) process.exitCode = 1;
 } else if (cmd === "inspect") {
-  if (cmdInspect(args[1]) > 0) process.exitCode = 1;
+  if (cmdInspect(positionalArgs[1], { json }) > 0) process.exitCode = 1;
 } else if (cmd === "install") {
-  const rest = args.slice(1);
+  const rest = positionalArgs.slice(1);
   if (rest.includes("--all")) {
     if (cmdInstallAll("Installing") > 0) process.exitCode = 1;
   } else if (rest.length === 0) {
@@ -321,7 +397,7 @@ if (!cmd || cmd === "--help" || cmd === "-h") {
     if (cmdInstall(rest) > 0) process.exitCode = 1;
   }
 } else if (cmd === "update") {
-  const rest = args.slice(1);
+  const rest = positionalArgs.slice(1);
   if (rest.length === 1 && rest[0] === "--all") {
     if (cmdInstallAll("Updating") > 0) process.exitCode = 1;
   } else {
@@ -329,7 +405,7 @@ if (!cmd || cmd === "--help" || cmd === "-h") {
     process.exitCode = 1;
   }
 } else if (cmd === "uninstall") {
-  const rest = args.slice(1);
+  const rest = positionalArgs.slice(1);
   if (rest.length === 0) {
     console.log("Usage: master-skill uninstall <name...>");
     process.exitCode = 1;

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -58,6 +58,18 @@ test("list names every prebuilt master with its description", () => {
   assert.match(stdout, /master-huineng\s+\S/);
 });
 
+test("list --json returns machine-readable master inventory", () => {
+  const { stdout, code } = run(["list", "--json"]);
+  assert.equal(code, 0);
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.count, prebuiltMasters.length);
+  assert.equal(payload.masters.length, prebuiltMasters.length);
+  assert.ok(
+    payload.masters.some((master) => master.name === "master-huineng" && master.description),
+    "missing master-huineng inventory item"
+  );
+});
+
 test("--version prints the package.json version", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(REPO, "package.json"), "utf8"));
   const { stdout, code } = run(["--version"]);
@@ -87,6 +99,19 @@ test("doctor reports local runtime paths and available skills", (t) => {
   assert.match(stdout, /Status: ok/);
 });
 
+test("doctor --json returns machine-readable runtime diagnostics", (t) => {
+  const { env } = tmpHome(t);
+  const { stdout, code } = run(["doctor", "--json"], env);
+  assert.equal(code, 0);
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.packageVersion, JSON.parse(fs.readFileSync(path.join(REPO, "package.json"), "utf8")).version);
+  assert.equal(payload.nodeVersion, process.version);
+  assert.equal(payload.availableSkills, prebuiltMasters.length);
+  assert.equal(payload.installedKnownSkills, 0);
+  assert.equal(payload.status, "ok");
+  assert.deepEqual(payload.problems, []);
+});
+
 test("doctor counts installed known skills", (t) => {
   const { env } = tmpHome(t);
   run(["install", "zhiyi"], env);
@@ -106,6 +131,20 @@ test("inspect shows master metadata, sources, and live grounding", (t) => {
   assert.match(stdout, /Installed: no/);
   assert.match(stdout, /Live grounding: yes/);
   assert.match(stdout, /T48n2008/);
+});
+
+test("inspect --json returns machine-readable master metadata", (t) => {
+  const { env } = tmpHome(t);
+  const { stdout, code } = run(["inspect", "huineng", "--json"], env);
+  assert.equal(code, 0);
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.name, "master-huineng");
+  assert.equal(payload.displayName, "慧能大师");
+  assert.equal(payload.slug, "huineng");
+  assert.equal(payload.tradition, "汉传");
+  assert.equal(payload.installed, false);
+  assert.equal(payload.liveGrounding, true);
+  assert.ok(payload.sources.some((source) => source.includes("T48n2008")));
 });
 
 test("inspect reflects installed state", (t) => {


### PR DESCRIPTION
## Summary

- Add `--json` output for `master-skill list`, `doctor`, and `inspect`.
- Keep existing human-readable CLI output unchanged.
- Add CLI integration tests for the new machine-readable runtime data contract.
- Record the change in `CHANGELOG.md`.

## Why

This is the first implementation step toward a native Master-skill Desktop Manager. A Rust GUI should consume stable JSON from the existing CLI instead of scraping text output or duplicating Master-skill runtime logic.

## Validation

- `node --test tests/cli.test.mjs`
- `npm test`
- Manual smoke checks for `list --json`, `doctor --json`, and `inspect huineng --json`
