### PR TITLE
feat(desktop): add evaluation drilldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added executable desktop diagnostic actions for install and per-skill fidelity dry-runs, wired into the existing Run Trace workflow.
 - Added expandable Run Trace drill-down with command, summary, duration, and detailed output for desktop operations.
 - Added Run Trace recovery controls with rerunnable actions, related skill navigation, and failure-kind classification.
+- Added Skill Detail fidelity case drill-down with prompt, difficulty, assertion counts, and per-skill dry-run access.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -7,7 +7,7 @@ use eframe::egui;
 
 use crate::catalog::{
     console_summary, evaluation_summary, filter_rows, tradition_options, DiagnosticAction,
-    DiagnosticOperation, InstallFilter, QualityLevel, SkillDiagnostics, SkillRow,
+    DiagnosticOperation, FidelityCase, InstallFilter, QualityLevel, SkillDiagnostics, SkillRow,
 };
 use crate::cli::CliClient;
 use crate::layout::{
@@ -1164,6 +1164,55 @@ impl MasterSkillApp {
         ui.separator();
     }
 
+    fn show_fidelity_cases_panel(&mut self, ui: &mut egui::Ui, slug: &str, cases: &[FidelityCase]) {
+        ui.heading("Fidelity Cases");
+        ui.horizontal(|ui| {
+            ui.label(format!("{} cases", cases.len()));
+            ui.separator();
+            if ui
+                .add_enabled(
+                    !self.is_busy() && !cases.is_empty(),
+                    egui::Button::new("Run skill dry-run"),
+                )
+                .clicked()
+            {
+                self.start_skill_fidelity_dry_run(slug.to_string());
+            }
+        });
+
+        if cases.is_empty() {
+            ui.label("No fidelity cases detected.");
+            ui.separator();
+            return;
+        }
+
+        egui::ScrollArea::vertical()
+            .max_height(220.0)
+            .show(ui, |ui| {
+                egui::Grid::new(format!("fidelity-case-grid-{slug}"))
+                    .num_columns(5)
+                    .striped(true)
+                    .min_col_width(72.0)
+                    .show(ui, |ui| {
+                        ui.strong("#");
+                        ui.strong("Difficulty");
+                        ui.strong("Cites");
+                        ui.strong("Keywords");
+                        ui.strong("Prompt");
+                        ui.end_row();
+                        for case in cases {
+                            ui.label(case.index.to_string());
+                            ui.label(case.difficulty.as_deref().unwrap_or("unspecified"));
+                            ui.label(case.citation_assertion_count.to_string());
+                            ui.label(case.keyword_assertion_count.to_string());
+                            ui.label(first_line(&case.question));
+                            ui.end_row();
+                        }
+                    });
+            });
+        ui.separator();
+    }
+
     fn show_recommended_actions_panel(&mut self, ui: &mut egui::Ui, actions: &[DiagnosticAction]) {
         ui.heading("Recommended Actions");
         if actions.is_empty() {
@@ -1261,6 +1310,10 @@ impl MasterSkillApp {
                 .as_ref()
                 .map(|row| row.fidelity_case_count)
                 .unwrap_or_default();
+            let fidelity_cases = selected_row
+                .as_ref()
+                .map(|row| row.fidelity_cases.clone())
+                .unwrap_or_default();
             let kind = selected_row
                 .as_ref()
                 .map(|row| row.kind.label())
@@ -1307,6 +1360,7 @@ impl MasterSkillApp {
                         quality,
                         &diagnostic_summary,
                     );
+                    self.show_fidelity_cases_panel(&mut columns[1], &master.slug, &fidelity_cases);
                     self.show_recommended_actions_panel(&mut columns[1], &diagnostic_actions);
                     Self::show_runtime_protocol_panel(&mut columns[1], &master);
                 });
@@ -1319,6 +1373,7 @@ impl MasterSkillApp {
                     quality,
                     &diagnostic_summary,
                 );
+                self.show_fidelity_cases_panel(ui, &master.slug, &fidelity_cases);
                 self.show_recommended_actions_panel(ui, &diagnostic_actions);
                 Self::show_runtime_protocol_panel(ui, &master);
             }

--- a/desktop/src/catalog.rs
+++ b/desktop/src/catalog.rs
@@ -43,9 +43,28 @@ impl SkillKind {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FidelityCase {
+    pub index: usize,
+    pub question: String,
+    pub difficulty: Option<String>,
+    pub citation_assertion_count: usize,
+    pub keyword_assertion_count: usize,
+    pub structure_assertion_count: usize,
+}
+
+impl FidelityCase {
+    pub fn total_assertion_count(&self) -> usize {
+        self.citation_assertion_count
+            + self.keyword_assertion_count
+            + self.structure_assertion_count
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SkillDiagnostics {
     pub fidelity_case_count: usize,
+    pub fidelity_cases: Vec<FidelityCase>,
     pub source_index_present: bool,
     pub kind: SkillKind,
 }
@@ -54,17 +73,13 @@ impl SkillDiagnostics {
     pub fn from_prebuilt_dir(prebuilt_dir: &Path, slug: &str) -> Self {
         let skill_dir = prebuilt_dir.join(format!("master-{slug}"));
         let fidelity_path = skill_dir.join("tests").join("fidelity.jsonl");
-        let fidelity_case_count = fs::read_to_string(fidelity_path)
-            .map(|content| {
-                content
-                    .lines()
-                    .filter(|line| !line.trim().is_empty())
-                    .count()
-            })
-            .unwrap_or(0);
+        let fidelity_cases = fs::read_to_string(fidelity_path)
+            .map(|content| parse_fidelity_cases(&content))
+            .unwrap_or_default();
 
         Self {
-            fidelity_case_count,
+            fidelity_case_count: fidelity_cases.len(),
+            fidelity_cases,
             source_index_present: skill_dir.join("sources").join("INDEX.md").is_file(),
             kind: detect_skill_kind(&skill_dir),
         }
@@ -96,6 +111,49 @@ fn detect_skill_kind(skill_dir: &Path) -> SkillKind {
     }
 }
 
+fn parse_fidelity_cases(content: &str) -> Vec<FidelityCase> {
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .enumerate()
+        .map(|(index, line)| {
+            let value = serde_json::from_str::<serde_json::Value>(line).unwrap_or_default();
+            FidelityCase {
+                index: index + 1,
+                question: value
+                    .get("q")
+                    .or_else(|| value.get("prompt"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("untitled case")
+                    .to_string(),
+                difficulty: value
+                    .get("difficulty")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                citation_assertion_count: json_array_len(&value, "must_cite"),
+                keyword_assertion_count: json_array_len(&value, "must_mention"),
+                structure_assertion_count: json_array_len(&value, "must_select_pair")
+                    + json_array_len(&value, "must_have_rounds")
+                    + json_array_len(&value, "must_have_sections")
+                    + usize::from(
+                        value
+                            .get("must_cite_per_round")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false),
+                    ),
+            }
+        })
+        .collect()
+}
+
+fn json_array_len(value: &serde_json::Value, key: &str) -> usize {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DiagnosticOperation {
     Manual,
@@ -125,6 +183,7 @@ pub struct SkillRow {
     pub keyword_count: usize,
     pub has_citation_format: bool,
     pub fidelity_case_count: usize,
+    pub fidelity_cases: Vec<FidelityCase>,
     pub source_index_present: bool,
     pub kind: SkillKind,
 }
@@ -150,6 +209,7 @@ impl SkillRow {
                 .map(|value| !value.trim().is_empty())
                 .unwrap_or(false),
             fidelity_case_count: 0,
+            fidelity_cases: Vec::new(),
             source_index_present: false,
             kind: SkillKind::Persona,
         }
@@ -161,6 +221,7 @@ impl SkillRow {
 
     pub fn apply_diagnostics(&mut self, diagnostics: SkillDiagnostics) {
         self.fidelity_case_count = diagnostics.fidelity_case_count;
+        self.fidelity_cases = diagnostics.fidelity_cases;
         self.source_index_present = diagnostics.source_index_present;
         self.kind = diagnostics.kind;
     }
@@ -507,6 +568,7 @@ mod tests {
             keyword_count: 8,
             has_citation_format: true,
             fidelity_case_count: 4,
+            fidelity_cases: Vec::new(),
             source_index_present: true,
             kind: SkillKind::Persona,
         }
@@ -590,6 +652,33 @@ mod tests {
 
         assert!(diagnostics.source_index_present);
         assert_eq!(diagnostics.fidelity_case_count, 2);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reads_fidelity_case_drilldown_from_jsonl() {
+        let root = temp_dir();
+        let skill_dir = root.join("master-huineng");
+        fs::create_dir_all(skill_dir.join("tests")).unwrap();
+        fs::write(
+            skill_dir.join("tests").join("fidelity.jsonl"),
+            "{\"q\":\"什么是见性成佛？\",\"difficulty\":\"basic\",\"must_cite\":[\"T48n2008\",\"坛经\"],\"must_mention\":[\"自性\",\"佛性\"]}\n{\"q\":\"顿悟怎么修？\",\"difficulty\":\"intermediate\",\"must_cite\":[\"T48n2008\"],\"must_mention\":[\"顿悟\"]}\n",
+        )
+        .unwrap();
+
+        let diagnostics = SkillDiagnostics::from_prebuilt_dir(Path::new(&root), "huineng");
+
+        assert_eq!(diagnostics.fidelity_cases.len(), 2);
+        assert_eq!(diagnostics.fidelity_cases[0].index, 1);
+        assert_eq!(diagnostics.fidelity_cases[0].question, "什么是见性成佛？");
+        assert_eq!(
+            diagnostics.fidelity_cases[0].difficulty.as_deref(),
+            Some("basic")
+        );
+        assert_eq!(diagnostics.fidelity_cases[0].citation_assertion_count, 2);
+        assert_eq!(diagnostics.fidelity_cases[0].keyword_assertion_count, 2);
+        assert_eq!(diagnostics.fidelity_cases[0].total_assertion_count(), 4);
 
         fs::remove_dir_all(root).unwrap();
     }


### PR DESCRIPTION
## Summary
- parse fidelity.jsonl into lightweight case drill-down metadata
- show Fidelity Cases in Skill Detail with prompt, difficulty, citation, and keyword assertion counts
- add per-skill dry-run access beside the case list

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
