### PR TITLE
feat(desktop): show per-case evaluation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Center run coverage metrics for latest suite evidence, dry-run counts, and graded counts.
 - Added persisted desktop run trace history so evaluation evidence and operation audit trails survive app restarts.
 - Fixed fidelity runner JSON mode so `--json` emits clean machine-readable output without human-readable banners.
+- Added desktop per-case fidelity result indexing from JSON dry-run traces and surfaced case-level status in Skill Detail.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -376,7 +376,7 @@ impl MasterSkillApp {
         self.start_task_with_action(
             "Running fidelity dry-run",
             Some(TraceAction::FidelityDryRunAll),
-            Some("python3 scripts/test-fidelity.py --all --dry-run"),
+            Some("python3 scripts/test-fidelity.py --all --dry-run --json"),
             move |client| {
                 let output = client.run_fidelity_dry_run()?;
                 Ok(TaskOutcome {
@@ -393,7 +393,7 @@ impl MasterSkillApp {
             format!("Running master-{slug} fidelity dry-run"),
             Some(TraceAction::FidelityDryRunSkill { slug: slug.clone() }),
             Some(format!(
-                "python3 scripts/test-fidelity.py --master master-{slug} --dry-run"
+                "python3 scripts/test-fidelity.py --master master-{slug} --dry-run --json"
             )),
             move |client| {
                 let output = client.run_fidelity_dry_run_for(&slug)?;
@@ -1216,6 +1216,12 @@ impl MasterSkillApp {
     fn show_fidelity_cases_panel(&mut self, ui: &mut egui::Ui, slug: &str, cases: &[FidelityCase]) {
         ui.heading("Fidelity Cases");
         let latest_result = self.traces.latest_evaluation_result_for(slug);
+        let case_results: BTreeMap<usize, _> = self
+            .traces
+            .latest_evaluation_case_results_for(slug)
+            .into_iter()
+            .map(|result| (result.case_index, result))
+            .collect();
         ui.horizontal(|ui| {
             ui.label(format!("{} cases", cases.len()));
             ui.separator();
@@ -1263,18 +1269,22 @@ impl MasterSkillApp {
                             ui.label(case.difficulty.as_deref().unwrap_or("unspecified"));
                             ui.label(case.citation_assertion_count.to_string());
                             ui.label(case.keyword_assertion_count.to_string());
-                            ui.label(
-                                latest_result
-                                    .as_ref()
-                                    .map(|result| {
-                                        if result.dry_run {
-                                            "N/A dry-run".to_string()
-                                        } else {
-                                            result.label()
-                                        }
-                                    })
-                                    .unwrap_or_else(|| "not run".to_string()),
-                            );
+                            if let Some(result) = case_results.get(&case.index) {
+                                ui.label(result.status.as_str());
+                            } else {
+                                ui.label(
+                                    latest_result
+                                        .as_ref()
+                                        .map(|result| {
+                                            if result.dry_run {
+                                                "N/A dry-run".to_string()
+                                            } else {
+                                                result.label()
+                                            }
+                                        })
+                                        .unwrap_or_else(|| "not run".to_string()),
+                                );
+                            }
                             ui.label(first_line(&case.question));
                             ui.end_row();
                         }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -63,7 +63,8 @@ impl CliClient {
             Command::new("python3")
                 .arg(self.repo_root.join("scripts").join("test-fidelity.py"))
                 .arg("--all")
-                .arg("--dry-run"),
+                .arg("--dry-run")
+                .arg("--json"),
             "failed to run fidelity dry-run",
         )
     }
@@ -74,7 +75,8 @@ impl CliClient {
                 .arg(self.repo_root.join("scripts").join("test-fidelity.py"))
                 .arg("--master")
                 .arg(format!("master-{slug}"))
-                .arg("--dry-run"),
+                .arg("--dry-run")
+                .arg("--json"),
             "failed to run skill fidelity dry-run",
         )
     }

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -99,6 +99,16 @@ impl EvaluationRunResult {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationCaseResult {
+    pub slug: String,
+    pub case_index: usize,
+    pub question: String,
+    pub difficulty: Option<String>,
+    pub status: String,
+    pub trace_id: u64,
+}
+
 impl TraceRecord {
     pub fn can_rerun(&self) -> bool {
         self.action.is_some() && self.status != TraceStatus::Running
@@ -146,6 +156,65 @@ impl TraceRecord {
 
         parse_evaluation_results(self.id, &self.detail)
     }
+
+    pub fn evaluation_case_results(&self) -> Vec<EvaluationCaseResult> {
+        if !matches!(
+            self.action,
+            Some(TraceAction::FidelityDryRunAll | TraceAction::FidelityDryRunSkill { .. })
+        ) {
+            return Vec::new();
+        }
+
+        parse_evaluation_case_results(self.id, &self.detail)
+    }
+}
+
+fn parse_evaluation_case_results(trace_id: u64, detail: &str) -> Vec<EvaluationCaseResult> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(detail) else {
+        return Vec::new();
+    };
+    let Some(suites) = value.as_array() else {
+        return Vec::new();
+    };
+
+    let mut case_results = Vec::new();
+    for suite in suites {
+        let Some(master_name) = suite.get("master").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some(slug) = master_name.strip_prefix("master-") else {
+            continue;
+        };
+        let Some(results) = suite.get("results").and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+
+        for result in results {
+            let Some(index) = result.get("index").and_then(serde_json::Value::as_u64) else {
+                continue;
+            };
+            let Some(status) = result.get("status").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            case_results.push(EvaluationCaseResult {
+                slug: slug.to_string(),
+                case_index: index as usize + 1,
+                question: result
+                    .get("question")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("untitled case")
+                    .to_string(),
+                difficulty: result
+                    .get("difficulty")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                status: status.to_string(),
+                trace_id,
+            });
+        }
+    }
+
+    case_results
 }
 
 fn parse_evaluation_results(trace_id: u64, detail: &str) -> Vec<EvaluationRunResult> {
@@ -389,6 +458,15 @@ impl TraceStore {
         }
 
         results.into_values().collect()
+    }
+
+    pub fn latest_evaluation_case_results_for(&self, slug: &str) -> Vec<EvaluationCaseResult> {
+        self.records
+            .iter()
+            .rev()
+            .flat_map(TraceRecord::evaluation_case_results)
+            .filter(|result| result.slug == slug)
+            .collect()
     }
 
     pub fn evaluation_run_coverage(&self, total_skill_count: usize) -> EvaluationRunCoverage {
@@ -686,6 +764,55 @@ mod tests {
         assert_eq!(results[1].slug, "zhiyi");
         assert_eq!(results[1].total_count, 10);
         assert_eq!(results[1].trace_id, old_run);
+    }
+
+    #[test]
+    fn indexes_latest_evaluation_case_results_from_json_trace() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity dry-run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "total": 2,
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "什么是见性成佛？",
+                    "difficulty": "basic",
+                    "status": "dry_run"
+                  },
+                  {
+                    "index": 1,
+                    "question": "顿悟怎么修？",
+                    "difficulty": "intermediate",
+                    "status": "dry_run"
+                  }
+                ]
+              }
+            ]"#,
+            Duration::from_millis(50),
+        );
+
+        let results = store.latest_evaluation_case_results_for("huineng");
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].case_index, 1);
+        assert_eq!(results[0].status, "dry_run");
+        assert_eq!(results[0].difficulty.as_deref(), Some("basic"));
+        assert_eq!(results[0].trace_id, run);
+        assert_eq!(results[1].case_index, 2);
+        assert_eq!(results[1].question, "顿悟怎么修？");
     }
 
     #[test]

--- a/desktop/tests/cli_client.rs
+++ b/desktop/tests/cli_client.rs
@@ -42,9 +42,14 @@ fn runs_fidelity_dry_run_from_repo_root() {
     let client = CliClient::new(repo_root());
 
     let output = client.run_fidelity_dry_run().unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&output).unwrap();
 
-    assert!(output.contains("Overall Summary"));
-    assert!(output.contains("master-huineng"));
+    assert!(payload.as_array().unwrap().len() > 1);
+    assert!(payload
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|suite| suite["master"] == "master-huineng"));
 }
 
 #[test]
@@ -52,7 +57,10 @@ fn runs_single_skill_fidelity_dry_run_from_repo_root() {
     let client = CliClient::new(repo_root());
 
     let output = client.run_fidelity_dry_run_for("huineng").unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let suites = payload.as_array().unwrap();
 
-    assert!(output.contains("Testing: master-huineng"));
-    assert!(!output.contains("Testing: master-zhiyi"));
+    assert_eq!(suites.len(), 1);
+    assert_eq!(suites[0]["master"], "master-huineng");
+    assert!(suites[0]["results"].as_array().unwrap().len() > 1);
 }


### PR DESCRIPTION
## Summary
- run desktop fidelity dry-runs with --json so traces carry structured suite and case data
- parse per-case fidelity JSON results in TraceStore
- surface case-level latest status in Skill Detail while keeping suite-level fallback status

## Validation
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test
