### PR TITLE
feat(desktop): add skill management actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added a pure Rust `desktop/` app skeleton using `egui/eframe` as the first native Master-skill Desktop Manager shell.
 - Added Rust models and tests for the CLI JSON contracts consumed by the desktop app.
 - The desktop app reads the existing `master-skill` CLI rather than duplicating install, update, doctor, or inspect logic.
+- Added per-master install/uninstall actions, background command execution, busy-state feedback, and isolated-home Rust integration coverage for desktop CLI operations.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1,3 +1,7 @@
+use std::sync::mpsc::{channel, Receiver};
+use std::thread;
+
+use anyhow::Result;
 use eframe::egui;
 
 use crate::cli::CliClient;
@@ -10,7 +14,23 @@ pub struct MasterSkillApp {
     selected: Option<MasterInspect>,
     selected_slug: Option<String>,
     log: String,
+    task_rx: Option<Receiver<TaskResult>>,
+    busy_label: Option<String>,
 }
+
+struct Snapshot {
+    inventory: SkillInventory,
+    doctor: DoctorReport,
+    selected_slug: Option<String>,
+    selected: Option<MasterInspect>,
+}
+
+struct TaskOutcome {
+    message: String,
+    snapshot: Option<Snapshot>,
+}
+
+type TaskResult = std::result::Result<TaskOutcome, String>;
 
 impl MasterSkillApp {
     pub fn new() -> Self {
@@ -21,81 +41,190 @@ impl MasterSkillApp {
             selected: None,
             selected_slug: None,
             log: "Starting desktop manager...".to_string(),
+            task_rx: None,
+            busy_label: None,
         };
         app.refresh_all();
         app
     }
 
+    fn load_snapshot(client: &CliClient, selected_slug: Option<String>) -> Result<Snapshot> {
+        let inventory = client.list()?;
+        let doctor = client.doctor()?;
+        let resolved_slug =
+            selected_slug.or_else(|| inventory.masters.first().map(|m| m.slug.clone()));
+        let selected = match resolved_slug.as_deref() {
+            Some(slug) => Some(client.inspect(slug)?),
+            None => None,
+        };
+
+        Ok(Snapshot {
+            inventory,
+            doctor,
+            selected_slug: resolved_slug,
+            selected,
+        })
+    }
+
+    fn apply_snapshot(&mut self, snapshot: Snapshot) {
+        self.inventory = Some(snapshot.inventory);
+        self.doctor = Some(snapshot.doctor);
+        self.selected_slug = snapshot.selected_slug;
+        self.selected = snapshot.selected;
+    }
+
     fn refresh_all(&mut self) {
-        match self.client.list() {
-            Ok(inventory) => {
-                let first_slug = inventory.masters.first().map(|m| m.slug.clone());
-                self.inventory = Some(inventory);
-                if self.selected_slug.is_none() {
-                    self.selected_slug = first_slug;
+        match Self::load_snapshot(&self.client, self.selected_slug.clone()) {
+            Ok(snapshot) => {
+                self.apply_snapshot(snapshot);
+                self.log = "Runtime data refreshed.".to_string();
+            }
+            Err(err) => self.log = format!("Refresh failed: {err:#}"),
+        }
+    }
+
+    fn is_busy(&self) -> bool {
+        self.task_rx.is_some()
+    }
+
+    fn start_task<F>(&mut self, label: impl Into<String>, task: F)
+    where
+        F: FnOnce(CliClient) -> Result<TaskOutcome> + Send + 'static,
+    {
+        if self.is_busy() {
+            self.log = "A task is already running.".to_string();
+            return;
+        }
+
+        let client = self.client.clone();
+        let label = label.into();
+        let (tx, rx) = channel();
+        self.task_rx = Some(rx);
+        self.busy_label = Some(label.clone());
+        self.log = format!("{label}...");
+
+        thread::spawn(move || {
+            let result = task(client).map_err(|err| format!("{err:#}"));
+            let _ = tx.send(result);
+        });
+    }
+
+    fn poll_task(&mut self) {
+        let result = self.task_rx.as_ref().and_then(|rx| rx.try_recv().ok());
+        if let Some(result) = result {
+            self.task_rx = None;
+            self.busy_label = None;
+            match result {
+                Ok(outcome) => {
+                    if let Some(snapshot) = outcome.snapshot {
+                        self.apply_snapshot(snapshot);
+                    }
+                    self.log = outcome.message;
                 }
+                Err(message) => self.log = message,
             }
-            Err(err) => {
-                self.log = format!("Failed to load inventory: {err:#}");
-                return;
-            }
-        }
-
-        match self.client.doctor() {
-            Ok(report) => self.doctor = Some(report),
-            Err(err) => self.log = format!("Doctor failed: {err:#}"),
-        }
-
-        if let Some(slug) = self.selected_slug.clone() {
-            self.inspect(&slug);
-        }
-
-        self.log = "Runtime data refreshed.".to_string();
-    }
-
-    fn inspect(&mut self, slug: &str) {
-        match self.client.inspect(slug) {
-            Ok(inspect) => {
-                self.selected = Some(inspect);
-                self.selected_slug = Some(slug.to_string());
-                self.log = format!("Loaded master-{slug}.");
-            }
-            Err(err) => self.log = format!("Inspect failed for {slug}: {err:#}"),
         }
     }
 
-    fn install_all(&mut self) {
-        match self.client.install_all() {
-            Ok(output) => {
-                self.log = output.trim().to_string();
-                self.refresh_all();
-            }
-            Err(err) => self.log = format!("Install failed: {err:#}"),
-        }
+    fn start_refresh(&mut self) {
+        let selected_slug = self.selected_slug.clone();
+        self.start_task("Refreshing runtime data", move |client| {
+            let snapshot = Self::load_snapshot(&client, selected_slug)?;
+            Ok(TaskOutcome {
+                message: "Runtime data refreshed.".to_string(),
+                snapshot: Some(snapshot),
+            })
+        });
     }
 
-    fn update_all(&mut self) {
-        match self.client.update_all() {
-            Ok(output) => {
-                self.log = output.trim().to_string();
-                self.refresh_all();
-            }
-            Err(err) => self.log = format!("Update failed: {err:#}"),
-        }
+    fn start_inspect(&mut self, slug: String) {
+        self.start_task(format!("Loading master-{slug}"), move |client| {
+            let selected = client.inspect(&slug)?;
+            Ok(TaskOutcome {
+                message: format!("Loaded master-{slug}."),
+                snapshot: Some(Snapshot {
+                    inventory: client.list()?,
+                    doctor: client.doctor()?,
+                    selected_slug: Some(slug),
+                    selected: Some(selected),
+                }),
+            })
+        });
+    }
+
+    fn start_install(&mut self, slug: String) {
+        self.start_task(format!("Installing master-{slug}"), move |client| {
+            let output = client.install(&slug)?;
+            let snapshot = Self::load_snapshot(&client, Some(slug))?;
+            Ok(TaskOutcome {
+                message: output.trim().to_string(),
+                snapshot: Some(snapshot),
+            })
+        });
+    }
+
+    fn start_uninstall(&mut self, slug: String) {
+        self.start_task(format!("Uninstalling master-{slug}"), move |client| {
+            let output = client.uninstall(&slug)?;
+            let snapshot = Self::load_snapshot(&client, Some(slug))?;
+            Ok(TaskOutcome {
+                message: output.trim().to_string(),
+                snapshot: Some(snapshot),
+            })
+        });
+    }
+
+    fn start_install_all(&mut self) {
+        let selected_slug = self.selected_slug.clone();
+        self.start_task("Installing all skills", move |client| {
+            let output = client.install_all()?;
+            let snapshot = Self::load_snapshot(&client, selected_slug)?;
+            Ok(TaskOutcome {
+                message: output.trim().to_string(),
+                snapshot: Some(snapshot),
+            })
+        });
+    }
+
+    fn start_update_all(&mut self) {
+        let selected_slug = self.selected_slug.clone();
+        self.start_task("Updating all skills", move |client| {
+            let output = client.update_all()?;
+            let snapshot = Self::load_snapshot(&client, selected_slug)?;
+            Ok(TaskOutcome {
+                message: output.trim().to_string(),
+                snapshot: Some(snapshot),
+            })
+        });
     }
 
     fn show_toolbar(&mut self, ui: &mut egui::Ui) {
+        let busy = self.is_busy();
         ui.horizontal(|ui| {
             ui.heading("Master-skill Desktop Manager");
             ui.separator();
-            if ui.button("Refresh").clicked() {
-                self.refresh_all();
+            if ui
+                .add_enabled(!busy, egui::Button::new("Refresh"))
+                .clicked()
+            {
+                self.start_refresh();
             }
-            if ui.button("Install all").clicked() {
-                self.install_all();
+            if ui
+                .add_enabled(!busy, egui::Button::new("Install all"))
+                .clicked()
+            {
+                self.start_install_all();
             }
-            if ui.button("Update all").clicked() {
-                self.update_all();
+            if ui
+                .add_enabled(!busy, egui::Button::new("Update all"))
+                .clicked()
+            {
+                self.start_update_all();
+            }
+            if let Some(label) = &self.busy_label {
+                ui.separator();
+                ui.spinner();
+                ui.label(label);
             }
         });
         ui.label(format!("Repo: {}", self.client.repo_root().display()));
@@ -118,7 +247,7 @@ impl MasterSkillApp {
                     format!("master-{}", master.slug)
                 };
                 if ui.selectable_label(selected, label).clicked() {
-                    self.inspect(&master.slug);
+                    self.start_inspect(master.slug);
                 }
             }
         });
@@ -162,10 +291,26 @@ impl MasterSkillApp {
         }
     }
 
-    fn show_selected(&self, ui: &mut egui::Ui) {
+    fn show_selected(&mut self, ui: &mut egui::Ui) {
         ui.heading("Selected Skill");
-        if let Some(master) = &self.selected {
+        if let Some(master) = self.selected.clone() {
             ui.label(master.display_name.as_deref().unwrap_or(&master.name));
+            ui.horizontal(|ui| {
+                if master.installed {
+                    if ui
+                        .add_enabled(!self.is_busy(), egui::Button::new("Uninstall"))
+                        .clicked()
+                    {
+                        self.start_uninstall(master.slug.clone());
+                    }
+                } else if ui
+                    .add_enabled(!self.is_busy(), egui::Button::new("Install"))
+                    .clicked()
+                {
+                    self.start_install(master.slug.clone());
+                }
+            });
+
             egui::Grid::new("inspect-grid")
                 .num_columns(2)
                 .show(ui, |ui| {
@@ -212,6 +357,11 @@ impl Default for MasterSkillApp {
 
 impl eframe::App for MasterSkillApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.poll_task();
+        if self.is_busy() {
+            ctx.request_repaint();
+        }
+
         egui::TopBottomPanel::top("top").show(ctx, |ui| self.show_toolbar(ui));
 
         egui::SidePanel::left("skills")

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -9,6 +9,7 @@ use crate::model::{DoctorReport, MasterInspect, SkillInventory};
 pub struct CliClient {
     repo_root: PathBuf,
     node_bin: String,
+    home: Option<PathBuf>,
 }
 
 impl CliClient {
@@ -16,7 +17,13 @@ impl CliClient {
         Self {
             repo_root: repo_root.into(),
             node_bin: std::env::var("NODE").unwrap_or_else(|_| "node".to_string()),
+            home: None,
         }
+    }
+
+    pub fn with_home(mut self, home: impl Into<PathBuf>) -> Self {
+        self.home = Some(home.into());
+        self
     }
 
     pub fn repo_root(&self) -> &Path {
@@ -35,8 +42,16 @@ impl CliClient {
         self.json(&["inspect", slug, "--json"])
     }
 
+    pub fn install(&self, slug: &str) -> Result<String> {
+        self.run(&["install", slug])
+    }
+
     pub fn install_all(&self) -> Result<String> {
         self.run(&["install", "--all"])
+    }
+
+    pub fn uninstall(&self, slug: &str) -> Result<String> {
+        self.run(&["uninstall", slug])
     }
 
     pub fn update_all(&self) -> Result<String> {
@@ -52,10 +67,16 @@ impl CliClient {
     }
 
     fn run(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new(&self.node_bin)
+        let mut command = Command::new(&self.node_bin);
+        command
             .arg(self.repo_root.join("bin").join("cli.mjs"))
             .args(args)
-            .current_dir(&self.repo_root)
+            .current_dir(&self.repo_root);
+        if let Some(home) = &self.home {
+            command.env("HOME", home).env("USERPROFILE", home);
+        }
+
+        let output = command
             .output()
             .with_context(|| format!("failed to run master-skill CLI with args {args:?}"))?;
 

--- a/desktop/tests/cli_client.rs
+++ b/desktop/tests/cli_client.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use master_skill_desktop::cli::CliClient;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn temp_home() -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("master-skill-desktop-test-{suffix}"))
+}
+
+#[test]
+fn installs_and_uninstalls_one_master_in_isolated_home() {
+    let home = temp_home();
+    fs::create_dir_all(&home).unwrap();
+
+    let client = CliClient::new(repo_root()).with_home(&home);
+
+    let install_output = client.install("huineng").unwrap();
+    assert!(install_output.contains("master-huineng"));
+    assert!(client.inspect("huineng").unwrap().installed);
+
+    let uninstall_output = client.uninstall("huineng").unwrap();
+    assert!(uninstall_output.contains("removed"));
+    assert!(!client.inspect("huineng").unwrap().installed);
+
+    fs::remove_dir_all(home).unwrap();
+}


### PR DESCRIPTION
## Summary

- Add per-master install and uninstall actions to the native desktop manager.
- Run desktop commands in background tasks so the UI can show busy state instead of blocking on CLI work.
- Refresh inventory, doctor, and inspect state after each operation.
- Add isolated-home Rust integration coverage for install/inspect/uninstall behavior.

## Why

The previous desktop shell could display Master-skill runtime data, but it was not yet a useful manager. This moves the native app into actionable MVP territory while keeping the existing CLI as the source of truth.

## Validation

- `cargo test --manifest-path desktop/Cargo.toml`
- `cargo build --manifest-path desktop/Cargo.toml`
- `npm test`
- `git diff --check`
