### PR TITLE
feat(desktop): summarize evaluation trends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added risk priorities to the Evaluation Center failure queue so fabricated citations, boundary violations, and forbidden text surface before lower-risk failures.
 - Added Evaluation Center run history with scope, status, result counts, failed counts, mode, duration, and rerun/open actions for recent evaluation runs.
 - Added Evaluation Center run trends so recent evaluation runs show whether each scope improved, regressed, stayed stable, or is new.
+- Added Evaluation Center trend summary cards for recent run health, regressions, improvements, and stable/new scopes.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -22,7 +22,8 @@ use crate::theme::{
 };
 use crate::trace::{
     EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
-    EvaluationRunHistoryItem, EvaluationRunTrend, TraceAction, TraceStatus, TraceStore,
+    EvaluationRunHistoryItem, EvaluationRunTrend, EvaluationTrendSummary, TraceAction, TraceStatus,
+    TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -716,6 +717,7 @@ impl MasterSkillApp {
         let failure_insights = self.traces.evaluation_failure_insights();
         let failure_queue = self.traces.evaluation_failure_queue();
         let run_history = self.traces.evaluation_run_history(8);
+        let trend_summary = self.traces.evaluation_trend_summary(8);
         Self::show_workspace_header(
             ui,
             "Evaluation Center",
@@ -781,6 +783,9 @@ impl MasterSkillApp {
         Self::show_metric_cards(ui, &cards);
 
         ui.separator();
+        Self::show_evaluation_trend_summary(ui, &trend_summary);
+
+        ui.separator();
         self.show_evaluation_failure_insights(ui, &failure_insights, &failure_queue);
 
         ui.separator();
@@ -798,6 +803,41 @@ impl MasterSkillApp {
             ui.separator();
             self.show_skill_suites(ui);
         }
+    }
+
+    fn show_evaluation_trend_summary(ui: &mut egui::Ui, summary: &EvaluationTrendSummary) {
+        ui.heading("Trend Summary");
+        let latest_regression = summary
+            .latest_regression_scope
+            .clone()
+            .unwrap_or_else(|| "none".to_string());
+        let cards = vec![
+            MetricCard {
+                title: "Trend Health",
+                value: summary.health_label().to_string(),
+                detail: format!("{} recent runs", summary.total_runs),
+                healthy: summary.regressed_count == 0,
+            },
+            MetricCard {
+                title: "Regressed",
+                value: summary.regressed_count.to_string(),
+                detail: latest_regression,
+                healthy: summary.regressed_count == 0,
+            },
+            MetricCard {
+                title: "Improved",
+                value: summary.improved_count.to_string(),
+                detail: "scopes".to_string(),
+                healthy: true,
+            },
+            MetricCard {
+                title: "Stable / New",
+                value: format!("{}/{}", summary.stable_count, summary.new_count),
+                detail: "scopes".to_string(),
+                healthy: summary.regressed_count == 0,
+            },
+        ];
+        Self::show_metric_cards(ui, &cards);
     }
 
     fn show_evaluation_failure_insights(

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -147,6 +147,28 @@ impl EvaluationRunTrend {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EvaluationTrendSummary {
+    pub total_runs: usize,
+    pub improved_count: usize,
+    pub regressed_count: usize,
+    pub stable_count: usize,
+    pub new_count: usize,
+    pub latest_regression_scope: Option<String>,
+}
+
+impl EvaluationTrendSummary {
+    pub fn health_label(&self) -> &'static str {
+        if self.regressed_count > 0 {
+            "review"
+        } else if self.total_runs == 0 {
+            "none"
+        } else {
+            "clear"
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EvaluationCaseResult {
     pub slug: String,
@@ -753,6 +775,30 @@ impl TraceStore {
             .collect();
         annotate_evaluation_run_trends(&mut history);
         history
+    }
+
+    pub fn evaluation_trend_summary(&self, limit: usize) -> EvaluationTrendSummary {
+        let history = self.evaluation_run_history(limit);
+        let mut summary = EvaluationTrendSummary {
+            total_runs: history.len(),
+            ..EvaluationTrendSummary::default()
+        };
+
+        for item in history {
+            match item.trend {
+                EvaluationRunTrend::Improved => summary.improved_count += 1,
+                EvaluationRunTrend::Regressed => {
+                    summary.regressed_count += 1;
+                    if summary.latest_regression_scope.is_none() {
+                        summary.latest_regression_scope = Some(item.scope);
+                    }
+                }
+                EvaluationRunTrend::Stable => summary.stable_count += 1,
+                EvaluationRunTrend::New => summary.new_count += 1,
+            }
+        }
+
+        summary
     }
 
     pub fn latest_evaluation_case_results_for(&self, slug: &str) -> Vec<EvaluationCaseResult> {
@@ -1725,6 +1771,95 @@ mod tests {
         assert_eq!(history[2].trend.label(), "new");
         assert_eq!(history[3].trace_id, old_huineng);
         assert_eq!(history[3].trend.label(), "new");
+    }
+
+    #[test]
+    fn summarizes_evaluation_trends_from_recent_run_history() {
+        let mut store = TraceStore::new(10);
+
+        let old_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_huineng,
+            "master-huineng fidelity run finished",
+            r#"[
+              {"master": "master-huineng", "results": [
+                {"index": 0, "question": "失败一", "status": "FAIL"},
+                {"index": 1, "question": "失败二", "status": "FAIL"}
+              ]}
+            ]"#,
+            Duration::from_millis(40),
+        );
+
+        let old_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_all,
+            "fidelity run finished",
+            r#"[
+              {"master": "master-huineng", "results": [
+                {"index": 0, "question": "通过", "status": "PASS"}
+              ]}
+            ]"#,
+            Duration::from_millis(45),
+        );
+
+        let new_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_huineng,
+            "master-huineng fidelity run finished",
+            r#"[
+              {"master": "master-huineng", "results": [
+                {"index": 0, "question": "通过", "status": "PASS"},
+                {"index": 1, "question": "仍失败", "status": "FAIL"}
+              ]}
+            ]"#,
+            Duration::from_millis(35),
+        );
+
+        let new_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_all,
+            "fidelity run finished",
+            r#"[
+              {"master": "master-huineng", "results": [
+                {"index": 0, "question": "失败", "status": "FAIL"}
+              ]}
+            ]"#,
+            Duration::from_millis(50),
+        );
+
+        let summary = store.evaluation_trend_summary(4);
+
+        assert_eq!(summary.total_runs, 4);
+        assert_eq!(summary.improved_count, 1);
+        assert_eq!(summary.regressed_count, 1);
+        assert_eq!(summary.stable_count, 0);
+        assert_eq!(summary.new_count, 2);
+        assert_eq!(summary.latest_regression_scope.as_deref(), Some("all"));
+        assert_eq!(summary.health_label(), "review");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add trend summary aggregation for recent Evaluation Center runs
- surface trend health, regression count, improved count, and stable/new counts as metric cards
- keep the regression card tied to the latest regressed scope for quick triage

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test