### PR TITLE
feat(desktop): add evaluation regression drilldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Center run history with scope, status, result counts, failed counts, mode, duration, and rerun/open actions for recent evaluation runs.
 - Added Evaluation Center run trends so recent evaluation runs show whether each scope improved, regressed, stayed stable, or is new.
 - Added Evaluation Center trend summary cards for recent run health, regressions, improvements, and stable/new scopes.
+- Added an Evaluation Center regression queue with current/previous trace context, failed-count deltas, pass-rate deltas, and direct rerun/open actions.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -22,8 +22,8 @@ use crate::theme::{
 };
 use crate::trace::{
     EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
-    EvaluationRunHistoryItem, EvaluationRunTrend, EvaluationTrendSummary, TraceAction, TraceStatus,
-    TraceStore,
+    EvaluationRegressionItem, EvaluationRunHistoryItem, EvaluationRunTrend, EvaluationTrendSummary,
+    TraceAction, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -718,6 +718,7 @@ impl MasterSkillApp {
         let failure_queue = self.traces.evaluation_failure_queue();
         let run_history = self.traces.evaluation_run_history(8);
         let trend_summary = self.traces.evaluation_trend_summary(8);
+        let regressions = self.traces.evaluation_regressions(8);
         Self::show_workspace_header(
             ui,
             "Evaluation Center",
@@ -786,6 +787,9 @@ impl MasterSkillApp {
         Self::show_evaluation_trend_summary(ui, &trend_summary);
 
         ui.separator();
+        self.show_evaluation_regressions(ui, &regressions);
+
+        ui.separator();
         self.show_evaluation_failure_insights(ui, &failure_insights, &failure_queue);
 
         ui.separator();
@@ -838,6 +842,90 @@ impl MasterSkillApp {
             },
         ];
         Self::show_metric_cards(ui, &cards);
+    }
+
+    fn show_evaluation_regressions(
+        &mut self,
+        ui: &mut egui::Ui,
+        regressions: &[EvaluationRegressionItem],
+    ) {
+        ui.heading("Regression Queue");
+        if regressions.is_empty() {
+            ui.small("No regressions detected in recent evaluation runs.");
+            return;
+        }
+
+        let busy = self.is_busy();
+        let mut action_to_rerun = None;
+        let mut skill_to_open = None;
+        egui::ScrollArea::horizontal()
+            .max_width(ui.available_width())
+            .show(ui, |ui| {
+                egui::Grid::new("evaluation-regression-grid")
+                    .num_columns(6)
+                    .striped(true)
+                    .min_col_width(104.0)
+                    .show(ui, |ui| {
+                        ui.strong("Scope");
+                        ui.strong("Current");
+                        ui.strong("Previous");
+                        ui.strong("Failed Delta");
+                        ui.strong("Pass Rate Delta");
+                        ui.strong("Actions");
+                        ui.end_row();
+
+                        for item in regressions {
+                            ui.label(&item.scope);
+                            ui.label(format!(
+                                "#{} / {} failed / {}%",
+                                item.current_trace_id,
+                                item.current_failed_count,
+                                item.current_pass_rate
+                            ));
+                            ui.label(format!(
+                                "#{} / {} failed / {}%",
+                                item.previous_trace_id,
+                                item.previous_failed_count,
+                                item.previous_pass_rate
+                            ));
+                            ui.colored_label(
+                                Self::evaluation_trend_color(EvaluationRunTrend::Regressed),
+                                format!("+{}", item.failed_delta),
+                            );
+                            ui.colored_label(
+                                Self::evaluation_trend_color(EvaluationRunTrend::Regressed),
+                                format!("{} pts", item.pass_rate_delta_points),
+                            );
+                            ui.horizontal(|ui| {
+                                if ui
+                                    .add_enabled(
+                                        !busy && item.action.is_some(),
+                                        egui::Button::new("Rerun"),
+                                    )
+                                    .clicked()
+                                {
+                                    action_to_rerun = item.action.clone();
+                                }
+                                if let Some(slug) =
+                                    item.scope.strip_prefix("master-").map(str::to_string)
+                                {
+                                    if ui.button("Open").clicked() {
+                                        skill_to_open = Some(slug);
+                                    }
+                                }
+                            });
+                            ui.end_row();
+                        }
+                    });
+            });
+
+        if let Some(action) = action_to_rerun {
+            self.start_trace_action(action);
+        }
+        if let Some(slug) = skill_to_open {
+            self.console_section = ConsoleSection::SkillDetail;
+            self.start_inspect(slug);
+        }
     }
 
     fn show_evaluation_failure_insights(

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -119,6 +119,10 @@ impl EvaluationRunHistoryItem {
         format!("{}/{} {mode}", self.passed_count, self.total_count)
     }
 
+    pub fn pass_rate_percent(&self) -> usize {
+        self.pass_rate_basis() / 100
+    }
+
     fn pass_rate_basis(&self) -> usize {
         if self.total_count == 0 {
             0
@@ -167,6 +171,20 @@ impl EvaluationTrendSummary {
             "clear"
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationRegressionItem {
+    pub scope: String,
+    pub current_trace_id: u64,
+    pub previous_trace_id: u64,
+    pub current_failed_count: usize,
+    pub previous_failed_count: usize,
+    pub failed_delta: isize,
+    pub current_pass_rate: usize,
+    pub previous_pass_rate: usize,
+    pub pass_rate_delta_points: isize,
+    pub action: Option<TraceAction>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -799,6 +817,45 @@ impl TraceStore {
         }
 
         summary
+    }
+
+    pub fn evaluation_regressions(&self, limit: usize) -> Vec<EvaluationRegressionItem> {
+        let history = self.evaluation_run_history(limit);
+        let mut regressions = Vec::new();
+
+        for index in 0..history.len() {
+            let current = &history[index];
+            if current.trend != EvaluationRunTrend::Regressed {
+                continue;
+            }
+
+            let Some(previous) = history[index + 1..]
+                .iter()
+                .find(|candidate| candidate.scope == current.scope)
+            else {
+                continue;
+            };
+
+            let current_failed_count = current.failed_count;
+            let previous_failed_count = previous.failed_count;
+            let current_pass_rate = current.pass_rate_percent();
+            let previous_pass_rate = previous.pass_rate_percent();
+
+            regressions.push(EvaluationRegressionItem {
+                scope: current.scope.clone(),
+                current_trace_id: current.trace_id,
+                previous_trace_id: previous.trace_id,
+                current_failed_count,
+                previous_failed_count,
+                failed_delta: current_failed_count as isize - previous_failed_count as isize,
+                current_pass_rate,
+                previous_pass_rate,
+                pass_rate_delta_points: current_pass_rate as isize - previous_pass_rate as isize,
+                action: current.action.clone(),
+            });
+        }
+
+        regressions
     }
 
     pub fn latest_evaluation_case_results_for(&self, slug: &str) -> Vec<EvaluationCaseResult> {
@@ -1860,6 +1917,104 @@ mod tests {
         assert_eq!(summary.new_count, 2);
         assert_eq!(summary.latest_regression_scope.as_deref(), Some("all"));
         assert_eq!(summary.health_label(), "review");
+    }
+
+    #[test]
+    fn lists_evaluation_regressions_with_previous_run_context() {
+        let mut store = TraceStore::new(10);
+
+        let old_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_huineng,
+            "master-huineng fidelity run finished",
+            r#"[
+              {"master": "master-huineng", "results": [
+                {"index": 0, "question": "通过一", "status": "PASS"},
+                {"index": 1, "question": "通过二", "status": "PASS"}
+              ]}
+            ]"#,
+            Duration::from_millis(40),
+        );
+
+        let old_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_all,
+            "fidelity run finished",
+            r#"[
+              {"master": "master-zhiyi", "results": [
+                {"index": 0, "question": "失败", "status": "FAIL"}
+              ]}
+            ]"#,
+            Duration::from_millis(45),
+        );
+
+        let new_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_huineng,
+            "master-huineng fidelity run finished",
+            r#"[
+              {"master": "master-huineng", "results": [
+                {"index": 0, "question": "通过", "status": "PASS"},
+                {"index": 1, "question": "回归失败", "status": "FAIL"}
+              ]}
+            ]"#,
+            Duration::from_millis(35),
+        );
+
+        let new_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_all,
+            "fidelity run finished",
+            r#"[
+              {"master": "master-zhiyi", "results": [
+                {"index": 0, "question": "通过", "status": "PASS"}
+              ]}
+            ]"#,
+            Duration::from_millis(50),
+        );
+
+        let regressions = store.evaluation_regressions(8);
+
+        assert_eq!(regressions.len(), 1);
+        assert_eq!(regressions[0].scope, "master-huineng");
+        assert_eq!(regressions[0].current_trace_id, new_huineng);
+        assert_eq!(regressions[0].previous_trace_id, old_huineng);
+        assert_eq!(regressions[0].current_failed_count, 1);
+        assert_eq!(regressions[0].previous_failed_count, 0);
+        assert_eq!(regressions[0].failed_delta, 1);
+        assert_eq!(regressions[0].current_pass_rate, 50);
+        assert_eq!(regressions[0].previous_pass_rate, 100);
+        assert_eq!(regressions[0].pass_rate_delta_points, -50);
+        assert_eq!(
+            regressions[0].action,
+            Some(TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string()
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add structured evaluation regression items with current and previous trace context
- show a Regression Queue in the desktop Evaluation Center
- include failed-count delta, pass-rate delta, and rerun/open actions

## Validation
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test