### PR TITLE
fix(desktop): load cjk fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Rust models and tests for the CLI JSON contracts consumed by the desktop app.
 - The desktop app reads the existing `master-skill` CLI rather than duplicating install, update, doctor, or inspect logic.
 - Added per-master install/uninstall actions, background command execution, busy-state feedback, and isolated-home Rust integration coverage for desktop CLI operations.
+- Added runtime CJK font loading for the native desktop app so Chinese master names, traditions, schools, and sources render correctly under WSL/Linux.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/fonts.rs
+++ b/desktop/src/fonts.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use eframe::egui;
+
+const CJK_FONT_CANDIDATES: &[&str] = &[
+    "/mnt/c/Windows/Fonts/NotoSansSC-VF.ttf",
+    "/mnt/c/Windows/Fonts/msyh.ttc",
+    "/mnt/c/Windows/Fonts/Deng.ttf",
+    "/mnt/c/Windows/Fonts/simsun.ttc",
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/opentype/noto/NotoSansCJKsc-Regular.otf",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
+];
+
+pub fn install_cjk_fonts(ctx: &egui::Context) {
+    let Some(path) = first_existing_path(CJK_FONT_CANDIDATES.iter().map(Path::new)) else {
+        return;
+    };
+    let Ok(bytes) = std::fs::read(path) else {
+        return;
+    };
+
+    let mut fonts = egui::FontDefinitions::default();
+    fonts.font_data.insert(
+        "master_skill_cjk".to_string(),
+        Arc::new(egui::FontData::from_owned(bytes)),
+    );
+
+    for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+        fonts
+            .families
+            .entry(family)
+            .or_default()
+            .insert(0, "master_skill_cjk".to_string());
+    }
+
+    ctx.set_fonts(fonts);
+}
+
+fn first_existing_path<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Option<PathBuf> {
+    paths
+        .into_iter()
+        .find(|path| path.is_file())
+        .map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_existing_path;
+    use std::fs;
+
+    #[test]
+    fn picks_first_existing_font_candidate() {
+        let root =
+            std::env::temp_dir().join(format!("master-skill-font-test-{}", std::process::id()));
+        let missing = root.join("missing.ttf");
+        let existing = root.join("existing.ttf");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&existing, b"font").unwrap();
+
+        let picked = first_existing_path([missing.as_path(), existing.as_path()]);
+
+        assert_eq!(picked.as_deref(), Some(existing.as_path()));
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod cli;
+pub mod fonts;
 pub mod model;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,5 +1,6 @@
 use eframe::egui;
 use master_skill_desktop::app::MasterSkillApp;
+use master_skill_desktop::fonts::install_cjk_fonts;
 
 fn main() -> eframe::Result {
     let options = eframe::NativeOptions {
@@ -10,6 +11,9 @@ fn main() -> eframe::Result {
     eframe::run_native(
         "Master-skill Desktop Manager",
         options,
-        Box::new(|_cc| Ok(Box::new(MasterSkillApp::new()))),
+        Box::new(|cc| {
+            install_cjk_fonts(&cc.egui_ctx);
+            Ok(Box::new(MasterSkillApp::new()))
+        }),
     )
 }


### PR DESCRIPTION
## Summary

- Load a runtime CJK font into the native egui desktop app.
- Prefer WSL-visible Windows fonts such as `NotoSansSC-VF.ttf`, then fall back to common Chinese-capable fonts.
- Add a unit test for font candidate selection.

## Why

The desktop manager opened successfully under WSL, but Chinese master names, traditions, schools, and sources rendered as tofu boxes because egui's default fonts do not include CJK glyph coverage. The app needs Chinese text to be readable for Master-skill's core use case.

## Validation

- `cargo test --manifest-path desktop/Cargo.toml`
- `cargo build --manifest-path desktop/Cargo.toml`
- `npm test`
- `git diff --check`
