### PR TITLE
feat(desktop): add evaluation failure queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added per-case fidelity failure evidence summaries in Skill Detail for missing citations, missing mentions, boundary issues, forbidden text, and fabricated citations.
 - Added Evaluation Center failure insights for latest case results, including failed-case counts, pass rate, failing skills, top failure source, and failure-type distribution.
 - Refined Evaluation Center pass-rate semantics so dry-run-only case results show `N/A` instead of a misleading graded percentage.
+- Added an Evaluation Center failure queue that lists latest failing cases with evidence and direct actions to open the skill or rerun its fidelity dry-run.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -20,7 +20,9 @@ use crate::model::{DoctorReport, MasterInspect, SkillInventory};
 use crate::theme::{
     apply_console_theme, sidebar_default_width, sidebar_row_height, status_badge_width,
 };
-use crate::trace::{EvaluationFailureInsights, TraceAction, TraceStatus, TraceStore};
+use crate::trace::{
+    EvaluationFailureInsights, EvaluationFailureItem, TraceAction, TraceStatus, TraceStore,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ConsoleSection {
@@ -694,6 +696,7 @@ impl MasterSkillApp {
         let summary = evaluation_summary(&self.rows);
         let run_coverage = self.traces.evaluation_run_coverage(summary.skill_count);
         let failure_insights = self.traces.evaluation_failure_insights();
+        let failure_queue = self.traces.evaluation_failure_queue();
         Self::show_workspace_header(
             ui,
             "Evaluation Center",
@@ -759,7 +762,7 @@ impl MasterSkillApp {
         Self::show_metric_cards(ui, &cards);
 
         ui.separator();
-        Self::show_evaluation_failure_insights(ui, &failure_insights);
+        self.show_evaluation_failure_insights(ui, &failure_insights, &failure_queue);
 
         ui.separator();
         let mode = dense_table_mode_for_width(ui.available_width());
@@ -775,7 +778,12 @@ impl MasterSkillApp {
         }
     }
 
-    fn show_evaluation_failure_insights(ui: &mut egui::Ui, insights: &EvaluationFailureInsights) {
+    fn show_evaluation_failure_insights(
+        &mut self,
+        ui: &mut egui::Ui,
+        insights: &EvaluationFailureInsights,
+        failure_queue: &[EvaluationFailureItem],
+    ) {
         ui.heading("Failure Insights");
         let top_failure_value = insights
             .top_failure_skill_slug
@@ -838,6 +846,72 @@ impl MasterSkillApp {
                 ui.label(insights.fabricated_cites_count.to_string());
                 ui.end_row();
             });
+
+        ui.separator();
+        self.show_evaluation_failure_queue(ui, failure_queue);
+    }
+
+    fn show_evaluation_failure_queue(
+        &mut self,
+        ui: &mut egui::Ui,
+        failure_queue: &[EvaluationFailureItem],
+    ) {
+        ui.heading("Failure Queue");
+        if failure_queue.is_empty() {
+            ui.small("No failing cases in the latest case-level evaluation results.");
+            return;
+        }
+
+        let busy = self.is_busy();
+        let mut skill_to_open = None;
+        let mut skill_to_run = None;
+        egui::ScrollArea::horizontal()
+            .max_width(ui.available_width())
+            .show(ui, |ui| {
+                egui::ScrollArea::vertical()
+                    .max_height(220.0)
+                    .show(ui, |ui| {
+                        egui::Grid::new("evaluation-failure-queue-grid")
+                            .num_columns(6)
+                            .striped(true)
+                            .min_col_width(92.0)
+                            .show(ui, |ui| {
+                                ui.strong("Skill");
+                                ui.strong("Case");
+                                ui.strong("Status");
+                                ui.strong("Question");
+                                ui.strong("Evidence");
+                                ui.strong("Actions");
+                                ui.end_row();
+
+                                for item in failure_queue {
+                                    ui.label(format!("master-{}", item.slug));
+                                    ui.label(format!("#{}", item.case_index));
+                                    ui.label(&item.status);
+                                    ui.label(&item.question);
+                                    ui.label(&item.failure_summary);
+                                    ui.horizontal(|ui| {
+                                        if ui.button("Open").clicked() {
+                                            skill_to_open = Some(item.slug.clone());
+                                        }
+                                        if ui.add_enabled(!busy, egui::Button::new("Run")).clicked()
+                                        {
+                                            skill_to_run = Some(item.slug.clone());
+                                        }
+                                    });
+                                    ui.end_row();
+                                }
+                            });
+                    });
+            });
+
+        if let Some(slug) = skill_to_open {
+            self.console_section = ConsoleSection::SkillDetail;
+            self.start_inspect(slug);
+        }
+        if let Some(slug) = skill_to_run {
+            self.start_skill_fidelity_dry_run(slug);
+        }
     }
 
     fn show_tradition_coverage(ui: &mut egui::Ui, groups: &[crate::catalog::EvaluationGroup]) {

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -371,6 +371,16 @@ pub struct EvaluationFailureInsights {
     pub fabricated_cites_count: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationFailureItem {
+    pub slug: String,
+    pub case_index: usize,
+    pub question: String,
+    pub status: String,
+    pub failure_summary: String,
+    pub trace_id: u64,
+}
+
 impl EvaluationFailureInsights {
     pub fn graded_cases(&self) -> usize {
         self.pass_cases + self.failed_cases
@@ -613,6 +623,25 @@ impl TraceStore {
         }
 
         insights
+    }
+
+    pub fn evaluation_failure_queue(&self) -> Vec<EvaluationFailureItem> {
+        self.latest_evaluation_case_results_by_slug()
+            .into_values()
+            .flatten()
+            .filter(|result| result.status == "FAIL" || result.has_failure_evidence())
+            .map(|result| {
+                let failure_summary = result.failure_summary();
+                EvaluationFailureItem {
+                    slug: result.slug,
+                    case_index: result.case_index,
+                    question: result.question,
+                    status: result.status,
+                    failure_summary,
+                    trace_id: result.trace_id,
+                }
+            })
+            .collect()
     }
 
     pub fn clear(&mut self) {
@@ -1174,6 +1203,95 @@ mod tests {
         assert_eq!(insights.dry_run_cases, 2);
         assert_eq!(insights.graded_cases(), 0);
         assert_eq!(insights.pass_rate_label(), "N/A");
+    }
+
+    #[test]
+    fn lists_latest_failed_evaluation_cases_for_action_queue() {
+        let mut store = TraceStore::new(10);
+
+        let old_run = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_run,
+            "master-huineng fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "旧失败不应进入队列",
+                    "status": "FAIL",
+                    "missing_cites": ["OLD"]
+                  }
+                ]
+              }
+            ]"#,
+            Duration::from_millis(40),
+        );
+
+        let latest_run = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            latest_run,
+            "fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "这个 case 已经通过",
+                    "status": "PASS"
+                  },
+                  {
+                    "index": 1,
+                    "question": "顿悟是否等于随意发挥？",
+                    "status": "FAIL",
+                    "missing_cites": ["T48n2008"],
+                    "forbidden_found": ["过程旁白"]
+                  }
+                ]
+              },
+              {
+                "master": "master-zhiyi",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "一念三千如何表达？",
+                    "status": "FAIL",
+                    "missing_mentions": ["三谛"]
+                  }
+                ]
+              }
+            ]"#,
+            Duration::from_millis(55),
+        );
+
+        let queue = store.evaluation_failure_queue();
+
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue[0].slug, "huineng");
+        assert_eq!(queue[0].case_index, 2);
+        assert_eq!(queue[0].question, "顿悟是否等于随意发挥？");
+        assert_eq!(
+            queue[0].failure_summary,
+            "missing cites: T48n2008; forbidden: 过程旁白"
+        );
+        assert_eq!(queue[0].trace_id, latest_run);
+        assert_eq!(queue[1].slug, "zhiyi");
+        assert_eq!(queue[1].case_index, 1);
+        assert_eq!(queue[1].failure_summary, "missing mentions: 三谛");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a latest-case evaluation failure queue derived from persisted desktop traces
- show failing cases in Evaluation Center with skill, case number, question, and evidence
- add direct actions to open the affected skill or rerun its fidelity dry-run

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test