### PR TITLE
feat(desktop): index evaluation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added expandable Run Trace drill-down with command, summary, duration, and detailed output for desktop operations.
 - Added Run Trace recovery controls with rerunnable actions, related skill navigation, and failure-kind classification.
 - Added Skill Detail fidelity case drill-down with prompt, difficulty, assertion counts, and per-skill dry-run access.
+- Added Evaluation Result Index from recent fidelity dry-run traces and surfaced latest suite status beside Skill Detail cases.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1166,9 +1166,17 @@ impl MasterSkillApp {
 
     fn show_fidelity_cases_panel(&mut self, ui: &mut egui::Ui, slug: &str, cases: &[FidelityCase]) {
         ui.heading("Fidelity Cases");
+        let latest_result = self.traces.latest_evaluation_result_for(slug);
         ui.horizontal(|ui| {
             ui.label(format!("{} cases", cases.len()));
             ui.separator();
+            if let Some(result) = &latest_result {
+                ui.label(format!("Latest: {}", result.label()));
+                ui.separator();
+            } else {
+                ui.label("Latest: not run");
+                ui.separator();
+            }
             if ui
                 .add_enabled(
                     !self.is_busy() && !cases.is_empty(),
@@ -1190,7 +1198,7 @@ impl MasterSkillApp {
             .max_height(220.0)
             .show(ui, |ui| {
                 egui::Grid::new(format!("fidelity-case-grid-{slug}"))
-                    .num_columns(5)
+                    .num_columns(6)
                     .striped(true)
                     .min_col_width(72.0)
                     .show(ui, |ui| {
@@ -1198,6 +1206,7 @@ impl MasterSkillApp {
                         ui.strong("Difficulty");
                         ui.strong("Cites");
                         ui.strong("Keywords");
+                        ui.strong("Last Result");
                         ui.strong("Prompt");
                         ui.end_row();
                         for case in cases {
@@ -1205,6 +1214,18 @@ impl MasterSkillApp {
                             ui.label(case.difficulty.as_deref().unwrap_or("unspecified"));
                             ui.label(case.citation_assertion_count.to_string());
                             ui.label(case.keyword_assertion_count.to_string());
+                            ui.label(
+                                latest_result
+                                    .as_ref()
+                                    .map(|result| {
+                                        if result.dry_run {
+                                            "N/A dry-run".to_string()
+                                        } else {
+                                            result.label()
+                                        }
+                                    })
+                                    .unwrap_or_else(|| "not run".to_string()),
+                            );
                             ui.label(first_line(&case.question));
                             ui.end_row();
                         }

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -78,6 +78,22 @@ pub struct TraceRecord {
     pub duration_ms: Option<u128>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationRunResult {
+    pub slug: String,
+    pub passed_count: usize,
+    pub total_count: usize,
+    pub dry_run: bool,
+    pub trace_id: u64,
+}
+
+impl EvaluationRunResult {
+    pub fn label(&self) -> String {
+        let mode = if self.dry_run { "N/A" } else { "graded" };
+        format!("{}/{} {mode}", self.passed_count, self.total_count)
+    }
+}
+
 impl TraceRecord {
     pub fn can_rerun(&self) -> bool {
         self.action.is_some() && self.status != TraceStatus::Running
@@ -114,6 +130,51 @@ impl TraceRecord {
             )),
         }
     }
+
+    pub fn evaluation_results(&self) -> Vec<EvaluationRunResult> {
+        if !matches!(
+            self.action,
+            Some(TraceAction::FidelityDryRunAll | TraceAction::FidelityDryRunSkill { .. })
+        ) {
+            return Vec::new();
+        }
+
+        parse_evaluation_results(self.id, &self.detail)
+    }
+}
+
+fn parse_evaluation_results(trace_id: u64, detail: &str) -> Vec<EvaluationRunResult> {
+    let mut results = Vec::new();
+    let mut current_slug: Option<String> = None;
+
+    for line in detail.lines().map(str::trim) {
+        if let Some(rest) = line.strip_prefix("Testing: master-") {
+            current_slug = Some(rest.to_string());
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("Result: ") {
+            if let Some(slug) = current_slug.take() {
+                if let Some((passed_count, total_count)) = parse_result_counts(rest) {
+                    results.push(EvaluationRunResult {
+                        slug,
+                        passed_count,
+                        total_count,
+                        dry_run: rest.contains("(N/A)"),
+                        trace_id,
+                    });
+                }
+            }
+        }
+    }
+
+    results
+}
+
+fn parse_result_counts(value: &str) -> Option<(usize, usize)> {
+    let counts = value.split_whitespace().next()?;
+    let (passed, total) = counts.split_once('/')?;
+    Some((passed.parse().ok()?, total.parse().ok()?))
 }
 
 fn classify_failure_text(text: &str) -> Option<FailureKind> {
@@ -257,6 +318,14 @@ impl TraceStore {
 
     pub fn recent(&self) -> Vec<TraceRecord> {
         self.records.iter().rev().cloned().collect()
+    }
+
+    pub fn latest_evaluation_result_for(&self, slug: &str) -> Option<EvaluationRunResult> {
+        self.records
+            .iter()
+            .rev()
+            .flat_map(TraceRecord::evaluation_results)
+            .find(|result| result.slug == slug)
     }
 
     pub fn clear(&mut self) {
@@ -454,6 +523,33 @@ mod tests {
         assert_eq!(recent[0].failure_kind(), Some(FailureKind::Install));
         assert_eq!(recent[1].failure_kind(), Some(FailureKind::Fidelity));
         assert_eq!(recent[2].failure_kind(), Some(FailureKind::Validation));
+    }
+
+    #[test]
+    fn indexes_latest_evaluation_result_from_dry_run_trace() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity dry-run finished",
+            "\n==================================================\nTesting: master-huineng\n==================================================\n\nResult: 0/12 passed (N/A)\n",
+            Duration::from_millis(50),
+        );
+
+        let result = store.latest_evaluation_result_for("huineng").unwrap();
+        assert_eq!(result.slug, "huineng");
+        assert_eq!(result.passed_count, 0);
+        assert_eq!(result.total_count, 12);
+        assert!(result.dry_run);
+        assert_eq!(result.label(), "0/12 N/A");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse recent fidelity dry-run traces into a lightweight Evaluation Result Index
- surface latest suite result beside Skill Detail fidelity cases
- show per-case last result status as not run, N/A dry-run, or graded summary

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
