### PR TITLE
feat(desktop): add evaluation run coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Skill Detail fidelity case drill-down with prompt, difficulty, assertion counts, and per-skill dry-run access.
 - Added Evaluation Result Index from recent fidelity dry-run traces and surfaced latest suite status beside Skill Detail cases.
 - Added latest fidelity run status to Evaluation Center skill suites using the desktop Evaluation Result Index.
+- Added Evaluation Center run coverage metrics for latest suite evidence, dry-run counts, and graded counts.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -669,6 +669,7 @@ impl MasterSkillApp {
     fn show_evaluation_center(&mut self, ui: &mut egui::Ui) {
         let busy = self.is_busy();
         let summary = evaluation_summary(&self.rows);
+        let run_coverage = self.traces.evaluation_run_coverage(summary.skill_count);
         Self::show_workspace_header(
             ui,
             "Evaluation Center",
@@ -695,6 +696,16 @@ impl MasterSkillApp {
                 value: summary.case_count.to_string(),
                 detail: format!("{} skills", summary.skill_count),
                 healthy: summary.missing_suite_count == 0,
+            },
+            MetricCard {
+                title: "Run Coverage",
+                value: run_coverage.label(),
+                detail: format!(
+                    "{} dry-run / {} graded",
+                    run_coverage.dry_run_count, run_coverage.graded_count
+                ),
+                healthy: summary.skill_count > 0
+                    && run_coverage.run_skill_count == summary.skill_count,
             },
             MetricCard {
                 title: "Ready",

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -208,6 +208,20 @@ pub struct TraceSummary {
     pub last_status: Option<TraceStatus>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EvaluationRunCoverage {
+    pub total_skill_count: usize,
+    pub run_skill_count: usize,
+    pub dry_run_count: usize,
+    pub graded_count: usize,
+}
+
+impl EvaluationRunCoverage {
+    pub fn label(&self) -> String {
+        format!("{}/{}", self.run_skill_count, self.total_skill_count)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct TraceStore {
     capacity: usize,
@@ -340,6 +354,16 @@ impl TraceStore {
         }
 
         results.into_values().collect()
+    }
+
+    pub fn evaluation_run_coverage(&self, total_skill_count: usize) -> EvaluationRunCoverage {
+        let results = self.latest_evaluation_results_by_slug();
+        EvaluationRunCoverage {
+            total_skill_count,
+            run_skill_count: results.len(),
+            dry_run_count: results.iter().filter(|result| result.dry_run).count(),
+            graded_count: results.iter().filter(|result| !result.dry_run).count(),
+        }
     }
 
     pub fn clear(&mut self) {
@@ -605,6 +629,32 @@ mod tests {
         assert_eq!(results[1].slug, "zhiyi");
         assert_eq!(results[1].total_count, 10);
         assert_eq!(results[1].trace_id, old_run);
+    }
+
+    #[test]
+    fn summarizes_evaluation_run_coverage_from_latest_results() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running fidelity dry-run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --dry-run"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "fidelity dry-run finished",
+            "Testing: master-huineng\nResult: 0/12 passed (N/A)\nTesting: master-zhiyi\nResult: 0/10 passed (N/A)",
+            Duration::from_millis(40),
+        );
+
+        let coverage = store.evaluation_run_coverage(18);
+
+        assert_eq!(coverage.total_skill_count, 18);
+        assert_eq!(coverage.run_skill_count, 2);
+        assert_eq!(coverage.dry_run_count, 2);
+        assert_eq!(coverage.graded_count, 0);
+        assert_eq!(coverage.label(), "2/18");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add evaluation run coverage metrics from the latest desktop trace results
- show Run Coverage, dry-run count, and graded count in Evaluation Center cards
- cover the aggregation with a trace-store unit test

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
