### PR TITLE
feat(desktop): persist run traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Result Index from recent fidelity dry-run traces and surfaced latest suite status beside Skill Detail cases.
 - Added latest fidelity run status to Evaluation Center skill suites using the desktop Evaluation Result Index.
 - Added Evaluation Center run coverage metrics for latest suite evidence, dry-run counts, and graded counts.
+- Added persisted desktop run trace history so evaluation evidence and operation audit trails survive app restarts.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -57,6 +58,7 @@ pub struct MasterSkillApp {
     console_section: ConsoleSection,
     log_expanded: bool,
     traces: TraceStore,
+    trace_path: PathBuf,
 }
 
 struct Snapshot {
@@ -90,6 +92,14 @@ struct MetricCard {
 
 impl MasterSkillApp {
     pub fn new() -> Self {
+        let trace_path = desktop_trace_store_path();
+        let (traces, trace_load_message) = match TraceStore::load_from_path(&trace_path, 200) {
+            Ok(traces) => (traces, None),
+            Err(err) => (
+                TraceStore::new(200),
+                Some(format!("Trace history load failed: {err:#}")),
+            ),
+        };
         let mut app = Self {
             client: CliClient::default(),
             inventory: None,
@@ -106,8 +116,12 @@ impl MasterSkillApp {
             busy_label: None,
             console_section: ConsoleSection::Overview,
             log_expanded: false,
-            traces: TraceStore::new(200),
+            traces,
+            trace_path,
         };
+        if let Some(message) = trace_load_message {
+            app.set_log(message);
+        }
         app.refresh_all();
         app
     }
@@ -160,6 +174,12 @@ impl MasterSkillApp {
         }
     }
 
+    fn persist_traces(&mut self) {
+        if let Err(err) = self.traces.save_to_path(&self.trace_path) {
+            self.set_log(format!("Trace history save failed: {err:#}"));
+        }
+    }
+
     fn refresh_all(&mut self) {
         match Self::load_snapshot(&self.client, self.selected_slug.clone()) {
             Ok(snapshot) => {
@@ -197,6 +217,7 @@ impl MasterSkillApp {
             self.traces
                 .begin_with_detail(label.clone(), command, "Queued.")
         };
+        self.persist_traces();
         let (tx, rx) = channel();
         self.task_rx = Some(rx);
         self.busy_label = Some(label.clone());
@@ -229,6 +250,7 @@ impl MasterSkillApp {
                         outcome.detail.clone(),
                         envelope.elapsed,
                     );
+                    self.persist_traces();
                     self.set_log(outcome.message);
                 }
                 Err(message) => {
@@ -238,6 +260,7 @@ impl MasterSkillApp {
                         message.clone(),
                         envelope.elapsed,
                     );
+                    self.persist_traces();
                     self.set_log(message);
                 }
             }
@@ -839,6 +862,7 @@ impl MasterSkillApp {
                     .clicked()
                 {
                     self.traces.clear();
+                    self.persist_traces();
                     self.set_log("Run trace history cleared.");
                 }
             },
@@ -1536,4 +1560,69 @@ fn first_line(value: &str) -> String {
         .map(str::trim)
         .unwrap_or("")
         .to_string()
+}
+
+fn desktop_trace_store_path() -> PathBuf {
+    desktop_trace_store_path_from_env(
+        std::env::var("XDG_DATA_HOME").ok().as_deref(),
+        std::env::var("HOME").ok().as_deref(),
+        std::env::var("APPDATA").ok().as_deref(),
+    )
+    .unwrap_or_else(|| {
+        std::env::temp_dir()
+            .join("master-skill")
+            .join("desktop-traces.json")
+    })
+}
+
+fn desktop_trace_store_path_from_env(
+    xdg_data_home: Option<&str>,
+    home: Option<&str>,
+    appdata: Option<&str>,
+) -> Option<PathBuf> {
+    if let Some(path) = xdg_data_home.filter(|value| !value.trim().is_empty()) {
+        return Some(
+            PathBuf::from(path)
+                .join("master-skill")
+                .join("desktop-traces.json"),
+        );
+    }
+
+    if let Some(path) = appdata.filter(|value| !value.trim().is_empty()) {
+        return Some(
+            PathBuf::from(path)
+                .join("Master-skill")
+                .join("desktop-traces.json"),
+        );
+    }
+
+    home.filter(|value| !value.trim().is_empty()).map(|path| {
+        PathBuf::from(path)
+            .join(".local")
+            .join("share")
+            .join("master-skill")
+            .join("desktop-traces.json")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    #[test]
+    fn trace_store_path_prefers_xdg_data_home() {
+        let path = super::desktop_trace_store_path_from_env(
+            Some("/tmp/xdg-data"),
+            Some("/home/user"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/xdg-data")
+                .join("master-skill")
+                .join("desktop-traces.json")
+        );
+    }
 }

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -1,7 +1,12 @@
 use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::path::Path;
 use std::time::Duration;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum TraceStatus {
     Running,
     Succeeded,
@@ -18,7 +23,7 @@ impl TraceStatus {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum TraceAction {
     Refresh,
     InspectSkill { slug: String },
@@ -66,7 +71,7 @@ impl FailureKind {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct TraceRecord {
     pub id: u64,
     pub label: String,
@@ -222,7 +227,7 @@ impl EvaluationRunCoverage {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TraceStore {
     capacity: usize,
     next_id: u64,
@@ -236,6 +241,36 @@ impl TraceStore {
             next_id: 1,
             records: VecDeque::new(),
         }
+    }
+
+    pub fn load_from_path(path: &Path, capacity: usize) -> Result<Self> {
+        if !path.is_file() {
+            return Ok(Self::new(capacity));
+        }
+
+        let content = fs::read_to_string(path)?;
+        let mut store: Self = serde_json::from_str(&content)?;
+        store.capacity = capacity;
+        store.next_id = store
+            .records
+            .iter()
+            .map(|record| record.id)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1)
+            .max(store.next_id);
+        store.mark_running_records_interrupted();
+        store.enforce_capacity();
+        Ok(store)
+    }
+
+    pub fn save_to_path(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string_pretty(self)?;
+        fs::write(path, content)?;
+        Ok(())
     }
 
     pub fn begin(&mut self, label: impl Into<String>) -> u64 {
@@ -415,13 +450,35 @@ impl TraceStore {
             self.records.pop_front();
         }
     }
+
+    fn mark_running_records_interrupted(&mut self) {
+        for record in &mut self.records {
+            if record.status == TraceStatus::Running {
+                record.status = TraceStatus::Failed;
+                record.summary = "Interrupted before completion.".to_string();
+                record.detail =
+                    "Desktop manager closed before this operation reported a result.".to_string();
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
     use std::time::Duration;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{FailureKind, TraceAction, TraceStatus, TraceStore};
+
+    fn temp_path(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("master-skill-desktop-{name}-{suffix}.json"))
+    }
 
     #[test]
     fn records_success_and_error_traces_with_summary() {
@@ -655,6 +712,66 @@ mod tests {
         assert_eq!(coverage.dry_run_count, 2);
         assert_eq!(coverage.graded_count, 0);
         assert_eq!(coverage.label(), "2/18");
+    }
+
+    #[test]
+    fn persists_trace_history_and_next_record_id() {
+        let path = temp_path("trace-history");
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity dry-run finished",
+            "Testing: master-huineng\nResult: 0/12 passed (N/A)",
+            Duration::from_millis(40),
+        );
+
+        store.save_to_path(&path).unwrap();
+        let mut restored = TraceStore::load_from_path(&path, 10).unwrap();
+        let next = restored.begin("Refreshing runtime data");
+
+        assert_eq!(restored.summary().total, 2);
+        assert_eq!(next, 2);
+        assert_eq!(
+            restored
+                .latest_evaluation_result_for("huineng")
+                .unwrap()
+                .label(),
+            "0/12 N/A"
+        );
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn marks_persisted_running_traces_as_interrupted_on_load() {
+        let path = temp_path("trace-interrupted");
+        let mut store = TraceStore::new(10);
+
+        store.begin_with_action(
+            "Running full validation",
+            TraceAction::FullValidation,
+            Some("npm test"),
+            "Queued.",
+        );
+
+        store.save_to_path(&path).unwrap();
+        let restored = TraceStore::load_from_path(&path, 10).unwrap();
+        let record = &restored.recent()[0];
+
+        assert_eq!(record.status, TraceStatus::Failed);
+        assert_eq!(record.summary, "Interrupted before completion.");
+        assert!(record.detail.contains("Desktop manager closed"));
+
+        fs::remove_file(path).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- persist desktop run trace history as JSON in the user data directory
- load persisted trace history on startup so evaluation evidence survives restarts
- mark persisted in-flight operations as interrupted failures instead of leaving stale running rows

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
