### PR TITLE
feat(desktop): add professional console shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Improved desktop console layout responsiveness with adaptive one/two-column sections and horizontal scrolling for dense evaluation and trace tables.
 - Tightened desktop console layout rules so metric cards keep stable widths and dense evaluation tables stay stacked until there is enough space for readable columns.
 - Reworked desktop metric card rows to calculate wrapping explicitly, preventing dashboard cards from being clipped at the right edge in normal WSL window sizes.
+- Added a professional console shell with top-level workspace navigation, compact runtime status, skill-detail routing, and an expandable operation log.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -12,7 +12,7 @@ use crate::catalog::{
 use crate::cli::CliClient;
 use crate::layout::{
     dashboard_columns_for_width, dense_table_mode_for_width, metric_card_width,
-    metric_cards_per_row, TwoPaneMode,
+    metric_cards_per_row, operation_log_height, TwoPaneMode,
 };
 use crate::model::{DoctorReport, MasterInspect, SkillInventory};
 use crate::trace::{TraceStatus, TraceStore};
@@ -23,6 +23,25 @@ enum DetailView {
     Sources,
     Evaluation,
     Runtime,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConsoleSection {
+    Overview,
+    Evaluation,
+    Runs,
+    SkillDetail,
+}
+
+impl ConsoleSection {
+    fn label(self) -> &'static str {
+        match self {
+            ConsoleSection::Overview => "Overview",
+            ConsoleSection::Evaluation => "Evaluation",
+            ConsoleSection::Runs => "Runs",
+            ConsoleSection::SkillDetail => "Skill Detail",
+        }
+    }
 }
 
 pub struct MasterSkillApp {
@@ -40,6 +59,8 @@ pub struct MasterSkillApp {
     task_rx: Option<Receiver<TaskEnvelope>>,
     busy_label: Option<String>,
     detail_view: DetailView,
+    console_section: ConsoleSection,
+    log_expanded: bool,
     traces: TraceStore,
 }
 
@@ -88,6 +109,8 @@ impl MasterSkillApp {
             task_rx: None,
             busy_label: None,
             detail_view: DetailView::Overview,
+            console_section: ConsoleSection::Overview,
+            log_expanded: false,
             traces: TraceStore::new(200),
         };
         app.refresh_all();
@@ -326,7 +349,24 @@ impl MasterSkillApp {
                 ui.label(label);
             }
         });
-        ui.label(format!("Repo: {}", self.client.repo_root().display()));
+        ui.horizontal(|ui| {
+            for section in [
+                ConsoleSection::Overview,
+                ConsoleSection::Evaluation,
+                ConsoleSection::Runs,
+                ConsoleSection::SkillDetail,
+            ] {
+                ui.selectable_value(&mut self.console_section, section, section.label());
+            }
+            ui.separator();
+            if let Some(report) = &self.doctor {
+                ui.label(format!(
+                    "Runtime: {} | Installed: {}/{}",
+                    report.status, report.installed_known_skills, report.available_skills
+                ));
+            }
+        });
+        ui.small(format!("Repo: {}", self.client.repo_root().display()));
     }
 
     fn quality_color(level: QualityLevel) -> egui::Color32 {
@@ -728,6 +768,7 @@ impl MasterSkillApp {
                 let title = row.title().to_string();
                 ui.horizontal(|ui| {
                     if ui.selectable_label(selected, row.name.clone()).clicked() {
+                        self.console_section = ConsoleSection::SkillDetail;
                         self.start_inspect(row.slug.clone());
                     }
                     ui.colored_label(Self::quality_color(quality), quality.label());
@@ -918,6 +959,59 @@ impl MasterSkillApp {
             ui.label("No skill selected.");
         }
     }
+
+    fn show_operation_log(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.heading("Operation Log");
+            let toggle_label = if self.log_expanded {
+                "Collapse"
+            } else {
+                "Expand"
+            };
+            if ui.button(toggle_label).clicked() {
+                self.log_expanded = !self.log_expanded;
+            }
+            if ui.button("Clear").clicked() {
+                self.log_lines.clear();
+            }
+            ui.separator();
+            ui.label(first_line(&self.log));
+        });
+
+        if self.log_expanded {
+            egui::ScrollArea::vertical()
+                .stick_to_bottom(true)
+                .show(ui, |ui| {
+                    for line in &self.log_lines {
+                        ui.label(line);
+                    }
+                });
+        }
+    }
+
+    fn show_overview_workspace(&mut self, ui: &mut egui::Ui) {
+        self.show_dashboard(ui);
+        ui.separator();
+        if dashboard_columns_for_width(ui.available_width()) == TwoPaneMode::TwoColumns {
+            ui.columns(2, |columns| {
+                self.show_doctor(&mut columns[0]);
+                self.show_selected(&mut columns[1]);
+            });
+        } else {
+            self.show_doctor(ui);
+            ui.separator();
+            self.show_selected(ui);
+        }
+    }
+
+    fn show_active_workspace(&mut self, ui: &mut egui::Ui) {
+        match self.console_section {
+            ConsoleSection::Overview => self.show_overview_workspace(ui),
+            ConsoleSection::Evaluation => self.show_evaluation_center(ui),
+            ConsoleSection::Runs => self.show_trace_center(ui),
+            ConsoleSection::SkillDetail => self.show_selected(ui),
+        }
+    }
 }
 
 impl Default for MasterSkillApp {
@@ -942,41 +1036,12 @@ impl eframe::App for MasterSkillApp {
 
         egui::TopBottomPanel::bottom("log")
             .resizable(true)
-            .default_height(130.0)
-            .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.heading("Operation Log");
-                    if ui.button("Clear").clicked() {
-                        self.log_lines.clear();
-                    }
-                });
-                egui::ScrollArea::vertical()
-                    .stick_to_bottom(true)
-                    .show(ui, |ui| {
-                        for line in &self.log_lines {
-                            ui.label(line);
-                        }
-                    });
-            });
+            .default_height(operation_log_height(self.log_expanded))
+            .show(ctx, |ui| self.show_operation_log(ui));
 
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
-                self.show_dashboard(ui);
-                ui.separator();
-                self.show_evaluation_center(ui);
-                ui.separator();
-                self.show_trace_center(ui);
-                ui.separator();
-                if dashboard_columns_for_width(ui.available_width()) == TwoPaneMode::TwoColumns {
-                    ui.columns(2, |columns| {
-                        self.show_doctor(&mut columns[0]);
-                        self.show_selected(&mut columns[1]);
-                    });
-                } else {
-                    self.show_doctor(ui);
-                    ui.separator();
-                    self.show_selected(ui);
-                }
+                self.show_active_workspace(ui);
             });
         });
     }

--- a/desktop/src/layout.rs
+++ b/desktop/src/layout.rs
@@ -39,12 +39,20 @@ pub fn metric_cards_per_row(content_width: f32, card_width: f32, item_spacing: f
     columns.max(1)
 }
 
+pub fn operation_log_height(expanded: bool) -> f32 {
+    if expanded {
+        170.0
+    } else {
+        42.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::TwoPaneMode;
     use super::{
         dashboard_columns_for_width, dense_table_mode_for_width, metric_card_width,
-        metric_cards_per_row,
+        metric_cards_per_row, operation_log_height,
     };
 
     #[test]
@@ -86,5 +94,12 @@ mod tests {
         assert_eq!(metric_cards_per_row(760.0, 150.0, 8.0), 4);
         assert_eq!(metric_cards_per_row(320.0, 145.0, 8.0), 2);
         assert_eq!(metric_cards_per_row(120.0, 145.0, 8.0), 1);
+    }
+
+    #[test]
+    fn keeps_operation_log_compact_by_default_but_expandable() {
+        assert_eq!(operation_log_height(false), 42.0);
+        assert_eq!(operation_log_height(true), 170.0);
+        assert!(operation_log_height(true) > operation_log_height(false));
     }
 }


### PR DESCRIPTION
## Summary
- add top-level console workspace navigation for overview, evaluation, runs, and skill detail
- route sidebar skill selection directly into the skill-detail workspace
- make the operation log compact by default with an expandable full log
- add layout coverage for the compact/expanded log heights

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
