### PR TITLE
feat(desktop): filter run traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Center run trends so recent evaluation runs show whether each scope improved, regressed, stayed stable, or is new.
 - Added Evaluation Center trend summary cards for recent run health, regressions, improvements, and stable/new scopes.
 - Added an Evaluation Center regression queue with current/previous trace context, failed-count deltas, pass-rate deltas, and direct rerun/open actions.
+- Added Run Trace Center filters for all, running, succeeded, failed, evaluation, and install operations.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -23,7 +23,7 @@ use crate::theme::{
 use crate::trace::{
     EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
     EvaluationRegressionItem, EvaluationRunHistoryItem, EvaluationRunTrend, EvaluationTrendSummary,
-    TraceAction, TraceStatus, TraceStore,
+    TraceAction, TraceListFilter, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -61,6 +61,7 @@ pub struct MasterSkillApp {
     busy_label: Option<String>,
     console_section: ConsoleSection,
     log_expanded: bool,
+    trace_filter: TraceListFilter,
     traces: TraceStore,
     trace_path: PathBuf,
 }
@@ -120,6 +121,7 @@ impl MasterSkillApp {
             busy_label: None,
             console_section: ConsoleSection::Overview,
             log_expanded: false,
+            trace_filter: TraceListFilter::All,
             traces,
             trace_path,
         };
@@ -1292,9 +1294,23 @@ impl MasterSkillApp {
         Self::show_metric_cards(ui, &cards);
 
         ui.separator();
-        let recent = self.traces.recent();
+        ui.horizontal_wrapped(|ui| {
+            ui.label("Filter");
+            for filter in [
+                TraceListFilter::All,
+                TraceListFilter::Running,
+                TraceListFilter::Succeeded,
+                TraceListFilter::Failed,
+                TraceListFilter::Evaluation,
+                TraceListFilter::Install,
+            ] {
+                ui.selectable_value(&mut self.trace_filter, filter, filter.label());
+            }
+        });
+
+        let recent = self.traces.recent_filtered(self.trace_filter);
         if recent.is_empty() {
-            ui.label("No traces recorded yet.");
+            ui.label("No traces match the current filter.");
             return;
         }
 

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -50,6 +50,23 @@ impl TraceAction {
             | Self::FullValidation => None,
         }
     }
+
+    fn is_evaluation(&self) -> bool {
+        matches!(
+            self,
+            Self::FidelityDryRunAll | Self::FidelityDryRunSkill { .. } | Self::FullValidation
+        )
+    }
+
+    fn is_install_operation(&self) -> bool {
+        matches!(
+            self,
+            Self::InstallSkill { .. }
+                | Self::UninstallSkill { .. }
+                | Self::InstallAll
+                | Self::UpdateAll
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -67,6 +84,29 @@ impl FailureKind {
             Self::Fidelity => "fidelity",
             Self::Install => "install",
             Self::Runtime => "runtime",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TraceListFilter {
+    All,
+    Running,
+    Succeeded,
+    Failed,
+    Evaluation,
+    Install,
+}
+
+impl TraceListFilter {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Running => "Running",
+            Self::Succeeded => "Succeeded",
+            Self::Failed => "Failed",
+            Self::Evaluation => "Evaluation",
+            Self::Install => "Install",
         }
     }
 }
@@ -284,6 +324,22 @@ impl TraceRecord {
                 "{}\n{}\n{}",
                 self.label, self.summary, self.detail
             )),
+        }
+    }
+
+    pub fn matches_filter(&self, filter: TraceListFilter) -> bool {
+        match filter {
+            TraceListFilter::All => true,
+            TraceListFilter::Running => self.status == TraceStatus::Running,
+            TraceListFilter::Succeeded => self.status == TraceStatus::Succeeded,
+            TraceListFilter::Failed => self.status == TraceStatus::Failed,
+            TraceListFilter::Evaluation => {
+                self.action.as_ref().is_some_and(TraceAction::is_evaluation)
+            }
+            TraceListFilter::Install => self
+                .action
+                .as_ref()
+                .is_some_and(TraceAction::is_install_operation),
         }
     }
 
@@ -761,6 +817,15 @@ impl TraceStore {
         self.records.iter().rev().cloned().collect()
     }
 
+    pub fn recent_filtered(&self, filter: TraceListFilter) -> Vec<TraceRecord> {
+        self.records
+            .iter()
+            .rev()
+            .filter(|record| record.matches_filter(filter))
+            .cloned()
+            .collect()
+    }
+
     pub fn latest_evaluation_result_for(&self, slug: &str) -> Option<EvaluationRunResult> {
         self.records
             .iter()
@@ -1036,7 +1101,7 @@ mod tests {
     use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{FailureKind, TraceAction, TraceStatus, TraceStore};
+    use super::{FailureKind, TraceAction, TraceListFilter, TraceStatus, TraceStore};
 
     fn temp_path(name: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -1184,6 +1249,63 @@ mod tests {
         assert_eq!(recent[0].failure_kind(), Some(FailureKind::Install));
         assert_eq!(recent[1].failure_kind(), Some(FailureKind::Fidelity));
         assert_eq!(recent[2].failure_kind(), Some(FailureKind::Validation));
+    }
+
+    #[test]
+    fn filters_recent_traces_by_status_and_operation_class() {
+        let mut store = TraceStore::new(10);
+
+        let refresh = store.begin_with_action(
+            "Refreshing runtime data",
+            TraceAction::Refresh,
+            None::<String>,
+            "Queued.",
+        );
+        store.finish_success(refresh, "Runtime data refreshed.", Duration::from_millis(8));
+
+        let install = store.begin_with_action(
+            "Installing master-huineng",
+            TraceAction::InstallSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("master-skill install huineng"),
+            "Queued.",
+        );
+        store.finish_error(install, "install failed", Duration::from_millis(12));
+
+        let fidelity = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run"),
+            "Queued.",
+        );
+        store.finish_success(fidelity, "fidelity finished", Duration::from_millis(20));
+
+        let validation = store.begin_with_action(
+            "Running full validation",
+            TraceAction::FullValidation,
+            Some("npm test"),
+            "Queued.",
+        );
+
+        let failed = store.recent_filtered(TraceListFilter::Failed);
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].id, install);
+
+        let running = store.recent_filtered(TraceListFilter::Running);
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0].id, validation);
+
+        let evaluation = store.recent_filtered(TraceListFilter::Evaluation);
+        assert_eq!(evaluation.len(), 2);
+        assert_eq!(evaluation[0].id, validation);
+        assert_eq!(evaluation[1].id, fidelity);
+
+        let install_ops = store.recent_filtered(TraceListFilter::Install);
+        assert_eq!(install_ops.len(), 1);
+        assert_eq!(install_ops[0].id, install);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add structured Run Trace Center filters for status and operation class
- expose all/running/succeeded/failed/evaluation/install filter tabs in the desktop Runs workspace
- add regression coverage for trace filtering behavior

## Validation
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test