### PR TITLE
feat(desktop): add run trace drilldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added diagnostic gap summaries for desktop skill quality, upgraded Skill Detail into structured contract sections, and made Evaluation Center skill rows jump to detail.
 - Added recommended diagnostic actions in desktop Skill Detail so quality gaps map to concrete next steps and runnable commands where available.
 - Added executable desktop diagnostic actions for install and per-skill fidelity dry-runs, wired into the existing Run Trace workflow.
+- Added expandable Run Trace drill-down with command, summary, duration, and detailed output for desktop operations.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -68,6 +68,7 @@ struct Snapshot {
 
 struct TaskOutcome {
     message: String,
+    detail: String,
     snapshot: Option<Snapshot>,
 }
 
@@ -176,6 +177,17 @@ impl MasterSkillApp {
     where
         F: FnOnce(CliClient) -> Result<TaskOutcome> + Send + 'static,
     {
+        self.start_task_with_command(label, None::<String>, task);
+    }
+
+    fn start_task_with_command<F>(
+        &mut self,
+        label: impl Into<String>,
+        command: Option<impl Into<String>>,
+        task: F,
+    ) where
+        F: FnOnce(CliClient) -> Result<TaskOutcome> + Send + 'static,
+    {
         if self.is_busy() {
             self.set_log("A task is already running.");
             return;
@@ -183,7 +195,9 @@ impl MasterSkillApp {
 
         let client = self.client.clone();
         let label = label.into();
-        let trace_id = self.traces.begin(label.clone());
+        let trace_id = self
+            .traces
+            .begin_with_detail(label.clone(), command, "Queued.");
         let (tx, rx) = channel();
         self.task_rx = Some(rx);
         self.busy_label = Some(label.clone());
@@ -210,16 +224,21 @@ impl MasterSkillApp {
                     if let Some(snapshot) = outcome.snapshot {
                         self.apply_snapshot(snapshot);
                     }
-                    self.traces.finish_success(
+                    self.traces.finish_success_with_detail(
                         envelope.trace_id,
                         outcome.message.clone(),
+                        outcome.detail.clone(),
                         envelope.elapsed,
                     );
                     self.set_log(outcome.message);
                 }
                 Err(message) => {
-                    self.traces
-                        .finish_error(envelope.trace_id, message.clone(), envelope.elapsed);
+                    self.traces.finish_error_with_detail(
+                        envelope.trace_id,
+                        first_line(&message),
+                        message.clone(),
+                        envelope.elapsed,
+                    );
                     self.set_log(message);
                 }
             }
@@ -232,6 +251,7 @@ impl MasterSkillApp {
             let snapshot = Self::load_snapshot(&client, selected_slug)?;
             Ok(TaskOutcome {
                 message: "Runtime data refreshed.".to_string(),
+                detail: "Reloaded inventory, runtime doctor report, selected skill metadata, and local diagnostics.".to_string(),
                 snapshot: Some(snapshot),
             })
         });
@@ -242,70 +262,101 @@ impl MasterSkillApp {
             let snapshot = Self::load_snapshot(&client, Some(slug.clone()))?;
             Ok(TaskOutcome {
                 message: format!("Loaded master-{slug}."),
+                detail: format!(
+                    "Loaded source, evaluation, install, and runtime metadata for master-{slug}."
+                ),
                 snapshot: Some(snapshot),
             })
         });
     }
 
     fn start_install(&mut self, slug: String) {
-        self.start_task(format!("Installing master-{slug}"), move |client| {
-            let output = client.install(&slug)?;
-            let snapshot = Self::load_snapshot(&client, Some(slug))?;
-            Ok(TaskOutcome {
-                message: output.trim().to_string(),
-                snapshot: Some(snapshot),
-            })
-        });
+        self.start_task_with_command(
+            format!("Installing master-{slug}"),
+            Some(format!("master-skill install {slug}")),
+            move |client| {
+                let output = client.install(&slug)?;
+                let snapshot = Self::load_snapshot(&client, Some(slug))?;
+                Ok(TaskOutcome {
+                    message: output.trim().to_string(),
+                    detail: output.trim().to_string(),
+                    snapshot: Some(snapshot),
+                })
+            },
+        );
     }
 
     fn start_uninstall(&mut self, slug: String) {
-        self.start_task(format!("Uninstalling master-{slug}"), move |client| {
-            let output = client.uninstall(&slug)?;
-            let snapshot = Self::load_snapshot(&client, Some(slug))?;
-            Ok(TaskOutcome {
-                message: output.trim().to_string(),
-                snapshot: Some(snapshot),
-            })
-        });
+        self.start_task_with_command(
+            format!("Uninstalling master-{slug}"),
+            Some(format!("master-skill uninstall {slug}")),
+            move |client| {
+                let output = client.uninstall(&slug)?;
+                let snapshot = Self::load_snapshot(&client, Some(slug))?;
+                Ok(TaskOutcome {
+                    message: output.trim().to_string(),
+                    detail: output.trim().to_string(),
+                    snapshot: Some(snapshot),
+                })
+            },
+        );
     }
 
     fn start_install_all(&mut self) {
         let selected_slug = self.selected_slug.clone();
-        self.start_task("Installing all skills", move |client| {
-            let output = client.install_all()?;
-            let snapshot = Self::load_snapshot(&client, selected_slug)?;
-            Ok(TaskOutcome {
-                message: output.trim().to_string(),
-                snapshot: Some(snapshot),
-            })
-        });
+        self.start_task_with_command(
+            "Installing all skills",
+            Some("master-skill install --all"),
+            move |client| {
+                let output = client.install_all()?;
+                let snapshot = Self::load_snapshot(&client, selected_slug)?;
+                Ok(TaskOutcome {
+                    message: output.trim().to_string(),
+                    detail: output.trim().to_string(),
+                    snapshot: Some(snapshot),
+                })
+            },
+        );
     }
 
     fn start_update_all(&mut self) {
         let selected_slug = self.selected_slug.clone();
-        self.start_task("Updating all skills", move |client| {
-            let output = client.update_all()?;
-            let snapshot = Self::load_snapshot(&client, selected_slug)?;
-            Ok(TaskOutcome {
-                message: output.trim().to_string(),
-                snapshot: Some(snapshot),
-            })
-        });
+        self.start_task_with_command(
+            "Updating all skills",
+            Some("master-skill update --all"),
+            move |client| {
+                let output = client.update_all()?;
+                let snapshot = Self::load_snapshot(&client, selected_slug)?;
+                Ok(TaskOutcome {
+                    message: output.trim().to_string(),
+                    detail: output.trim().to_string(),
+                    snapshot: Some(snapshot),
+                })
+            },
+        );
     }
 
     fn start_fidelity_dry_run(&mut self) {
-        self.start_task("Running fidelity dry-run", move |client| {
-            let output = client.run_fidelity_dry_run()?;
-            Ok(TaskOutcome {
-                message: summarize_command_output("Fidelity dry-run finished", &output),
-                snapshot: None,
-            })
-        });
+        self.start_task_with_command(
+            "Running fidelity dry-run",
+            Some("python3 scripts/test-fidelity.py --all --dry-run"),
+            move |client| {
+                let output = client.run_fidelity_dry_run()?;
+                Ok(TaskOutcome {
+                    message: summarize_command_output("Fidelity dry-run finished", &output),
+                    detail: output.trim().to_string(),
+                    snapshot: None,
+                })
+            },
+        );
     }
 
     fn start_skill_fidelity_dry_run(&mut self, slug: String) {
-        self.start_task(
+        self.start_task_with_command(
             format!("Running master-{slug} fidelity dry-run"),
+            Some(format!(
+                "python3 scripts/test-fidelity.py --master master-{slug} --dry-run"
+            )),
             move |client| {
                 let output = client.run_fidelity_dry_run_for(&slug)?;
                 Ok(TaskOutcome {
@@ -313,6 +364,7 @@ impl MasterSkillApp {
                         &format!("master-{slug} fidelity dry-run finished"),
                         &output,
                     ),
+                    detail: output.trim().to_string(),
                     snapshot: None,
                 })
             },
@@ -320,10 +372,11 @@ impl MasterSkillApp {
     }
 
     fn start_full_validation(&mut self) {
-        self.start_task("Running full validation", move |client| {
+        self.start_task_with_command("Running full validation", Some("npm test"), move |client| {
             let output = client.run_full_validation()?;
             Ok(TaskOutcome {
                 message: summarize_command_output("Full validation finished", &output),
+                detail: output.trim().to_string(),
                 snapshot: None,
             })
         });
@@ -777,40 +830,67 @@ impl MasterSkillApp {
             return;
         }
 
-        egui::ScrollArea::horizontal().show(ui, |ui| {
-            egui::ScrollArea::vertical()
-                .max_height(190.0)
-                .show(ui, |ui| {
-                    egui::Grid::new("run-trace-grid")
-                        .num_columns(5)
-                        .striped(true)
-                        .min_col_width(88.0)
+        egui::ScrollArea::vertical()
+            .max_height(320.0)
+            .show(ui, |ui| {
+                for record in recent {
+                    let duration = record
+                        .duration_ms
+                        .map(|duration| format!("{duration} ms"))
+                        .unwrap_or_else(|| "running".to_string());
+                    let header = format!(
+                        "#{}  {}  {}  {}",
+                        record.id,
+                        record.status.label(),
+                        duration,
+                        record.label
+                    );
+                    egui::CollapsingHeader::new(header)
+                        .default_open(record.status == TraceStatus::Failed)
                         .show(ui, |ui| {
-                            ui.strong("ID");
-                            ui.strong("Status");
-                            ui.strong("Duration");
-                            ui.strong("Operation");
-                            ui.strong("Summary");
-                            ui.end_row();
-                            for record in recent {
-                                ui.label(format!("#{}", record.id));
-                                ui.colored_label(
-                                    Self::trace_color(record.status),
-                                    record.status.label(),
-                                );
-                                ui.label(
-                                    record
-                                        .duration_ms
-                                        .map(|duration| format!("{duration} ms"))
-                                        .unwrap_or_else(|| "running".to_string()),
-                                );
-                                ui.label(record.label);
-                                ui.label(first_line(&record.summary));
-                                ui.end_row();
-                            }
+                            egui::Grid::new(format!("trace-detail-grid-{}", record.id))
+                                .num_columns(2)
+                                .striped(true)
+                                .show(ui, |ui| {
+                                    ui.label("Status");
+                                    ui.colored_label(
+                                        Self::trace_color(record.status),
+                                        record.status.label(),
+                                    );
+                                    ui.end_row();
+                                    ui.label("Duration");
+                                    ui.label(&duration);
+                                    ui.end_row();
+                                    ui.label("Operation");
+                                    ui.label(&record.label);
+                                    ui.end_row();
+                                    ui.label("Summary");
+                                    ui.label(first_line(&record.summary));
+                                    ui.end_row();
+                                    ui.label("Command");
+                                    if let Some(command) = &record.command {
+                                        ui.monospace(command);
+                                    } else {
+                                        ui.label("internal");
+                                    }
+                                    ui.end_row();
+                                });
+                            ui.separator();
+                            ui.label("Detail");
+                            let detail = if record.detail.trim().is_empty() {
+                                &record.summary
+                            } else {
+                                &record.detail
+                            };
+                            egui::ScrollArea::vertical()
+                                .max_height(160.0)
+                                .show(ui, |ui| {
+                                    ui.monospace(detail);
+                                });
                         });
-                });
-        });
+                    ui.separator();
+                }
+            });
     }
 
     fn show_sidebar(&mut self, ui: &mut egui::Ui) {

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -24,6 +24,8 @@ pub struct TraceRecord {
     pub label: String,
     pub status: TraceStatus,
     pub summary: String,
+    pub detail: String,
+    pub command: Option<String>,
     pub duration_ms: Option<u128>,
 }
 
@@ -53,6 +55,15 @@ impl TraceStore {
     }
 
     pub fn begin(&mut self, label: impl Into<String>) -> u64 {
+        self.begin_with_detail(label, None::<String>, "Started.")
+    }
+
+    pub fn begin_with_detail(
+        &mut self,
+        label: impl Into<String>,
+        command: Option<impl Into<String>>,
+        detail: impl Into<String>,
+    ) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
         self.records.push_back(TraceRecord {
@@ -60,6 +71,8 @@ impl TraceStore {
             label: label.into(),
             status: TraceStatus::Running,
             summary: "Started.".to_string(),
+            detail: detail.into(),
+            command: command.map(Into::into),
             duration_ms: None,
         });
         self.enforce_capacity();
@@ -67,11 +80,49 @@ impl TraceStore {
     }
 
     pub fn finish_success(&mut self, id: u64, summary: impl Into<String>, duration: Duration) {
-        self.finish(id, TraceStatus::Succeeded, summary, duration);
+        self.finish(
+            id,
+            TraceStatus::Succeeded,
+            summary,
+            None::<String>,
+            duration,
+        );
+    }
+
+    pub fn finish_success_with_detail(
+        &mut self,
+        id: u64,
+        summary: impl Into<String>,
+        detail: impl Into<String>,
+        duration: Duration,
+    ) {
+        self.finish(
+            id,
+            TraceStatus::Succeeded,
+            summary,
+            Some(detail.into()),
+            duration,
+        );
     }
 
     pub fn finish_error(&mut self, id: u64, summary: impl Into<String>, duration: Duration) {
-        self.finish(id, TraceStatus::Failed, summary, duration);
+        self.finish(id, TraceStatus::Failed, summary, None::<String>, duration);
+    }
+
+    pub fn finish_error_with_detail(
+        &mut self,
+        id: u64,
+        summary: impl Into<String>,
+        detail: impl Into<String>,
+        duration: Duration,
+    ) {
+        self.finish(
+            id,
+            TraceStatus::Failed,
+            summary,
+            Some(detail.into()),
+            duration,
+        );
     }
 
     pub fn recent(&self) -> Vec<TraceRecord> {
@@ -109,11 +160,15 @@ impl TraceStore {
         id: u64,
         status: TraceStatus,
         summary: impl Into<String>,
+        detail: Option<String>,
         duration: Duration,
     ) {
         if let Some(record) = self.records.iter_mut().find(|record| record.id == id) {
             record.status = status;
             record.summary = summary.into();
+            if let Some(detail) = detail {
+                record.detail = detail;
+            }
             record.duration_ms = Some(duration.as_millis());
         }
     }
@@ -157,6 +212,35 @@ mod tests {
         assert_eq!(recent[0].duration_ms, Some(125));
         assert_eq!(recent[1].label, "Refreshing runtime data");
         assert_eq!(recent[1].status, TraceStatus::Succeeded);
+    }
+
+    #[test]
+    fn records_trace_command_and_detail_for_drilldown() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_detail(
+            "Running master-huineng fidelity dry-run",
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run"),
+            "Dry-run queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity dry-run finished",
+            "Testing: master-huineng\nResult: 0/12 passed (N/A)",
+            Duration::from_millis(88),
+        );
+
+        let recent = store.recent();
+        assert_eq!(
+            recent[0].command.as_deref(),
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run")
+        );
+        assert_eq!(
+            recent[0].summary,
+            "master-huineng fidelity dry-run finished"
+        );
+        assert!(recent[0].detail.contains("Testing: master-huineng"));
+        assert_eq!(recent[0].duration_ms, Some(88));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- store command and detailed output on desktop run traces
- show expandable trace drill-down rows with status, duration, operation, command, summary, and detail
- preserve existing task flow while attaching command metadata to install, update, validation, and fidelity operations

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
