### PR TITLE
feat(desktop): show evaluation run trends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added an Evaluation Center failure queue that lists latest failing cases with evidence and direct actions to open the skill or rerun its fidelity dry-run.
 - Added risk priorities to the Evaluation Center failure queue so fabricated citations, boundary violations, and forbidden text surface before lower-risk failures.
 - Added Evaluation Center run history with scope, status, result counts, failed counts, mode, duration, and rerun/open actions for recent evaluation runs.
+- Added Evaluation Center run trends so recent evaluation runs show whether each scope improved, regressed, stayed stable, or is new.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -22,7 +22,7 @@ use crate::theme::{
 };
 use crate::trace::{
     EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
-    EvaluationRunHistoryItem, TraceAction, TraceStatus, TraceStore,
+    EvaluationRunHistoryItem, EvaluationRunTrend, TraceAction, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -501,6 +501,15 @@ impl MasterSkillApp {
         }
     }
 
+    fn evaluation_trend_color(trend: EvaluationRunTrend) -> egui::Color32 {
+        match trend {
+            EvaluationRunTrend::Improved => egui::Color32::from_rgb(100, 190, 130),
+            EvaluationRunTrend::Regressed => egui::Color32::from_rgb(220, 90, 85),
+            EvaluationRunTrend::Stable => egui::Color32::from_rgb(145, 160, 180),
+            EvaluationRunTrend::New => egui::Color32::from_rgb(120, 170, 230),
+        }
+    }
+
     fn quality_badge_fill(level: QualityLevel) -> egui::Color32 {
         match level {
             QualityLevel::Ready => egui::Color32::from_rgb(21, 64, 44),
@@ -953,7 +962,7 @@ impl MasterSkillApp {
                     .max_height(180.0)
                     .show(ui, |ui| {
                         egui::Grid::new("evaluation-run-history-grid")
-                            .num_columns(8)
+                            .num_columns(9)
                             .striped(true)
                             .min_col_width(92.0)
                             .show(ui, |ui| {
@@ -962,6 +971,7 @@ impl MasterSkillApp {
                                 ui.strong("Status");
                                 ui.strong("Result");
                                 ui.strong("Failed");
+                                ui.strong("Trend");
                                 ui.strong("Mode");
                                 ui.strong("Duration");
                                 ui.strong("Actions");
@@ -976,6 +986,10 @@ impl MasterSkillApp {
                                     );
                                     ui.label(item.result_label());
                                     ui.label(item.failed_count.to_string());
+                                    ui.colored_label(
+                                        Self::evaluation_trend_color(item.trend),
+                                        item.trend.label(),
+                                    );
                                     ui.label(if item.dry_run { "dry-run" } else { "graded" });
                                     ui.label(
                                         item.duration_ms

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -110,12 +110,40 @@ pub struct EvaluationRunHistoryItem {
     pub dry_run: bool,
     pub duration_ms: Option<u128>,
     pub action: Option<TraceAction>,
+    pub trend: EvaluationRunTrend,
 }
 
 impl EvaluationRunHistoryItem {
     pub fn result_label(&self) -> String {
         let mode = if self.dry_run { "N/A" } else { "graded" };
         format!("{}/{} {mode}", self.passed_count, self.total_count)
+    }
+
+    fn pass_rate_basis(&self) -> usize {
+        if self.total_count == 0 {
+            0
+        } else {
+            self.passed_count * 10_000 / self.total_count
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvaluationRunTrend {
+    New,
+    Improved,
+    Stable,
+    Regressed,
+}
+
+impl EvaluationRunTrend {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::New => "new",
+            Self::Improved => "improved",
+            Self::Stable => "stable",
+            Self::Regressed => "regressed",
+        }
     }
 }
 
@@ -267,6 +295,7 @@ impl TraceRecord {
                 dry_run,
                 duration_ms: self.duration_ms,
                 action: self.action.clone(),
+                trend: EvaluationRunTrend::New,
             });
         }
 
@@ -294,6 +323,7 @@ impl TraceRecord {
             dry_run,
             duration_ms: self.duration_ms,
             action: self.action.clone(),
+            trend: EvaluationRunTrend::New,
         })
     }
 
@@ -426,6 +456,37 @@ fn classify_failure_text(text: &str) -> Option<FailureKind> {
         None
     } else {
         Some(FailureKind::Runtime)
+    }
+}
+
+fn annotate_evaluation_run_trends(history: &mut [EvaluationRunHistoryItem]) {
+    for index in 0..history.len() {
+        let Some(previous) = history[index + 1..]
+            .iter()
+            .find(|candidate| candidate.scope == history[index].scope)
+        else {
+            history[index].trend = EvaluationRunTrend::New;
+            continue;
+        };
+
+        history[index].trend = compare_evaluation_runs(&history[index], previous);
+    }
+}
+
+fn compare_evaluation_runs(
+    current: &EvaluationRunHistoryItem,
+    previous: &EvaluationRunHistoryItem,
+) -> EvaluationRunTrend {
+    if current.failed_count < previous.failed_count {
+        EvaluationRunTrend::Improved
+    } else if current.failed_count > previous.failed_count {
+        EvaluationRunTrend::Regressed
+    } else {
+        match current.pass_rate_basis().cmp(&previous.pass_rate_basis()) {
+            std::cmp::Ordering::Greater => EvaluationRunTrend::Improved,
+            std::cmp::Ordering::Less => EvaluationRunTrend::Regressed,
+            std::cmp::Ordering::Equal => EvaluationRunTrend::Stable,
+        }
     }
 }
 
@@ -683,12 +744,15 @@ impl TraceStore {
     }
 
     pub fn evaluation_run_history(&self, limit: usize) -> Vec<EvaluationRunHistoryItem> {
-        self.records
+        let mut history: Vec<_> = self
+            .records
             .iter()
             .rev()
             .filter_map(TraceRecord::evaluation_run_history_item)
             .take(limit)
-            .collect()
+            .collect();
+        annotate_evaluation_run_trends(&mut history);
+        history
     }
 
     pub fn latest_evaluation_case_results_for(&self, slug: &str) -> Vec<EvaluationCaseResult> {
@@ -1559,6 +1623,108 @@ mod tests {
                 slug: "huineng".to_string()
             })
         );
+    }
+
+    #[test]
+    fn annotates_evaluation_run_history_with_scope_trends() {
+        let mut store = TraceStore::new(10);
+
+        let old_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_huineng,
+            "master-huineng fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {"index": 0, "question": "失败一", "status": "FAIL"},
+                  {"index": 1, "question": "失败二", "status": "FAIL"}
+                ]
+              }
+            ]"#,
+            Duration::from_millis(40),
+        );
+
+        let old_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_all,
+            "fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {"index": 0, "question": "通过", "status": "PASS"}
+                ]
+              }
+            ]"#,
+            Duration::from_millis(45),
+        );
+
+        let new_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_huineng,
+            "master-huineng fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {"index": 0, "question": "通过", "status": "PASS"},
+                  {"index": 1, "question": "仍失败", "status": "FAIL"}
+                ]
+              }
+            ]"#,
+            Duration::from_millis(35),
+        );
+
+        let new_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_all,
+            "fidelity run finished",
+            r#"[
+              {
+                "master": "master-huineng",
+                "results": [
+                  {"index": 0, "question": "失败", "status": "FAIL"}
+                ]
+              }
+            ]"#,
+            Duration::from_millis(50),
+        );
+
+        let history = store.evaluation_run_history(4);
+
+        assert_eq!(history[0].trace_id, new_all);
+        assert_eq!(history[0].trend.label(), "regressed");
+        assert_eq!(history[1].trace_id, new_huineng);
+        assert_eq!(history[1].trend.label(), "improved");
+        assert_eq!(history[2].trace_id, old_all);
+        assert_eq!(history[2].trend.label(), "new");
+        assert_eq!(history[3].trace_id, old_huineng);
+        assert_eq!(history[3].trend.label(), "new");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add per-scope evaluation trend annotations for recent run history
- compare the latest run against the previous run for the same scope
- show color-coded improved/regressed/stable/new trend labels in Evaluation Center

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test