### PR TITLE
fix(fidelity): emit clean json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added latest fidelity run status to Evaluation Center skill suites using the desktop Evaluation Result Index.
 - Added Evaluation Center run coverage metrics for latest suite evidence, dry-run counts, and graded counts.
 - Added persisted desktop run trace history so evaluation evidence and operation audit trails survive app restarts.
+- Fixed fidelity runner JSON mode so `--json` emits clean machine-readable output without human-readable banners.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/scripts/test-fidelity.py
+++ b/scripts/test-fidelity.py
@@ -138,6 +138,7 @@ def run_tests(
     dry_run: bool = False,
     model: str = "claude-sonnet-4-6",
     max_tests: int | None = None,
+    quiet: bool = False,
 ) -> dict:
     """Run fidelity tests for a master. Returns summary."""
     master_dir = PREBUILT_DIR / master_name
@@ -197,7 +198,8 @@ def run_tests(
     failed = 0
 
     for i, test in enumerate(tests):
-        print(f"  [{i+1}/{len(tests)}] {test['q'][:50]}...", end=" ", flush=True)
+        if not quiet:
+            print(f"  [{i+1}/{len(tests)}] {test['q'][:50]}...", end=" ", flush=True)
 
         try:
             message = client.messages.create(
@@ -215,7 +217,8 @@ def run_tests(
                 "error": str(e),
             })
             failed += 1
-            print("API ERROR")
+            if not quiet:
+                print("API ERROR")
             continue
 
         check = check_response(
@@ -240,12 +243,14 @@ def run_tests(
 
         if check["passed"]:
             passed += 1
-            print("PASS")
+            if not quiet:
+                print("PASS")
         else:
             failed += 1
             failures = (check["missing_cites"] + check["missing_mentions"]
                         + check["forbidden_found"] + check["boundary_violations"])
-            print(f"FAIL ({failures})")
+            if not quiet:
+                print(f"FAIL ({failures})")
 
     return {
         "master": master_name,
@@ -276,6 +281,9 @@ def main():
     if not args.master and not args.all:
         parser.error("Specify --master <name> or --all")
 
+    if args.json and hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     if args.all:
         masters = sorted(
             d.name for d in PREBUILT_DIR.iterdir()
@@ -286,11 +294,16 @@ def main():
 
     all_results = []
     for master in masters:
-        print(f"\n{'='*50}")
-        print(f"Testing: {master}")
-        print(f"{'='*50}")
+        if not args.json:
+            print(f"\n{'='*50}")
+            print(f"Testing: {master}")
+            print(f"{'='*50}")
         result = run_tests(
-            master, dry_run=args.dry_run, model=args.model, max_tests=args.max_tests
+            master,
+            dry_run=args.dry_run,
+            model=args.model,
+            max_tests=args.max_tests,
+            quiet=args.json,
         )
         all_results.append(result)
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -275,6 +275,29 @@ test("unknown command exits non-zero", () => {
   assert.equal(code, 1);
 });
 
+test("fidelity runner --json emits parseable JSON without text banners", () => {
+  const stdout = execFileSync(
+    "python3",
+    [
+      path.join(REPO, "scripts", "test-fidelity.py"),
+      "--master",
+      "master-huineng",
+      "--dry-run",
+      "--json",
+      "--max-tests",
+      "1",
+    ],
+    { encoding: "utf8" }
+  );
+
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.length, 1);
+  assert.equal(payload[0].master, "master-huineng");
+  assert.equal(payload[0].total, 1);
+  assert.equal(payload[0].results.length, 1);
+  assert.equal(payload[0].results[0].status, "dry_run");
+});
+
 // Deterministic CRLF coverage: the windows-latest job only exercises CRLF
 // because the repo lacks .gitattributes and the runner defaults autocrlf=true.
 // This test pins the code path on every OS by building a synthetic install


### PR DESCRIPTION
## Summary
- make scripts/test-fidelity.py --json emit clean parseable JSON without text banners
- silence graded-run progress output when JSON mode is requested
- add Node integration coverage that parses the JSON dry-run output

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
