### PR TITLE
feat(desktop): add evaluation center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added desktop search, install-state filters, tradition filters, per-skill status labels, citation/search-keyword details, and a scrollable operation log.
 - Added a professional console health dashboard for runtime, installation, source coverage, fidelity evaluation coverage, runtime protocol readiness, and attention counts.
 - Added per-skill quality states plus `Overview`, `Sources`, `Evaluation`, and `Runtime` detail views in the desktop manager.
+- Added an Evaluation Center with fidelity case totals, per-tradition coverage, per-skill suite status, and background actions for fidelity dry-run and full validation.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -5,8 +5,8 @@ use anyhow::Result;
 use eframe::egui;
 
 use crate::catalog::{
-    console_summary, filter_rows, tradition_options, InstallFilter, QualityLevel, SkillDiagnostics,
-    SkillRow,
+    console_summary, evaluation_summary, filter_rows, tradition_options, InstallFilter,
+    QualityLevel, SkillDiagnostics, SkillRow,
 };
 use crate::cli::CliClient;
 use crate::model::{DoctorReport, MasterInspect, SkillInventory};
@@ -241,6 +241,26 @@ impl MasterSkillApp {
         });
     }
 
+    fn start_fidelity_dry_run(&mut self) {
+        self.start_task("Running fidelity dry-run", move |client| {
+            let output = client.run_fidelity_dry_run()?;
+            Ok(TaskOutcome {
+                message: summarize_command_output("Fidelity dry-run finished", &output),
+                snapshot: None,
+            })
+        });
+    }
+
+    fn start_full_validation(&mut self) {
+        self.start_task("Running full validation", move |client| {
+            let output = client.run_full_validation()?;
+            Ok(TaskOutcome {
+                message: summarize_command_output("Full validation finished", &output),
+                snapshot: None,
+            })
+        });
+    }
+
     fn show_toolbar(&mut self, ui: &mut egui::Ui) {
         let busy = self.is_busy();
         ui.horizontal(|ui| {
@@ -368,6 +388,111 @@ impl MasterSkillApp {
         } else {
             ui.label("No runtime report loaded.");
         }
+    }
+
+    fn show_evaluation_center(&mut self, ui: &mut egui::Ui) {
+        ui.heading("Evaluation Center");
+        let busy = self.is_busy();
+        let summary = evaluation_summary(&self.rows);
+
+        ui.horizontal_wrapped(|ui| {
+            Self::show_metric_card(
+                ui,
+                "Fidelity Cases",
+                summary.case_count.to_string(),
+                &format!("{} skills", summary.skill_count),
+                summary.missing_suite_count == 0,
+            );
+            Self::show_metric_card(
+                ui,
+                "Ready",
+                summary.ready_count.to_string(),
+                "source + protocol + eval",
+                summary.ready_count == summary.skill_count,
+            );
+            Self::show_metric_card(
+                ui,
+                "Attention",
+                summary.attention_count.to_string(),
+                "installed but incomplete",
+                summary.attention_count == 0,
+            );
+            Self::show_metric_card(
+                ui,
+                "Missing",
+                summary.missing_count.to_string(),
+                "not installed",
+                summary.missing_count == 0,
+            );
+            Self::show_metric_card(
+                ui,
+                "Missing Suites",
+                summary.missing_suite_count.to_string(),
+                "no fidelity jsonl",
+                summary.missing_suite_count == 0,
+            );
+        });
+
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(!busy, egui::Button::new("Run fidelity dry-run"))
+                .clicked()
+            {
+                self.start_fidelity_dry_run();
+            }
+            if ui
+                .add_enabled(!busy, egui::Button::new("Run full validation"))
+                .clicked()
+            {
+                self.start_full_validation();
+            }
+        });
+
+        ui.separator();
+        ui.columns(2, |columns| {
+            columns[0].heading("Tradition Coverage");
+            egui::Grid::new("evaluation-tradition-grid")
+                .num_columns(4)
+                .striped(true)
+                .show(&mut columns[0], |ui| {
+                    ui.strong("Tradition");
+                    ui.strong("Skills");
+                    ui.strong("Cases");
+                    ui.strong("Missing");
+                    ui.end_row();
+                    for group in &summary.groups {
+                        ui.label(&group.tradition);
+                        ui.label(group.skill_count.to_string());
+                        ui.label(group.case_count.to_string());
+                        ui.label(group.missing_suite_count.to_string());
+                        ui.end_row();
+                    }
+                });
+
+            columns[1].heading("Skill Suites");
+            egui::ScrollArea::vertical()
+                .max_height(210.0)
+                .show(&mut columns[1], |ui| {
+                    egui::Grid::new("evaluation-skill-grid")
+                        .num_columns(4)
+                        .striped(true)
+                        .show(ui, |ui| {
+                            ui.strong("Skill");
+                            ui.strong("Tradition");
+                            ui.strong("Cases");
+                            ui.strong("Status");
+                            ui.end_row();
+                            for row in &self.rows {
+                                let level = row.quality_level();
+                                ui.label(&row.name);
+                                ui.label(row.tradition.as_deref().unwrap_or("unspecified"));
+                                ui.label(row.fidelity_case_count.to_string());
+                                ui.colored_label(Self::quality_color(level), level.label());
+                                ui.end_row();
+                            }
+                        });
+                });
+        });
     }
 
     fn show_sidebar(&mut self, ui: &mut egui::Ui) {
@@ -645,6 +770,8 @@ impl eframe::App for MasterSkillApp {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 self.show_dashboard(ui);
                 ui.separator();
+                self.show_evaluation_center(ui);
+                ui.separator();
                 ui.columns(2, |columns| {
                     self.show_doctor(&mut columns[0]);
                     self.show_selected(&mut columns[1]);
@@ -652,4 +779,17 @@ impl eframe::App for MasterSkillApp {
             });
         });
     }
+}
+
+fn summarize_command_output(prefix: &str, output: &str) -> String {
+    let lines: Vec<&str> = output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    if lines.is_empty() {
+        return prefix.to_string();
+    }
+
+    let start = lines.len().saturating_sub(12);
+    format!("{prefix}:\n{}", lines[start..].join("\n"))
 }

--- a/desktop/src/catalog.rs
+++ b/desktop/src/catalog.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -171,6 +172,70 @@ pub fn console_summary(
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationGroup {
+    pub tradition: String,
+    pub skill_count: usize,
+    pub case_count: usize,
+    pub missing_suite_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationSummary {
+    pub skill_count: usize,
+    pub case_count: usize,
+    pub ready_count: usize,
+    pub attention_count: usize,
+    pub missing_count: usize,
+    pub missing_suite_count: usize,
+    pub groups: Vec<EvaluationGroup>,
+}
+
+pub fn evaluation_summary(rows: &[SkillRow]) -> EvaluationSummary {
+    let mut ready_count = 0;
+    let mut attention_count = 0;
+    let mut missing_count = 0;
+    let mut groups: BTreeMap<String, EvaluationGroup> = BTreeMap::new();
+
+    for row in rows {
+        match row.quality_level() {
+            QualityLevel::Ready => ready_count += 1,
+            QualityLevel::Attention => attention_count += 1,
+            QualityLevel::Missing => missing_count += 1,
+        }
+
+        let tradition = row
+            .tradition
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "unspecified".to_string());
+        let group = groups.entry(tradition.clone()).or_insert(EvaluationGroup {
+            tradition,
+            skill_count: 0,
+            case_count: 0,
+            missing_suite_count: 0,
+        });
+        group.skill_count += 1;
+        group.case_count += row.fidelity_case_count;
+        if row.fidelity_case_count == 0 {
+            group.missing_suite_count += 1;
+        }
+    }
+
+    EvaluationSummary {
+        skill_count: rows.len(),
+        case_count: rows.iter().map(|row| row.fidelity_case_count).sum(),
+        ready_count,
+        attention_count,
+        missing_count,
+        missing_suite_count: rows
+            .iter()
+            .filter(|row| row.fidelity_case_count == 0)
+            .count(),
+        groups: groups.into_values().collect(),
+    }
+}
+
 pub fn filter_rows<'a>(
     rows: &'a [SkillRow],
     query: &str,
@@ -226,8 +291,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        console_summary, filter_rows, tradition_options, InstallFilter, QualityLevel,
-        SkillDiagnostics, SkillRow,
+        console_summary, evaluation_summary, filter_rows, tradition_options, EvaluationGroup,
+        InstallFilter, QualityLevel, SkillDiagnostics, SkillRow,
     };
 
     fn temp_dir() -> PathBuf {
@@ -334,5 +399,51 @@ mod tests {
         assert_eq!(diagnostics.fidelity_case_count, 2);
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn summarizes_evaluation_center_by_quality_and_tradition() {
+        let mut rows = vec![
+            row("huineng", "慧能大师", "汉传", true),
+            row("zhiyi", "智者大师", "汉传", true),
+            row("atisha", "阿底峡尊者", "藏传", true),
+            row("ajahn-chah", "阿姜查", "南传", false),
+        ];
+        rows[0].fidelity_case_count = 12;
+        rows[1].fidelity_case_count = 10;
+        rows[2].fidelity_case_count = 0;
+        rows[3].fidelity_case_count = 13;
+
+        let summary = evaluation_summary(&rows);
+
+        assert_eq!(summary.skill_count, 4);
+        assert_eq!(summary.case_count, 35);
+        assert_eq!(summary.ready_count, 2);
+        assert_eq!(summary.attention_count, 1);
+        assert_eq!(summary.missing_count, 1);
+        assert_eq!(summary.missing_suite_count, 1);
+        assert_eq!(
+            summary.groups,
+            vec![
+                EvaluationGroup {
+                    tradition: "南传".to_string(),
+                    skill_count: 1,
+                    case_count: 13,
+                    missing_suite_count: 0,
+                },
+                EvaluationGroup {
+                    tradition: "汉传".to_string(),
+                    skill_count: 2,
+                    case_count: 22,
+                    missing_suite_count: 0,
+                },
+                EvaluationGroup {
+                    tradition: "藏传".to_string(),
+                    skill_count: 1,
+                    case_count: 0,
+                    missing_suite_count: 1,
+                },
+            ]
+        );
     }
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -58,6 +58,23 @@ impl CliClient {
         self.run(&["update", "--all"])
     }
 
+    pub fn run_fidelity_dry_run(&self) -> Result<String> {
+        self.run_command(
+            Command::new("python3")
+                .arg(self.repo_root.join("scripts").join("test-fidelity.py"))
+                .arg("--all")
+                .arg("--dry-run"),
+            "failed to run fidelity dry-run",
+        )
+    }
+
+    pub fn run_full_validation(&self) -> Result<String> {
+        self.run_command(
+            Command::new("npm").arg("test"),
+            "failed to run full validation",
+        )
+    }
+
     fn json<T>(&self, args: &[&str]) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
@@ -76,9 +93,19 @@ impl CliClient {
             command.env("HOME", home).env("USERPROFILE", home);
         }
 
-        let output = command
-            .output()
-            .with_context(|| format!("failed to run master-skill CLI with args {args:?}"))?;
+        self.run_command(
+            &mut command,
+            &format!("failed to run master-skill CLI with args {args:?}"),
+        )
+    }
+
+    fn run_command(&self, command: &mut Command, context: &str) -> Result<String> {
+        command.current_dir(&self.repo_root);
+        if let Some(home) = &self.home {
+            command.env("HOME", home).env("USERPROFILE", home);
+        }
+
+        let output = command.output().with_context(|| context.to_string())?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         if output.status.success() {
@@ -87,7 +114,7 @@ impl CliClient {
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(anyhow!(
-            "master-skill CLI failed with status {}: {}{}",
+            "command failed with status {}: {}{}",
             output.status,
             stdout,
             stderr

--- a/desktop/tests/cli_client.rs
+++ b/desktop/tests/cli_client.rs
@@ -36,3 +36,13 @@ fn installs_and_uninstalls_one_master_in_isolated_home() {
 
     fs::remove_dir_all(home).unwrap();
 }
+
+#[test]
+fn runs_fidelity_dry_run_from_repo_root() {
+    let client = CliClient::new(repo_root());
+
+    let output = client.run_fidelity_dry_run().unwrap();
+
+    assert!(output.contains("Overall Summary"));
+    assert!(output.contains("master-huineng"));
+}


### PR DESCRIPTION
## Summary
- add an Evaluation Center to the native desktop console with fidelity totals, quality distribution, per-tradition coverage, and per-skill suite status
- add background actions for running fidelity dry-run and full validation from the desktop app
- add Rust coverage for evaluation summary aggregation and the fidelity dry-run CLI bridge

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
