### PR TITLE
fix(desktop): clarify graded pass rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added desktop per-case fidelity result indexing from JSON dry-run traces and surfaced case-level status in Skill Detail.
 - Added per-case fidelity failure evidence summaries in Skill Detail for missing citations, missing mentions, boundary issues, forbidden text, and fabricated citations.
 - Added Evaluation Center failure insights for latest case results, including failed-case counts, pass rate, failing skills, top failure source, and failure-type distribution.
+- Refined Evaluation Center pass-rate semantics so dry-run-only case results show `N/A` instead of a misleading graded percentage.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -794,10 +794,11 @@ impl MasterSkillApp {
                 title: "Pass Rate",
                 value: insights.pass_rate_label(),
                 detail: format!(
-                    "{} pass / {} dry-run",
-                    insights.pass_cases, insights.dry_run_cases
+                    "{} graded / {} dry-run",
+                    insights.graded_cases(),
+                    insights.dry_run_cases
                 ),
-                healthy: insights.failed_cases == 0 && insights.total_cases > 0,
+                healthy: insights.failed_cases == 0,
             },
             MetricCard {
                 title: "Failing Skills",

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -372,12 +372,17 @@ pub struct EvaluationFailureInsights {
 }
 
 impl EvaluationFailureInsights {
+    pub fn graded_cases(&self) -> usize {
+        self.pass_cases + self.failed_cases
+    }
+
     pub fn pass_rate_label(&self) -> String {
-        if self.total_cases == 0 {
+        let graded_cases = self.graded_cases();
+        if graded_cases == 0 {
             return "N/A".to_string();
         }
 
-        format!("{}%", self.pass_cases * 100 / self.total_cases)
+        format!("{}%", self.pass_cases * 100 / graded_cases)
     }
 
     pub fn top_failure_label(&self) -> String {
@@ -1126,6 +1131,49 @@ mod tests {
         assert_eq!(insights.forbidden_found_count, 1);
         assert_eq!(insights.boundary_violations_count, 1);
         assert_eq!(insights.fabricated_cites_count, 0);
+    }
+
+    #[test]
+    fn keeps_pass_rate_not_applicable_for_dry_run_only_cases() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity dry-run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "什么是见性成佛？",
+                    "status": "dry_run"
+                  },
+                  {
+                    "index": 1,
+                    "question": "顿悟怎么修？",
+                    "status": "dry_run"
+                  }
+                ]
+              }
+            ]"#,
+            Duration::from_millis(55),
+        );
+
+        let insights = store.evaluation_failure_insights();
+
+        assert_eq!(insights.total_cases, 2);
+        assert_eq!(insights.dry_run_cases, 2);
+        assert_eq!(insights.graded_cases(), 0);
+        assert_eq!(insights.pass_rate_label(), "N/A");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make Evaluation Center pass-rate calculations ignore dry-run-only cases
- show graded/dry-run case counts in the pass-rate card
- add regression coverage for dry-run-only evaluation insights

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test