### PR TITLE
feat(desktop): show evaluation run results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Run Trace recovery controls with rerunnable actions, related skill navigation, and failure-kind classification.
 - Added Skill Detail fidelity case drill-down with prompt, difficulty, assertion counts, and per-skill dry-run access.
 - Added Evaluation Result Index from recent fidelity dry-run traces and surfaced latest suite status beside Skill Detail cases.
+- Added latest fidelity run status to Evaluation Center skill suites using the desktop Evaluation Result Index.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::mpsc::{channel, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -765,6 +766,12 @@ impl MasterSkillApp {
     fn show_skill_suites(&mut self, ui: &mut egui::Ui) {
         ui.heading("Skill Suites");
         let rows = self.rows.clone();
+        let latest_results: BTreeMap<_, _> = self
+            .traces
+            .latest_evaluation_results_by_slug()
+            .into_iter()
+            .map(|result| (result.slug.clone(), result))
+            .collect();
         egui::ScrollArea::horizontal()
             .max_width(ui.available_width())
             .show(ui, |ui| {
@@ -772,7 +779,7 @@ impl MasterSkillApp {
                     .max_height(260.0)
                     .show(ui, |ui| {
                         egui::Grid::new("evaluation-skill-grid")
-                            .num_columns(6)
+                            .num_columns(7)
                             .striped(true)
                             .min_col_width(104.0)
                             .show(ui, |ui| {
@@ -780,6 +787,7 @@ impl MasterSkillApp {
                                 ui.strong("Tradition");
                                 ui.strong("Kind");
                                 ui.strong("Cases");
+                                ui.strong("Last Run");
                                 ui.strong("Status");
                                 ui.strong("Gaps");
                                 ui.end_row();
@@ -792,6 +800,12 @@ impl MasterSkillApp {
                                     ui.label(row.tradition.as_deref().unwrap_or("unspecified"));
                                     ui.label(row.kind.label());
                                     ui.label(row.fidelity_case_count.to_string());
+                                    ui.label(
+                                        latest_results
+                                            .get(&row.slug)
+                                            .map(|result| result.label())
+                                            .unwrap_or_else(|| "not run".to_string()),
+                                    );
                                     ui.colored_label(Self::quality_color(level), level.label());
                                     ui.label(row.diagnostic_summary());
                                     ui.end_row();

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -328,6 +328,20 @@ impl TraceStore {
             .find(|result| result.slug == slug)
     }
 
+    pub fn latest_evaluation_results_by_slug(&self) -> Vec<EvaluationRunResult> {
+        let mut results = BTreeMap::new();
+        for result in self
+            .records
+            .iter()
+            .rev()
+            .flat_map(TraceRecord::evaluation_results)
+        {
+            results.entry(result.slug.clone()).or_insert(result);
+        }
+
+        results.into_values().collect()
+    }
+
     pub fn clear(&mut self) {
         self.records.clear();
     }
@@ -550,6 +564,47 @@ mod tests {
         assert_eq!(result.total_count, 12);
         assert!(result.dry_run);
         assert_eq!(result.label(), "0/12 N/A");
+    }
+
+    #[test]
+    fn indexes_latest_evaluation_results_by_skill_from_full_dry_run_trace() {
+        let mut store = TraceStore::new(10);
+
+        let old_run = store.begin_with_action(
+            "Running fidelity dry-run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --dry-run"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_run,
+            "fidelity dry-run finished",
+            "Testing: master-huineng\nResult: 0/8 passed (N/A)\nTesting: master-zhiyi\nResult: 0/10 passed (N/A)",
+            Duration::from_millis(40),
+        );
+
+        let new_run = store.begin_with_action(
+            "Running fidelity dry-run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --dry-run"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_run,
+            "fidelity dry-run finished",
+            "Testing: master-huineng\nResult: 0/12 passed (N/A)",
+            Duration::from_millis(45),
+        );
+
+        let results = store.latest_evaluation_results_by_slug();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].slug, "huineng");
+        assert_eq!(results[0].total_count, 12);
+        assert_eq!(results[0].trace_id, new_run);
+        assert_eq!(results[1].slug, "zhiyi");
+        assert_eq!(results[1].total_count, 10);
+        assert_eq!(results[1].trace_id, old_run);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- index the latest fidelity dry-run result for every skill from desktop trace history
- add Last Run status to Evaluation Center skill suites
- keep per-skill result lookups available for Skill Detail

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
