### PR TITLE
feat(desktop): show evaluation run history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Refined Evaluation Center pass-rate semantics so dry-run-only case results show `N/A` instead of a misleading graded percentage.
 - Added an Evaluation Center failure queue that lists latest failing cases with evidence and direct actions to open the skill or rerun its fidelity dry-run.
 - Added risk priorities to the Evaluation Center failure queue so fabricated citations, boundary violations, and forbidden text surface before lower-risk failures.
+- Added Evaluation Center run history with scope, status, result counts, failed counts, mode, duration, and rerun/open actions for recent evaluation runs.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -21,8 +21,8 @@ use crate::theme::{
     apply_console_theme, sidebar_default_width, sidebar_row_height, status_badge_width,
 };
 use crate::trace::{
-    EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority, TraceAction,
-    TraceStatus, TraceStore,
+    EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
+    EvaluationRunHistoryItem, TraceAction, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -706,6 +706,7 @@ impl MasterSkillApp {
         let run_coverage = self.traces.evaluation_run_coverage(summary.skill_count);
         let failure_insights = self.traces.evaluation_failure_insights();
         let failure_queue = self.traces.evaluation_failure_queue();
+        let run_history = self.traces.evaluation_run_history(8);
         Self::show_workspace_header(
             ui,
             "Evaluation Center",
@@ -772,6 +773,9 @@ impl MasterSkillApp {
 
         ui.separator();
         self.show_evaluation_failure_insights(ui, &failure_insights, &failure_queue);
+
+        ui.separator();
+        self.show_evaluation_run_history(ui, &run_history);
 
         ui.separator();
         let mode = dense_table_mode_for_width(ui.available_width());
@@ -925,6 +929,89 @@ impl MasterSkillApp {
         }
         if let Some(slug) = skill_to_run {
             self.start_skill_fidelity_dry_run(slug);
+        }
+    }
+
+    fn show_evaluation_run_history(
+        &mut self,
+        ui: &mut egui::Ui,
+        run_history: &[EvaluationRunHistoryItem],
+    ) {
+        ui.heading("Run History");
+        if run_history.is_empty() {
+            ui.small("No evaluation runs recorded yet.");
+            return;
+        }
+
+        let busy = self.is_busy();
+        let mut action_to_rerun = None;
+        let mut skill_to_open = None;
+        egui::ScrollArea::horizontal()
+            .max_width(ui.available_width())
+            .show(ui, |ui| {
+                egui::ScrollArea::vertical()
+                    .max_height(180.0)
+                    .show(ui, |ui| {
+                        egui::Grid::new("evaluation-run-history-grid")
+                            .num_columns(8)
+                            .striped(true)
+                            .min_col_width(92.0)
+                            .show(ui, |ui| {
+                                ui.strong("Trace");
+                                ui.strong("Scope");
+                                ui.strong("Status");
+                                ui.strong("Result");
+                                ui.strong("Failed");
+                                ui.strong("Mode");
+                                ui.strong("Duration");
+                                ui.strong("Actions");
+                                ui.end_row();
+
+                                for item in run_history {
+                                    ui.label(format!("#{}", item.trace_id));
+                                    ui.label(&item.scope);
+                                    ui.colored_label(
+                                        Self::trace_color(item.status),
+                                        item.status.label(),
+                                    );
+                                    ui.label(item.result_label());
+                                    ui.label(item.failed_count.to_string());
+                                    ui.label(if item.dry_run { "dry-run" } else { "graded" });
+                                    ui.label(
+                                        item.duration_ms
+                                            .map(|duration| format!("{duration} ms"))
+                                            .unwrap_or_else(|| "running".to_string()),
+                                    );
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .add_enabled(
+                                                !busy && item.action.is_some(),
+                                                egui::Button::new("Rerun"),
+                                            )
+                                            .clicked()
+                                        {
+                                            action_to_rerun = item.action.clone();
+                                        }
+                                        if let Some(slug) =
+                                            item.scope.strip_prefix("master-").map(str::to_string)
+                                        {
+                                            if ui.button("Open").clicked() {
+                                                skill_to_open = Some(slug);
+                                            }
+                                        }
+                                    });
+                                    ui.end_row();
+                                }
+                            });
+                    });
+            });
+
+        if let Some(action) = action_to_rerun {
+            self.start_trace_action(action);
+        }
+        if let Some(slug) = skill_to_open {
+            self.console_section = ConsoleSection::SkillDetail;
+            self.start_inspect(slug);
         }
     }
 

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -100,6 +100,26 @@ impl EvaluationRunResult {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationRunHistoryItem {
+    pub trace_id: u64,
+    pub scope: String,
+    pub status: TraceStatus,
+    pub passed_count: usize,
+    pub total_count: usize,
+    pub failed_count: usize,
+    pub dry_run: bool,
+    pub duration_ms: Option<u128>,
+    pub action: Option<TraceAction>,
+}
+
+impl EvaluationRunHistoryItem {
+    pub fn result_label(&self) -> String {
+        let mode = if self.dry_run { "N/A" } else { "graded" };
+        format!("{}/{} {mode}", self.passed_count, self.total_count)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EvaluationCaseResult {
     pub slug: String,
     pub case_index: usize,
@@ -219,6 +239,70 @@ impl TraceRecord {
         }
 
         parse_evaluation_case_results(self.id, &self.detail)
+    }
+
+    fn evaluation_run_history_item(&self) -> Option<EvaluationRunHistoryItem> {
+        if !matches!(
+            self.action,
+            Some(TraceAction::FidelityDryRunAll | TraceAction::FidelityDryRunSkill { .. })
+        ) {
+            return None;
+        }
+
+        let cases = self.evaluation_case_results();
+        if !cases.is_empty() {
+            let passed_count = cases.iter().filter(|case| case.status == "PASS").count();
+            let failed_count = cases
+                .iter()
+                .filter(|case| case.status == "FAIL" || case.has_failure_evidence())
+                .count();
+            let dry_run = cases.iter().all(|case| case.status == "dry_run");
+            return Some(EvaluationRunHistoryItem {
+                trace_id: self.id,
+                scope: self.evaluation_scope_label(),
+                status: self.status,
+                passed_count,
+                total_count: cases.len(),
+                failed_count,
+                dry_run,
+                duration_ms: self.duration_ms,
+                action: self.action.clone(),
+            });
+        }
+
+        let results = self.evaluation_results();
+        if results.is_empty() {
+            return None;
+        }
+
+        let passed_count: usize = results.iter().map(|result| result.passed_count).sum();
+        let total_count: usize = results.iter().map(|result| result.total_count).sum();
+        let dry_run = results.iter().all(|result| result.dry_run);
+        let failed_count = if dry_run {
+            0
+        } else {
+            total_count.saturating_sub(passed_count)
+        };
+
+        Some(EvaluationRunHistoryItem {
+            trace_id: self.id,
+            scope: self.evaluation_scope_label(),
+            status: self.status,
+            passed_count,
+            total_count,
+            failed_count,
+            dry_run,
+            duration_ms: self.duration_ms,
+            action: self.action.clone(),
+        })
+    }
+
+    fn evaluation_scope_label(&self) -> String {
+        match &self.action {
+            Some(TraceAction::FidelityDryRunSkill { slug }) => format!("master-{slug}"),
+            Some(TraceAction::FidelityDryRunAll) => "all".to_string(),
+            _ => "evaluation".to_string(),
+        }
     }
 }
 
@@ -596,6 +680,15 @@ impl TraceStore {
         }
 
         results.into_values().collect()
+    }
+
+    pub fn evaluation_run_history(&self, limit: usize) -> Vec<EvaluationRunHistoryItem> {
+        self.records
+            .iter()
+            .rev()
+            .filter_map(TraceRecord::evaluation_run_history_item)
+            .take(limit)
+            .collect()
     }
 
     pub fn latest_evaluation_case_results_for(&self, slug: &str) -> Vec<EvaluationCaseResult> {
@@ -1394,6 +1487,78 @@ mod tests {
         assert_eq!(queue[1].priority.label(), "high");
         assert_eq!(queue[2].slug, "huineng");
         assert_eq!(queue[2].priority.label(), "medium");
+    }
+
+    #[test]
+    fn lists_recent_evaluation_run_history_with_counts_and_rerun_actions() {
+        let mut store = TraceStore::new(10);
+
+        let skill_run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            skill_run,
+            "master-huineng fidelity dry-run finished",
+            "Testing: master-huineng\nResult: 0/12 passed (N/A)",
+            Duration::from_millis(40),
+        );
+
+        let all_run = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            all_run,
+            "fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {"index": 0, "question": "通过", "status": "PASS"},
+                  {"index": 1, "question": "失败", "status": "FAIL"}
+                ]
+              },
+              {
+                "master": "master-zhiyi",
+                "results": [
+                  {"index": 0, "question": "通过", "status": "PASS"}
+                ]
+              }
+            ]"#,
+            Duration::from_millis(55),
+        );
+
+        let history = store.evaluation_run_history(5);
+
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].trace_id, all_run);
+        assert_eq!(history[0].scope, "all");
+        assert_eq!(history[0].passed_count, 2);
+        assert_eq!(history[0].total_count, 3);
+        assert_eq!(history[0].failed_count, 1);
+        assert!(!history[0].dry_run);
+        assert_eq!(history[0].duration_ms, Some(55));
+        assert_eq!(history[0].action, Some(TraceAction::FidelityDryRunAll));
+
+        assert_eq!(history[1].trace_id, skill_run);
+        assert_eq!(history[1].scope, "master-huineng");
+        assert_eq!(history[1].passed_count, 0);
+        assert_eq!(history[1].total_count, 12);
+        assert_eq!(history[1].failed_count, 0);
+        assert!(history[1].dry_run);
+        assert_eq!(
+            history[1].action,
+            Some(TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string()
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add evaluation run history summaries from persisted desktop traces
- show recent evaluation runs in Evaluation Center with scope, status, result counts, failed count, mode, and duration
- add rerun/open actions from the run history table

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test