### PR TITLE
feat(desktop): add trace recovery actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added recommended diagnostic actions in desktop Skill Detail so quality gaps map to concrete next steps and runnable commands where available.
 - Added executable desktop diagnostic actions for install and per-skill fidelity dry-runs, wired into the existing Run Trace workflow.
 - Added expandable Run Trace drill-down with command, summary, duration, and detailed output for desktop operations.
+- Added Run Trace recovery controls with rerunnable actions, related skill navigation, and failure-kind classification.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -18,7 +18,7 @@ use crate::model::{DoctorReport, MasterInspect, SkillInventory};
 use crate::theme::{
     apply_console_theme, sidebar_default_width, sidebar_row_height, status_badge_width,
 };
-use crate::trace::{TraceStatus, TraceStore};
+use crate::trace::{TraceAction, TraceStatus, TraceStore};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ConsoleSection {
@@ -173,16 +173,10 @@ impl MasterSkillApp {
         self.task_rx.is_some()
     }
 
-    fn start_task<F>(&mut self, label: impl Into<String>, task: F)
-    where
-        F: FnOnce(CliClient) -> Result<TaskOutcome> + Send + 'static,
-    {
-        self.start_task_with_command(label, None::<String>, task);
-    }
-
-    fn start_task_with_command<F>(
+    fn start_task_with_action<F>(
         &mut self,
         label: impl Into<String>,
+        action: Option<TraceAction>,
         command: Option<impl Into<String>>,
         task: F,
     ) where
@@ -195,9 +189,13 @@ impl MasterSkillApp {
 
         let client = self.client.clone();
         let label = label.into();
-        let trace_id = self
-            .traces
-            .begin_with_detail(label.clone(), command, "Queued.");
+        let trace_id = if let Some(action) = action {
+            self.traces
+                .begin_with_action(label.clone(), action, command, "Queued.")
+        } else {
+            self.traces
+                .begin_with_detail(label.clone(), command, "Queued.")
+        };
         let (tx, rx) = channel();
         self.task_rx = Some(rx);
         self.busy_label = Some(label.clone());
@@ -247,32 +245,43 @@ impl MasterSkillApp {
 
     fn start_refresh(&mut self) {
         let selected_slug = self.selected_slug.clone();
-        self.start_task("Refreshing runtime data", move |client| {
-            let snapshot = Self::load_snapshot(&client, selected_slug)?;
-            Ok(TaskOutcome {
-                message: "Runtime data refreshed.".to_string(),
-                detail: "Reloaded inventory, runtime doctor report, selected skill metadata, and local diagnostics.".to_string(),
-                snapshot: Some(snapshot),
-            })
-        });
+        self.start_task_with_action(
+            "Refreshing runtime data",
+            Some(TraceAction::Refresh),
+            None::<String>,
+            move |client| {
+                let snapshot = Self::load_snapshot(&client, selected_slug)?;
+                Ok(TaskOutcome {
+                    message: "Runtime data refreshed.".to_string(),
+                    detail: "Reloaded inventory, runtime doctor report, selected skill metadata, and local diagnostics.".to_string(),
+                    snapshot: Some(snapshot),
+                })
+            },
+        );
     }
 
     fn start_inspect(&mut self, slug: String) {
-        self.start_task(format!("Loading master-{slug}"), move |client| {
-            let snapshot = Self::load_snapshot(&client, Some(slug.clone()))?;
-            Ok(TaskOutcome {
-                message: format!("Loaded master-{slug}."),
-                detail: format!(
-                    "Loaded source, evaluation, install, and runtime metadata for master-{slug}."
-                ),
-                snapshot: Some(snapshot),
-            })
-        });
+        self.start_task_with_action(
+            format!("Loading master-{slug}"),
+            Some(TraceAction::InspectSkill { slug: slug.clone() }),
+            None::<String>,
+            move |client| {
+                let snapshot = Self::load_snapshot(&client, Some(slug.clone()))?;
+                Ok(TaskOutcome {
+                    message: format!("Loaded master-{slug}."),
+                    detail: format!(
+                        "Loaded source, evaluation, install, and runtime metadata for master-{slug}."
+                    ),
+                    snapshot: Some(snapshot),
+                })
+            },
+        );
     }
 
     fn start_install(&mut self, slug: String) {
-        self.start_task_with_command(
+        self.start_task_with_action(
             format!("Installing master-{slug}"),
+            Some(TraceAction::InstallSkill { slug: slug.clone() }),
             Some(format!("master-skill install {slug}")),
             move |client| {
                 let output = client.install(&slug)?;
@@ -287,8 +296,9 @@ impl MasterSkillApp {
     }
 
     fn start_uninstall(&mut self, slug: String) {
-        self.start_task_with_command(
+        self.start_task_with_action(
             format!("Uninstalling master-{slug}"),
+            Some(TraceAction::UninstallSkill { slug: slug.clone() }),
             Some(format!("master-skill uninstall {slug}")),
             move |client| {
                 let output = client.uninstall(&slug)?;
@@ -304,8 +314,9 @@ impl MasterSkillApp {
 
     fn start_install_all(&mut self) {
         let selected_slug = self.selected_slug.clone();
-        self.start_task_with_command(
+        self.start_task_with_action(
             "Installing all skills",
+            Some(TraceAction::InstallAll),
             Some("master-skill install --all"),
             move |client| {
                 let output = client.install_all()?;
@@ -321,8 +332,9 @@ impl MasterSkillApp {
 
     fn start_update_all(&mut self) {
         let selected_slug = self.selected_slug.clone();
-        self.start_task_with_command(
+        self.start_task_with_action(
             "Updating all skills",
+            Some(TraceAction::UpdateAll),
             Some("master-skill update --all"),
             move |client| {
                 let output = client.update_all()?;
@@ -337,8 +349,9 @@ impl MasterSkillApp {
     }
 
     fn start_fidelity_dry_run(&mut self) {
-        self.start_task_with_command(
+        self.start_task_with_action(
             "Running fidelity dry-run",
+            Some(TraceAction::FidelityDryRunAll),
             Some("python3 scripts/test-fidelity.py --all --dry-run"),
             move |client| {
                 let output = client.run_fidelity_dry_run()?;
@@ -352,8 +365,9 @@ impl MasterSkillApp {
     }
 
     fn start_skill_fidelity_dry_run(&mut self, slug: String) {
-        self.start_task_with_command(
+        self.start_task_with_action(
             format!("Running master-{slug} fidelity dry-run"),
+            Some(TraceAction::FidelityDryRunSkill { slug: slug.clone() }),
             Some(format!(
                 "python3 scripts/test-fidelity.py --master master-{slug} --dry-run"
             )),
@@ -372,14 +386,19 @@ impl MasterSkillApp {
     }
 
     fn start_full_validation(&mut self) {
-        self.start_task_with_command("Running full validation", Some("npm test"), move |client| {
-            let output = client.run_full_validation()?;
-            Ok(TaskOutcome {
-                message: summarize_command_output("Full validation finished", &output),
-                detail: output.trim().to_string(),
-                snapshot: None,
-            })
-        });
+        self.start_task_with_action(
+            "Running full validation",
+            Some(TraceAction::FullValidation),
+            Some("npm test"),
+            move |client| {
+                let output = client.run_full_validation()?;
+                Ok(TaskOutcome {
+                    message: summarize_command_output("Full validation finished", &output),
+                    detail: output.trim().to_string(),
+                    snapshot: None,
+                })
+            },
+        );
     }
 
     fn show_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -483,6 +502,20 @@ impl MasterSkillApp {
             }
             DiagnosticOperation::InstallSkill { slug } => self.start_install(slug),
             DiagnosticOperation::FidelityDryRun { slug } => self.start_skill_fidelity_dry_run(slug),
+        }
+    }
+
+    fn start_trace_action(&mut self, action: TraceAction) {
+        match action {
+            TraceAction::Refresh => self.start_refresh(),
+            TraceAction::InspectSkill { slug } => self.start_inspect(slug),
+            TraceAction::InstallSkill { slug } => self.start_install(slug),
+            TraceAction::UninstallSkill { slug } => self.start_uninstall(slug),
+            TraceAction::InstallAll => self.start_install_all(),
+            TraceAction::UpdateAll => self.start_update_all(),
+            TraceAction::FidelityDryRunAll => self.start_fidelity_dry_run(),
+            TraceAction::FidelityDryRunSkill { slug } => self.start_skill_fidelity_dry_run(slug),
+            TraceAction::FullValidation => self.start_full_validation(),
         }
     }
 
@@ -830,6 +863,10 @@ impl MasterSkillApp {
             return;
         }
 
+        let busy = self.is_busy();
+        let mut action_to_rerun = None;
+        let mut skill_to_open = None;
+
         egui::ScrollArea::vertical()
             .max_height(320.0)
             .show(ui, |ui| {
@@ -867,6 +904,16 @@ impl MasterSkillApp {
                                     ui.label("Summary");
                                     ui.label(first_line(&record.summary));
                                     ui.end_row();
+                                    ui.label("Issue");
+                                    if let Some(kind) = record.failure_kind() {
+                                        ui.colored_label(
+                                            Self::trace_color(TraceStatus::Failed),
+                                            kind.label(),
+                                        );
+                                    } else {
+                                        ui.label("none");
+                                    }
+                                    ui.end_row();
                                     ui.label("Command");
                                     if let Some(command) = &record.command {
                                         ui.monospace(command);
@@ -875,6 +922,22 @@ impl MasterSkillApp {
                                     }
                                     ui.end_row();
                                 });
+                            ui.horizontal(|ui| {
+                                if ui
+                                    .add_enabled(
+                                        !busy && record.can_rerun(),
+                                        egui::Button::new("Rerun"),
+                                    )
+                                    .clicked()
+                                {
+                                    action_to_rerun = record.action.clone();
+                                }
+                                if let Some(slug) = record.related_skill_slug() {
+                                    if ui.button("Open Skill").clicked() {
+                                        skill_to_open = Some(slug.to_string());
+                                    }
+                                }
+                            });
                             ui.separator();
                             ui.label("Detail");
                             let detail = if record.detail.trim().is_empty() {
@@ -891,6 +954,13 @@ impl MasterSkillApp {
                     ui.separator();
                 }
             });
+        if let Some(action) = action_to_rerun {
+            self.start_trace_action(action);
+        }
+        if let Some(slug) = skill_to_open {
+            self.console_section = ConsoleSection::SkillDetail;
+            self.start_inspect(slug);
+        }
     }
 
     fn show_sidebar(&mut self, ui: &mut egui::Ui) {

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -19,6 +19,54 @@ impl TraceStatus {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TraceAction {
+    Refresh,
+    InspectSkill { slug: String },
+    InstallSkill { slug: String },
+    UninstallSkill { slug: String },
+    InstallAll,
+    UpdateAll,
+    FidelityDryRunAll,
+    FidelityDryRunSkill { slug: String },
+    FullValidation,
+}
+
+impl TraceAction {
+    pub fn related_skill_slug(&self) -> Option<&str> {
+        match self {
+            Self::InspectSkill { slug }
+            | Self::InstallSkill { slug }
+            | Self::UninstallSkill { slug }
+            | Self::FidelityDryRunSkill { slug } => Some(slug),
+            Self::Refresh
+            | Self::InstallAll
+            | Self::UpdateAll
+            | Self::FidelityDryRunAll
+            | Self::FullValidation => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FailureKind {
+    Validation,
+    Fidelity,
+    Install,
+    Runtime,
+}
+
+impl FailureKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Validation => "validation",
+            Self::Fidelity => "fidelity",
+            Self::Install => "install",
+            Self::Runtime => "runtime",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TraceRecord {
     pub id: u64,
     pub label: String,
@@ -26,7 +74,68 @@ pub struct TraceRecord {
     pub summary: String,
     pub detail: String,
     pub command: Option<String>,
+    pub action: Option<TraceAction>,
     pub duration_ms: Option<u128>,
+}
+
+impl TraceRecord {
+    pub fn can_rerun(&self) -> bool {
+        self.action.is_some() && self.status != TraceStatus::Running
+    }
+
+    pub fn related_skill_slug(&self) -> Option<&str> {
+        self.action
+            .as_ref()
+            .and_then(TraceAction::related_skill_slug)
+    }
+
+    pub fn failure_kind(&self) -> Option<FailureKind> {
+        if self.status != TraceStatus::Failed {
+            return None;
+        }
+
+        match &self.action {
+            Some(TraceAction::FullValidation) => Some(FailureKind::Validation),
+            Some(TraceAction::FidelityDryRunAll | TraceAction::FidelityDryRunSkill { .. }) => {
+                Some(FailureKind::Fidelity)
+            }
+            Some(
+                TraceAction::InstallSkill { .. }
+                | TraceAction::UninstallSkill { .. }
+                | TraceAction::InstallAll
+                | TraceAction::UpdateAll,
+            ) => Some(FailureKind::Install),
+            Some(TraceAction::Refresh | TraceAction::InspectSkill { .. }) => {
+                Some(FailureKind::Runtime)
+            }
+            None => classify_failure_text(&format!(
+                "{}\n{}\n{}",
+                self.label, self.summary, self.detail
+            )),
+        }
+    }
+}
+
+fn classify_failure_text(text: &str) -> Option<FailureKind> {
+    let value = text.to_ascii_lowercase();
+    if value.contains("fidelity") || value.contains("fidelity.jsonl") {
+        Some(FailureKind::Fidelity)
+    } else if value.contains("validation")
+        || value.contains("npm test")
+        || value.contains("validate")
+    {
+        Some(FailureKind::Validation)
+    } else if value.contains("install")
+        || value.contains("uninstall")
+        || value.contains("update")
+        || value.contains("master-skill cli")
+    {
+        Some(FailureKind::Install)
+    } else if value.trim().is_empty() {
+        None
+    } else {
+        Some(FailureKind::Runtime)
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -64,6 +173,26 @@ impl TraceStore {
         command: Option<impl Into<String>>,
         detail: impl Into<String>,
     ) -> u64 {
+        self.begin_record(label, None, command.map(Into::into), detail)
+    }
+
+    pub fn begin_with_action(
+        &mut self,
+        label: impl Into<String>,
+        action: TraceAction,
+        command: Option<impl Into<String>>,
+        detail: impl Into<String>,
+    ) -> u64 {
+        self.begin_record(label, Some(action), command.map(Into::into), detail)
+    }
+
+    fn begin_record(
+        &mut self,
+        label: impl Into<String>,
+        action: Option<TraceAction>,
+        command: Option<String>,
+        detail: impl Into<String>,
+    ) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
         self.records.push_back(TraceRecord {
@@ -72,7 +201,8 @@ impl TraceStore {
             status: TraceStatus::Running,
             summary: "Started.".to_string(),
             detail: detail.into(),
-            command: command.map(Into::into),
+            command,
+            action,
             duration_ms: None,
         });
         self.enforce_capacity();
@@ -184,7 +314,7 @@ impl TraceStore {
 mod tests {
     use std::time::Duration;
 
-    use super::{TraceStatus, TraceStore};
+    use super::{FailureKind, TraceAction, TraceStatus, TraceStore};
 
     #[test]
     fn records_success_and_error_traces_with_summary() {
@@ -241,6 +371,89 @@ mod tests {
         );
         assert!(recent[0].detail.contains("Testing: master-huineng"));
         assert_eq!(recent[0].duration_ms, Some(88));
+    }
+
+    #[test]
+    fn records_rerunnable_trace_action_and_related_skill() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run"),
+            "Dry-run queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity dry-run finished",
+            "Testing: master-huineng",
+            Duration::from_millis(91),
+        );
+
+        let record = &store.recent()[0];
+        assert_eq!(
+            record.action,
+            Some(TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string()
+            })
+        );
+        assert!(record.can_rerun());
+        assert_eq!(record.related_skill_slug(), Some("huineng"));
+    }
+
+    #[test]
+    fn classifies_failed_trace_kind_from_action_and_detail() {
+        let mut store = TraceStore::new(10);
+
+        let validation = store.begin_with_action(
+            "Running full validation",
+            TraceAction::FullValidation,
+            Some("npm test"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            validation,
+            "npm test failed",
+            "validate-fidelity.py failed",
+            Duration::from_millis(10),
+        );
+
+        let fidelity = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            fidelity,
+            "fidelity failed",
+            "No fidelity.jsonl found",
+            Duration::from_millis(11),
+        );
+
+        let install = store.begin_with_action(
+            "Installing master-huineng",
+            TraceAction::InstallSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("master-skill install huineng"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            install,
+            "install failed",
+            "failed to run master-skill CLI",
+            Duration::from_millis(12),
+        );
+
+        let recent = store.recent();
+        assert_eq!(recent[0].failure_kind(), Some(FailureKind::Install));
+        assert_eq!(recent[1].failure_kind(), Some(FailureKind::Fidelity));
+        assert_eq!(recent[2].failure_kind(), Some(FailureKind::Validation));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add rerunnable trace action metadata for refresh, skill inspect/install, install/update all, validation, and fidelity runs
- classify failed traces by validation, fidelity, install, or runtime issue kind
- add Run Trace recovery controls for Rerun and related skill navigation

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
