### PR TITLE
feat(desktop): prioritize evaluation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Center failure insights for latest case results, including failed-case counts, pass rate, failing skills, top failure source, and failure-type distribution.
 - Refined Evaluation Center pass-rate semantics so dry-run-only case results show `N/A` instead of a misleading graded percentage.
 - Added an Evaluation Center failure queue that lists latest failing cases with evidence and direct actions to open the skill or rerun its fidelity dry-run.
+- Added risk priorities to the Evaluation Center failure queue so fabricated citations, boundary violations, and forbidden text surface before lower-risk failures.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -21,7 +21,8 @@ use crate::theme::{
     apply_console_theme, sidebar_default_width, sidebar_row_height, status_badge_width,
 };
 use crate::trace::{
-    EvaluationFailureInsights, EvaluationFailureItem, TraceAction, TraceStatus, TraceStore,
+    EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority, TraceAction,
+    TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -492,6 +493,14 @@ impl MasterSkillApp {
         }
     }
 
+    fn failure_priority_color(priority: EvaluationFailurePriority) -> egui::Color32 {
+        match priority {
+            EvaluationFailurePriority::Critical => egui::Color32::from_rgb(220, 90, 85),
+            EvaluationFailurePriority::High => egui::Color32::from_rgb(210, 145, 70),
+            EvaluationFailurePriority::Medium => egui::Color32::from_rgb(145, 160, 180),
+        }
+    }
+
     fn quality_badge_fill(level: QualityLevel) -> egui::Color32 {
         match level {
             QualityLevel::Ready => egui::Color32::from_rgb(21, 64, 44),
@@ -872,11 +881,12 @@ impl MasterSkillApp {
                     .max_height(220.0)
                     .show(ui, |ui| {
                         egui::Grid::new("evaluation-failure-queue-grid")
-                            .num_columns(6)
+                            .num_columns(7)
                             .striped(true)
                             .min_col_width(92.0)
                             .show(ui, |ui| {
                                 ui.strong("Skill");
+                                ui.strong("Priority");
                                 ui.strong("Case");
                                 ui.strong("Status");
                                 ui.strong("Question");
@@ -886,6 +896,10 @@ impl MasterSkillApp {
 
                                 for item in failure_queue {
                                     ui.label(format!("master-{}", item.slug));
+                                    ui.colored_label(
+                                        Self::failure_priority_color(item.priority),
+                                        item.priority.label(),
+                                    );
                                     ui.label(format!("#{}", item.case_index));
                                     ui.label(&item.status);
                                     ui.label(&item.question);

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -141,6 +141,19 @@ impl EvaluationCaseResult {
             || !self.boundary_violations.is_empty()
             || !self.fabricated_cites.is_empty()
     }
+
+    fn failure_priority(&self) -> EvaluationFailurePriority {
+        if !self.fabricated_cites.is_empty()
+            || !self.boundary_violations.is_empty()
+            || !self.forbidden_found.is_empty()
+        {
+            EvaluationFailurePriority::Critical
+        } else if !self.missing_cites.is_empty() || !self.missing_mentions.is_empty() {
+            EvaluationFailurePriority::High
+        } else {
+            EvaluationFailurePriority::Medium
+        }
+    }
 }
 
 fn push_detail_part(parts: &mut Vec<String>, label: &str, values: &[String]) {
@@ -377,8 +390,26 @@ pub struct EvaluationFailureItem {
     pub case_index: usize,
     pub question: String,
     pub status: String,
+    pub priority: EvaluationFailurePriority,
     pub failure_summary: String,
     pub trace_id: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EvaluationFailurePriority {
+    Medium,
+    High,
+    Critical,
+}
+
+impl EvaluationFailurePriority {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
 }
 
 impl EvaluationFailureInsights {
@@ -626,22 +657,33 @@ impl TraceStore {
     }
 
     pub fn evaluation_failure_queue(&self) -> Vec<EvaluationFailureItem> {
-        self.latest_evaluation_case_results_by_slug()
+        let mut queue: Vec<_> = self
+            .latest_evaluation_case_results_by_slug()
             .into_values()
             .flatten()
             .filter(|result| result.status == "FAIL" || result.has_failure_evidence())
             .map(|result| {
+                let priority = result.failure_priority();
                 let failure_summary = result.failure_summary();
                 EvaluationFailureItem {
                     slug: result.slug,
                     case_index: result.case_index,
                     question: result.question,
                     status: result.status,
+                    priority,
                     failure_summary,
                     trace_id: result.trace_id,
                 }
             })
-            .collect()
+            .collect();
+        queue.sort_by(|left, right| {
+            right
+                .priority
+                .cmp(&left.priority)
+                .then_with(|| left.slug.cmp(&right.slug))
+                .then_with(|| left.case_index.cmp(&right.case_index))
+        });
+        queue
     }
 
     pub fn clear(&mut self) {
@@ -1292,6 +1334,66 @@ mod tests {
         assert_eq!(queue[1].slug, "zhiyi");
         assert_eq!(queue[1].case_index, 1);
         assert_eq!(queue[1].failure_summary, "missing mentions: 三谛");
+    }
+
+    #[test]
+    fn prioritizes_failure_queue_by_risk() {
+        let mut store = TraceStore::new(10);
+
+        let run = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "只有 status 失败",
+                    "status": "FAIL"
+                  }
+                ]
+              },
+              {
+                "master": "master-zhiyi",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "缺少引用",
+                    "status": "FAIL",
+                    "missing_cites": ["T46n1911"]
+                  }
+                ]
+              },
+              {
+                "master": "master-xuanzang",
+                "results": [
+                  {
+                    "index": 0,
+                    "question": "伪造引用",
+                    "status": "FAIL",
+                    "fabricated_cites": ["T99n9999"]
+                  }
+                ]
+              }
+            ]"#,
+            Duration::from_millis(55),
+        );
+
+        let queue = store.evaluation_failure_queue();
+
+        assert_eq!(queue[0].slug, "xuanzang");
+        assert_eq!(queue[0].priority.label(), "critical");
+        assert_eq!(queue[1].slug, "zhiyi");
+        assert_eq!(queue[1].priority.label(), "high");
+        assert_eq!(queue[2].slug, "huineng");
+        assert_eq!(queue[2].priority.label(), "medium");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add critical/high/medium priorities to Evaluation Center failure queue items
- sort queue items so fabricated citations, boundary violations, and forbidden text surface first
- show color-coded priority labels in the desktop failure queue

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test