### PR TITLE
feat(desktop): tighten visual system and sidebar density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Reworked desktop metric card rows to calculate wrapping explicitly, preventing dashboard cards from being clipped at the right edge in normal WSL window sizes.
 - Added a professional console shell with top-level workspace navigation, compact runtime status, skill-detail routing, and an expandable operation log.
 - Added workspace headers with contextual actions, moved evaluation validation into the workspace action bar, and added clearable run trace history.
+- Added a shared desktop visual theme and tightened sidebar information density with fixed-width quality badges, compact rows, and a ready-count summary.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -15,6 +15,9 @@ use crate::layout::{
     metric_cards_per_row, operation_log_height, TwoPaneMode,
 };
 use crate::model::{DoctorReport, MasterInspect, SkillInventory};
+use crate::theme::{
+    apply_console_theme, sidebar_default_width, sidebar_row_height, status_badge_width,
+};
 use crate::trace::{TraceStatus, TraceStore};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -383,6 +386,35 @@ impl MasterSkillApp {
             TraceStatus::Succeeded => egui::Color32::from_rgb(100, 190, 130),
             TraceStatus::Failed => egui::Color32::from_rgb(210, 100, 100),
         }
+    }
+
+    fn quality_badge_fill(level: QualityLevel) -> egui::Color32 {
+        match level {
+            QualityLevel::Ready => egui::Color32::from_rgb(21, 64, 44),
+            QualityLevel::Attention => egui::Color32::from_rgb(76, 57, 28),
+            QualityLevel::Missing => egui::Color32::from_rgb(74, 36, 36),
+        }
+    }
+
+    fn show_quality_badge(ui: &mut egui::Ui, level: QualityLevel) {
+        let fill = Self::quality_badge_fill(level);
+        let stroke = egui::Stroke::new(1.0, Self::quality_color(level));
+        ui.allocate_ui_with_layout(
+            egui::vec2(status_badge_width(), sidebar_row_height() - 4.0),
+            egui::Layout::top_down(egui::Align::Center),
+            |ui| {
+                egui::Frame::new()
+                    .fill(fill)
+                    .stroke(stroke)
+                    .inner_margin(egui::Margin::symmetric(6, 2))
+                    .show(ui, |ui| {
+                        ui.set_width((status_badge_width() - 16.0).max(28.0));
+                        ui.centered_and_justified(|ui| {
+                            ui.small(level.label());
+                        });
+                    });
+            },
+        );
     }
 
     fn show_workspace_header(
@@ -760,7 +792,17 @@ impl MasterSkillApp {
     }
 
     fn show_sidebar(&mut self, ui: &mut egui::Ui) {
-        ui.heading("Skills");
+        let ready_count = self
+            .rows
+            .iter()
+            .filter(|row| row.quality_level() == QualityLevel::Ready)
+            .count();
+        ui.horizontal(|ui| {
+            ui.heading("Skills");
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.small(format!("{ready_count}/{} ready", self.rows.len()));
+            });
+        });
         ui.add(
             egui::TextEdit::singleline(&mut self.search_query)
                 .hint_text("Search name, slug, tradition, school"),
@@ -805,13 +847,26 @@ impl MasterSkillApp {
                 let selected = self.selected_slug.as_deref() == Some(row.slug.as_str());
                 let quality = row.quality_level();
                 let title = row.title().to_string();
-                ui.horizontal(|ui| {
-                    if ui.selectable_label(selected, row.name.clone()).clicked() {
-                        self.console_section = ConsoleSection::SkillDetail;
-                        self.start_inspect(row.slug.clone());
-                    }
-                    ui.colored_label(Self::quality_color(quality), quality.label());
-                });
+                ui.allocate_ui_with_layout(
+                    egui::vec2(ui.available_width(), sidebar_row_height()),
+                    egui::Layout::left_to_right(egui::Align::Center),
+                    |ui| {
+                        let name_width =
+                            (ui.available_width() - status_badge_width() - 10.0).max(80.0);
+                        let name = egui::RichText::new(row.name.clone()).size(13.0);
+                        if ui
+                            .add_sized(
+                                egui::vec2(name_width, sidebar_row_height()),
+                                egui::SelectableLabel::new(selected, name),
+                            )
+                            .clicked()
+                        {
+                            self.console_section = ConsoleSection::SkillDetail;
+                            self.start_inspect(row.slug.clone());
+                        }
+                        Self::show_quality_badge(ui, quality);
+                    },
+                );
                 if selected && title != row.name {
                     ui.small(title);
                 }
@@ -1069,6 +1124,7 @@ impl Default for MasterSkillApp {
 
 impl eframe::App for MasterSkillApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        apply_console_theme(ctx);
         self.poll_task();
         if self.is_busy() {
             ctx.request_repaint();
@@ -1078,7 +1134,7 @@ impl eframe::App for MasterSkillApp {
 
         egui::SidePanel::left("skills")
             .resizable(true)
-            .default_width(260.0)
+            .default_width(sidebar_default_width())
             .show(ctx, |ui| self.show_sidebar(ui));
 
         egui::TopBottomPanel::bottom("log")

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -4,4 +4,5 @@ pub mod cli;
 pub mod fonts;
 pub mod layout;
 pub mod model;
+pub mod theme;
 pub mod trace;

--- a/desktop/src/theme.rs
+++ b/desktop/src/theme.rs
@@ -1,0 +1,60 @@
+use eframe::egui;
+
+pub const SIDEBAR_DEFAULT_WIDTH: f32 = 280.0;
+pub const SIDEBAR_ROW_HEIGHT: f32 = 24.0;
+pub const STATUS_BADGE_WIDTH: f32 = 54.0;
+
+pub fn apply_console_theme(ctx: &egui::Context) {
+    let mut visuals = egui::Visuals::dark();
+    visuals.panel_fill = egui::Color32::from_rgb(18, 20, 20);
+    visuals.window_fill = egui::Color32::from_rgb(20, 23, 23);
+    visuals.faint_bg_color = egui::Color32::from_rgb(26, 30, 30);
+    visuals.extreme_bg_color = egui::Color32::from_rgb(8, 10, 10);
+    visuals.selection.bg_fill = egui::Color32::from_rgb(18, 94, 126);
+    visuals.selection.stroke = egui::Stroke::new(1.0, egui::Color32::from_rgb(76, 164, 196));
+    visuals.widgets.inactive.bg_fill = egui::Color32::from_rgb(38, 42, 42);
+    visuals.widgets.hovered.bg_fill = egui::Color32::from_rgb(48, 56, 56);
+    visuals.widgets.active.bg_fill = egui::Color32::from_rgb(30, 84, 96);
+    visuals.widgets.noninteractive.fg_stroke =
+        egui::Stroke::new(1.0, egui::Color32::from_rgb(186, 194, 190));
+    ctx.set_visuals(visuals);
+
+    let mut style = (*ctx.style()).clone();
+    style.spacing.item_spacing = egui::vec2(8.0, 5.0);
+    style.spacing.button_padding = egui::vec2(8.0, 3.0);
+    style.spacing.interact_size.y = 22.0;
+    ctx.set_style(style);
+}
+
+pub fn status_badge_width() -> f32 {
+    STATUS_BADGE_WIDTH
+}
+
+pub fn sidebar_row_height() -> f32 {
+    SIDEBAR_ROW_HEIGHT
+}
+
+pub fn sidebar_default_width() -> f32 {
+    SIDEBAR_DEFAULT_WIDTH
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sidebar_default_width, sidebar_row_height, status_badge_width};
+
+    #[test]
+    fn keeps_sidebar_rows_dense_but_clickable() {
+        assert!(sidebar_row_height() >= 22.0);
+        assert!(sidebar_row_height() <= 28.0);
+    }
+
+    #[test]
+    fn keeps_status_badges_wide_enough_for_attention_labels() {
+        assert!(status_badge_width() >= 52.0);
+    }
+
+    #[test]
+    fn gives_sidebar_enough_width_for_names_and_badges() {
+        assert!(sidebar_default_width() >= 280.0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared desktop theme for darker console surfaces, selection, spacing, and widget states
- tighten the Skills sidebar with fixed-width quality badges, compact rows, and a ready-count summary
- increase the default sidebar width so names and badges remain aligned

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
