### PR TITLE
feat(desktop): execute diagnostic actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added a shared desktop visual theme and tightened sidebar information density with fixed-width quality badges, compact rows, and a ready-count summary.
 - Added diagnostic gap summaries for desktop skill quality, upgraded Skill Detail into structured contract sections, and made Evaluation Center skill rows jump to detail.
 - Added recommended diagnostic actions in desktop Skill Detail so quality gaps map to concrete next steps and runnable commands where available.
+- Added executable desktop diagnostic actions for install and per-skill fidelity dry-runs, wired into the existing Run Trace workflow.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -7,7 +7,7 @@ use eframe::egui;
 
 use crate::catalog::{
     console_summary, evaluation_summary, filter_rows, tradition_options, DiagnosticAction,
-    InstallFilter, QualityLevel, SkillDiagnostics, SkillRow,
+    DiagnosticOperation, InstallFilter, QualityLevel, SkillDiagnostics, SkillRow,
 };
 use crate::cli::CliClient;
 use crate::layout::{
@@ -303,6 +303,22 @@ impl MasterSkillApp {
         });
     }
 
+    fn start_skill_fidelity_dry_run(&mut self, slug: String) {
+        self.start_task(
+            format!("Running master-{slug} fidelity dry-run"),
+            move |client| {
+                let output = client.run_fidelity_dry_run_for(&slug)?;
+                Ok(TaskOutcome {
+                    message: summarize_command_output(
+                        &format!("master-{slug} fidelity dry-run finished"),
+                        &output,
+                    ),
+                    snapshot: None,
+                })
+            },
+        );
+    }
+
     fn start_full_validation(&mut self) {
         self.start_task("Running full validation", move |client| {
             let output = client.run_full_validation()?;
@@ -405,6 +421,16 @@ impl MasterSkillApp {
                     });
             },
         );
+    }
+
+    fn start_diagnostic_operation(&mut self, operation: DiagnosticOperation) {
+        match operation {
+            DiagnosticOperation::Manual => {
+                self.set_log("Manual action selected; edit the skill files and refresh.");
+            }
+            DiagnosticOperation::InstallSkill { slug } => self.start_install(slug),
+            DiagnosticOperation::FidelityDryRun { slug } => self.start_skill_fidelity_dry_run(slug),
+        }
     }
 
     fn show_workspace_header(
@@ -988,7 +1014,7 @@ impl MasterSkillApp {
         ui.separator();
     }
 
-    fn show_recommended_actions_panel(ui: &mut egui::Ui, actions: &[DiagnosticAction]) {
+    fn show_recommended_actions_panel(&mut self, ui: &mut egui::Ui, actions: &[DiagnosticAction]) {
         ui.heading("Recommended Actions");
         if actions.is_empty() {
             ui.label("No action needed.");
@@ -996,14 +1022,17 @@ impl MasterSkillApp {
             return;
         }
 
+        let busy = self.is_busy();
+        let mut operation_to_start = None;
         egui::Grid::new("recommended-actions-grid")
-            .num_columns(3)
+            .num_columns(4)
             .striped(true)
             .min_col_width(104.0)
             .show(ui, |ui| {
                 ui.strong("Action");
                 ui.strong("Reason");
                 ui.strong("Command");
+                ui.strong("Run");
                 ui.end_row();
                 for action in actions {
                     ui.label(&action.title);
@@ -1013,9 +1042,22 @@ impl MasterSkillApp {
                     } else {
                         ui.label("manual");
                     }
+                    match &action.operation {
+                        DiagnosticOperation::Manual => {
+                            ui.label("manual");
+                        }
+                        operation => {
+                            if ui.add_enabled(!busy, egui::Button::new("Run")).clicked() {
+                                operation_to_start = Some(operation.clone());
+                            }
+                        }
+                    }
                     ui.end_row();
                 }
             });
+        if let Some(operation) = operation_to_start {
+            self.start_diagnostic_operation(operation);
+        }
         ui.separator();
     }
 
@@ -1115,7 +1157,7 @@ impl MasterSkillApp {
                         quality,
                         &diagnostic_summary,
                     );
-                    Self::show_recommended_actions_panel(&mut columns[1], &diagnostic_actions);
+                    self.show_recommended_actions_panel(&mut columns[1], &diagnostic_actions);
                     Self::show_runtime_protocol_panel(&mut columns[1], &master);
                 });
             } else {
@@ -1127,7 +1169,7 @@ impl MasterSkillApp {
                     quality,
                     &diagnostic_summary,
                 );
-                Self::show_recommended_actions_panel(ui, &diagnostic_actions);
+                self.show_recommended_actions_panel(ui, &diagnostic_actions);
                 Self::show_runtime_protocol_panel(ui, &master);
             }
         } else {

--- a/desktop/src/catalog.rs
+++ b/desktop/src/catalog.rs
@@ -97,9 +97,17 @@ fn detect_skill_kind(skill_dir: &Path) -> SkillKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiagnosticOperation {
+    Manual,
+    InstallSkill { slug: String },
+    FidelityDryRun { slug: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DiagnosticAction {
     pub title: String,
     pub detail: String,
+    pub operation: DiagnosticOperation,
     pub command: Option<String>,
 }
 
@@ -227,6 +235,9 @@ impl SkillRow {
                 title: "Install skill".to_string(),
                 detail: "Install this skill into the local Codex/Claude skills directory."
                     .to_string(),
+                operation: DiagnosticOperation::InstallSkill {
+                    slug: self.slug.clone(),
+                },
                 command: Some(format!("master-skill install {}", self.slug)),
             }];
         }
@@ -237,6 +248,7 @@ impl SkillRow {
                 actions.push(DiagnosticAction {
                     title: "Add source declarations".to_string(),
                     detail: "Declare primary textual sources in the skill metadata.".to_string(),
+                    operation: DiagnosticOperation::Manual,
                     command: None,
                 });
             }
@@ -244,6 +256,7 @@ impl SkillRow {
                 actions.push(DiagnosticAction {
                     title: "Create source index".to_string(),
                     detail: "Add sources/INDEX.md so source grounding is auditable.".to_string(),
+                    operation: DiagnosticOperation::Manual,
                     command: None,
                 });
             }
@@ -251,6 +264,7 @@ impl SkillRow {
                 actions.push(DiagnosticAction {
                     title: "Declare citation format".to_string(),
                     detail: "Add the expected citation format to the skill metadata.".to_string(),
+                    operation: DiagnosticOperation::Manual,
                     command: None,
                 });
             }
@@ -258,6 +272,7 @@ impl SkillRow {
                 actions.push(DiagnosticAction {
                     title: "Enable live grounding".to_string(),
                     detail: "Set the runtime grounding protocol for this persona.".to_string(),
+                    operation: DiagnosticOperation::Manual,
                     command: None,
                 });
             }
@@ -268,6 +283,9 @@ impl SkillRow {
                 title: "Add fidelity suite".to_string(),
                 detail: "Create tests/fidelity.jsonl, then dry-run the suite for this skill."
                     .to_string(),
+                operation: DiagnosticOperation::FidelityDryRun {
+                    slug: self.slug.clone(),
+                },
                 command: Some(format!(
                     "python3 scripts/test-fidelity.py --master master-{} --dry-run",
                     self.slug
@@ -463,8 +481,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        console_summary, evaluation_summary, filter_rows, tradition_options, EvaluationGroup,
-        InstallFilter, QualityLevel, SkillDiagnostics, SkillKind, SkillRow,
+        console_summary, evaluation_summary, filter_rows, tradition_options, DiagnosticOperation,
+        EvaluationGroup, InstallFilter, QualityLevel, SkillDiagnostics, SkillKind, SkillRow,
     };
 
     fn temp_dir() -> PathBuf {
@@ -646,6 +664,12 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Install skill");
         assert_eq!(
+            actions[0].operation,
+            DiagnosticOperation::InstallSkill {
+                slug: "atisha".to_string()
+            }
+        );
+        assert_eq!(
             actions[0].command.as_deref(),
             Some("master-skill install atisha")
         );
@@ -662,6 +686,10 @@ mod tests {
 
         let actions = broken.diagnostic_actions();
         let titles: Vec<&str> = actions.iter().map(|action| action.title.as_str()).collect();
+        let operations: Vec<DiagnosticOperation> = actions
+            .iter()
+            .map(|action| action.operation.clone())
+            .collect();
         let commands: Vec<Option<&str>> = actions
             .iter()
             .map(|action| action.command.as_deref())
@@ -675,6 +703,18 @@ mod tests {
                 "Declare citation format",
                 "Enable live grounding",
                 "Add fidelity suite",
+            ]
+        );
+        assert_eq!(
+            operations,
+            vec![
+                DiagnosticOperation::Manual,
+                DiagnosticOperation::Manual,
+                DiagnosticOperation::Manual,
+                DiagnosticOperation::Manual,
+                DiagnosticOperation::FidelityDryRun {
+                    slug: "huineng".to_string()
+                },
             ]
         );
         assert_eq!(

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -68,6 +68,17 @@ impl CliClient {
         )
     }
 
+    pub fn run_fidelity_dry_run_for(&self, slug: &str) -> Result<String> {
+        self.run_command(
+            Command::new("python3")
+                .arg(self.repo_root.join("scripts").join("test-fidelity.py"))
+                .arg("--master")
+                .arg(format!("master-{slug}"))
+                .arg("--dry-run"),
+            "failed to run skill fidelity dry-run",
+        )
+    }
+
     pub fn run_full_validation(&self) -> Result<String> {
         self.run_command(
             Command::new("npm").arg("test"),

--- a/desktop/tests/cli_client.rs
+++ b/desktop/tests/cli_client.rs
@@ -46,3 +46,13 @@ fn runs_fidelity_dry_run_from_repo_root() {
     assert!(output.contains("Overall Summary"));
     assert!(output.contains("master-huineng"));
 }
+
+#[test]
+fn runs_single_skill_fidelity_dry_run_from_repo_root() {
+    let client = CliClient::new(repo_root());
+
+    let output = client.run_fidelity_dry_run_for("huineng").unwrap();
+
+    assert!(output.contains("Testing: master-huineng"));
+    assert!(!output.contains("Testing: master-zhiyi"));
+}


### PR DESCRIPTION
## Summary
- add machine-readable diagnostic operations for manual, install, and per-skill fidelity dry-run actions
- add a single-skill fidelity dry-run client method and test it from the repo root
- make executable Recommended Actions runnable from Skill Detail and route results through the existing Run Trace workflow

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
