### PR TITLE
feat(desktop): add console filters and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - The desktop app reads the existing `master-skill` CLI rather than duplicating install, update, doctor, or inspect logic.
 - Added per-master install/uninstall actions, background command execution, busy-state feedback, and isolated-home Rust integration coverage for desktop CLI operations.
 - Added runtime CJK font loading for the native desktop app so Chinese master names, traditions, schools, and sources render correctly under WSL/Linux.
+- Added desktop search, install-state filters, tradition filters, per-skill status labels, citation/search-keyword details, and a scrollable operation log.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -4,22 +4,29 @@ use std::thread;
 use anyhow::Result;
 use eframe::egui;
 
+use crate::catalog::{filter_rows, tradition_options, InstallFilter, SkillRow};
 use crate::cli::CliClient;
-use crate::model::{DoctorReport, MasterInspect, SkillInventory, SkillSummary};
+use crate::model::{DoctorReport, MasterInspect, SkillInventory};
 
 pub struct MasterSkillApp {
     client: CliClient,
     inventory: Option<SkillInventory>,
+    rows: Vec<SkillRow>,
     doctor: Option<DoctorReport>,
     selected: Option<MasterInspect>,
     selected_slug: Option<String>,
+    search_query: String,
+    install_filter: InstallFilter,
+    tradition_filter: Option<String>,
     log: String,
+    log_lines: Vec<String>,
     task_rx: Option<Receiver<TaskResult>>,
     busy_label: Option<String>,
 }
 
 struct Snapshot {
     inventory: SkillInventory,
+    rows: Vec<SkillRow>,
     doctor: DoctorReport,
     selected_slug: Option<String>,
     selected: Option<MasterInspect>,
@@ -37,10 +44,15 @@ impl MasterSkillApp {
         let mut app = Self {
             client: CliClient::default(),
             inventory: None,
+            rows: Vec::new(),
             doctor: None,
             selected: None,
             selected_slug: None,
+            search_query: String::new(),
+            install_filter: InstallFilter::All,
+            tradition_filter: None,
             log: "Starting desktop manager...".to_string(),
+            log_lines: vec!["Starting desktop manager...".to_string()],
             task_rx: None,
             busy_label: None,
         };
@@ -53,13 +65,20 @@ impl MasterSkillApp {
         let doctor = client.doctor()?;
         let resolved_slug =
             selected_slug.or_else(|| inventory.masters.first().map(|m| m.slug.clone()));
-        let selected = match resolved_slug.as_deref() {
-            Some(slug) => Some(client.inspect(slug)?),
-            None => None,
-        };
+        let mut rows = Vec::with_capacity(inventory.masters.len());
+        let mut selected = None;
+
+        for summary in &inventory.masters {
+            let inspect = client.inspect(&summary.slug)?;
+            if resolved_slug.as_deref() == Some(summary.slug.as_str()) {
+                selected = Some(inspect.clone());
+            }
+            rows.push(SkillRow::from_summary_and_inspect(summary, Some(&inspect)));
+        }
 
         Ok(Snapshot {
             inventory,
+            rows,
             doctor,
             selected_slug: resolved_slug,
             selected,
@@ -68,18 +87,28 @@ impl MasterSkillApp {
 
     fn apply_snapshot(&mut self, snapshot: Snapshot) {
         self.inventory = Some(snapshot.inventory);
+        self.rows = snapshot.rows;
         self.doctor = Some(snapshot.doctor);
         self.selected_slug = snapshot.selected_slug;
         self.selected = snapshot.selected;
+    }
+
+    fn set_log(&mut self, message: impl Into<String>) {
+        let message = message.into();
+        self.log = message.clone();
+        self.log_lines.push(message);
+        if self.log_lines.len() > 200 {
+            self.log_lines.remove(0);
+        }
     }
 
     fn refresh_all(&mut self) {
         match Self::load_snapshot(&self.client, self.selected_slug.clone()) {
             Ok(snapshot) => {
                 self.apply_snapshot(snapshot);
-                self.log = "Runtime data refreshed.".to_string();
+                self.set_log("Runtime data refreshed.");
             }
-            Err(err) => self.log = format!("Refresh failed: {err:#}"),
+            Err(err) => self.set_log(format!("Refresh failed: {err:#}")),
         }
     }
 
@@ -92,7 +121,7 @@ impl MasterSkillApp {
         F: FnOnce(CliClient) -> Result<TaskOutcome> + Send + 'static,
     {
         if self.is_busy() {
-            self.log = "A task is already running.".to_string();
+            self.set_log("A task is already running.");
             return;
         }
 
@@ -101,7 +130,7 @@ impl MasterSkillApp {
         let (tx, rx) = channel();
         self.task_rx = Some(rx);
         self.busy_label = Some(label.clone());
-        self.log = format!("{label}...");
+        self.set_log(format!("{label}..."));
 
         thread::spawn(move || {
             let result = task(client).map_err(|err| format!("{err:#}"));
@@ -119,9 +148,9 @@ impl MasterSkillApp {
                     if let Some(snapshot) = outcome.snapshot {
                         self.apply_snapshot(snapshot);
                     }
-                    self.log = outcome.message;
+                    self.set_log(outcome.message);
                 }
-                Err(message) => self.log = message,
+                Err(message) => self.set_log(message),
             }
         }
     }
@@ -139,15 +168,10 @@ impl MasterSkillApp {
 
     fn start_inspect(&mut self, slug: String) {
         self.start_task(format!("Loading master-{slug}"), move |client| {
-            let selected = client.inspect(&slug)?;
+            let snapshot = Self::load_snapshot(&client, Some(slug.clone()))?;
             Ok(TaskOutcome {
                 message: format!("Loaded master-{slug}."),
-                snapshot: Some(Snapshot {
-                    inventory: client.list()?,
-                    doctor: client.doctor()?,
-                    selected_slug: Some(slug),
-                    selected: Some(selected),
-                }),
+                snapshot: Some(snapshot),
             })
         });
     }
@@ -232,22 +256,62 @@ impl MasterSkillApp {
 
     fn show_sidebar(&mut self, ui: &mut egui::Ui) {
         ui.heading("Skills");
-        let masters: Vec<SkillSummary> = self
-            .inventory
-            .as_ref()
-            .map(|inventory| inventory.masters.clone())
-            .unwrap_or_default();
+        ui.add(
+            egui::TextEdit::singleline(&mut self.search_query)
+                .hint_text("Search name, slug, tradition, school"),
+        );
+
+        ui.horizontal(|ui| {
+            ui.selectable_value(&mut self.install_filter, InstallFilter::All, "All");
+            ui.selectable_value(
+                &mut self.install_filter,
+                InstallFilter::Installed,
+                "Installed",
+            );
+            ui.selectable_value(&mut self.install_filter, InstallFilter::Missing, "Missing");
+        });
+
+        egui::ComboBox::from_label("Tradition")
+            .selected_text(self.tradition_filter.as_deref().unwrap_or("All traditions"))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut self.tradition_filter, None, "All traditions");
+                for tradition in tradition_options(&self.rows) {
+                    ui.selectable_value(
+                        &mut self.tradition_filter,
+                        Some(tradition.clone()),
+                        tradition,
+                    );
+                }
+            });
+
+        ui.separator();
+        let visible_rows: Vec<SkillRow> = filter_rows(
+            &self.rows,
+            &self.search_query,
+            self.install_filter,
+            self.tradition_filter.as_deref(),
+        )
+        .into_iter()
+        .cloned()
+        .collect();
 
         egui::ScrollArea::vertical().show(ui, |ui| {
-            for master in masters {
-                let selected = self.selected_slug.as_deref() == Some(master.slug.as_str());
-                let label = if master.name.starts_with("master-") {
-                    master.name.clone()
+            for row in visible_rows {
+                let selected = self.selected_slug.as_deref() == Some(row.slug.as_str());
+                let status = if row.installed {
+                    "installed"
                 } else {
-                    format!("master-{}", master.slug)
+                    "missing"
                 };
-                if ui.selectable_label(selected, label).clicked() {
-                    self.start_inspect(master.slug);
+                let title = row.title().to_string();
+                ui.horizontal(|ui| {
+                    if ui.selectable_label(selected, row.name.clone()).clicked() {
+                        self.start_inspect(row.slug.clone());
+                    }
+                    ui.small(status);
+                });
+                if selected && title != row.name {
+                    ui.small(title);
                 }
             }
         });
@@ -332,6 +396,9 @@ impl MasterSkillApp {
                     ui.label("Live grounding");
                     ui.label(if master.live_grounding { "yes" } else { "no" });
                     ui.end_row();
+                    ui.label("Citation format");
+                    ui.label(master.citation_format.as_deref().unwrap_or("not declared"));
+                    ui.end_row();
                 });
 
             ui.separator();
@@ -342,6 +409,12 @@ impl MasterSkillApp {
                 for source in &master.sources {
                     ui.label(source);
                 }
+            }
+
+            if !master.search_keywords.is_empty() {
+                ui.separator();
+                ui.heading("Search Keywords");
+                ui.label(master.search_keywords.join(", "));
             }
         } else {
             ui.label("No skill selected.");
@@ -369,9 +442,24 @@ impl eframe::App for MasterSkillApp {
             .default_width(260.0)
             .show(ctx, |ui| self.show_sidebar(ui));
 
-        egui::TopBottomPanel::bottom("log").show(ctx, |ui| {
-            ui.label(&self.log);
-        });
+        egui::TopBottomPanel::bottom("log")
+            .resizable(true)
+            .default_height(130.0)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("Operation Log");
+                    if ui.button("Clear").clicked() {
+                        self.log_lines.clear();
+                    }
+                });
+                egui::ScrollArea::vertical()
+                    .stick_to_bottom(true)
+                    .show(ui, |ui| {
+                        for line in &self.log_lines {
+                            ui.label(line);
+                        }
+                    });
+            });
 
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {

--- a/desktop/src/catalog.rs
+++ b/desktop/src/catalog.rs
@@ -1,0 +1,133 @@
+use crate::model::{MasterInspect, SkillSummary};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstallFilter {
+    All,
+    Installed,
+    Missing,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillRow {
+    pub name: String,
+    pub slug: String,
+    pub description: String,
+    pub display_name: Option<String>,
+    pub tradition: Option<String>,
+    pub school: Option<String>,
+    pub installed: bool,
+    pub live_grounding: bool,
+}
+
+impl SkillRow {
+    pub fn from_summary_and_inspect(
+        summary: &SkillSummary,
+        inspect: Option<&MasterInspect>,
+    ) -> Self {
+        Self {
+            name: summary.name.clone(),
+            slug: summary.slug.clone(),
+            description: summary.description.clone(),
+            display_name: inspect.and_then(|i| i.display_name.clone()),
+            tradition: inspect.and_then(|i| i.tradition.clone()),
+            school: inspect.and_then(|i| i.school.clone()),
+            installed: inspect.map(|i| i.installed).unwrap_or(false),
+            live_grounding: inspect.map(|i| i.live_grounding).unwrap_or(false),
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        self.display_name.as_deref().unwrap_or(&self.name)
+    }
+}
+
+pub fn filter_rows<'a>(
+    rows: &'a [SkillRow],
+    query: &str,
+    install_filter: InstallFilter,
+    tradition_filter: Option<&str>,
+) -> Vec<&'a SkillRow> {
+    let query = query.trim().to_lowercase();
+    rows.iter()
+        .filter(|row| match install_filter {
+            InstallFilter::All => true,
+            InstallFilter::Installed => row.installed,
+            InstallFilter::Missing => !row.installed,
+        })
+        .filter(|row| {
+            tradition_filter
+                .map(|tradition| row.tradition.as_deref() == Some(tradition))
+                .unwrap_or(true)
+        })
+        .filter(|row| {
+            if query.is_empty() {
+                return true;
+            }
+            let haystack = [
+                row.name.as_str(),
+                row.slug.as_str(),
+                row.display_name.as_deref().unwrap_or(""),
+                row.tradition.as_deref().unwrap_or(""),
+                row.school.as_deref().unwrap_or(""),
+                row.description.as_str(),
+            ]
+            .join(" ")
+            .to_lowercase();
+            haystack.contains(&query)
+        })
+        .collect()
+}
+
+pub fn tradition_options(rows: &[SkillRow]) -> Vec<String> {
+    let mut options: Vec<String> = rows
+        .iter()
+        .filter_map(|row| row.tradition.clone())
+        .filter(|value| !value.trim().is_empty())
+        .collect();
+    options.sort();
+    options.dedup();
+    options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_rows, tradition_options, InstallFilter, SkillRow};
+
+    fn row(slug: &str, display_name: &str, tradition: &str, installed: bool) -> SkillRow {
+        SkillRow {
+            name: format!("master-{slug}"),
+            slug: slug.to_string(),
+            description: format!("{display_name} description"),
+            display_name: Some(display_name.to_string()),
+            tradition: Some(tradition.to_string()),
+            school: None,
+            installed,
+            live_grounding: true,
+        }
+    }
+
+    #[test]
+    fn filters_by_query_install_state_and_tradition() {
+        let rows = vec![
+            row("huineng", "慧能大师", "汉传", true),
+            row("atisha", "阿底峡尊者", "藏传", false),
+            row("ajahn-chah", "阿姜查", "南传", true),
+        ];
+
+        let filtered = filter_rows(&rows, "阿", InstallFilter::Installed, Some("南传"));
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].slug, "ajahn-chah");
+    }
+
+    #[test]
+    fn returns_sorted_unique_tradition_options() {
+        let rows = vec![
+            row("huineng", "慧能大师", "汉传", true),
+            row("zhiyi", "智者大师", "汉传", true),
+            row("atisha", "阿底峡尊者", "藏传", false),
+        ];
+
+        assert_eq!(tradition_options(&rows), vec!["汉传", "藏传"]);
+    }
+}

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod catalog;
 pub mod cli;
 pub mod fonts;
 pub mod model;


### PR DESCRIPTION
## Summary

- Add desktop catalog view model for search, install-state filters, and tradition filters.
- Show installed/missing state directly in the skills list.
- Show citation format and search keywords in the selected skill details.
- Replace the single-line footer with a scrollable operation log.

## Why

This moves the native manager from an MVP utility toward a professional Master-skill control console: users can scan, filter, inspect, and audit operations without reading CLI output manually.

## Validation

- `cargo test --manifest-path desktop/Cargo.toml`
- `cargo build --manifest-path desktop/Cargo.toml`
- `npm test`
- `git diff --check`
