### PR TITLE
feat(desktop): add trace failure queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Center trend summary cards for recent run health, regressions, improvements, and stable/new scopes.
 - Added an Evaluation Center regression queue with current/previous trace context, failed-count deltas, pass-rate deltas, and direct rerun/open actions.
 - Added Run Trace Center filters for all, running, succeeded, failed, evaluation, and install operations.
+- Added a Run Trace Center failure queue with failure kind, operation summary, duration, rerun actions, and related-skill navigation.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -23,7 +23,7 @@ use crate::theme::{
 use crate::trace::{
     EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
     EvaluationRegressionItem, EvaluationRunHistoryItem, EvaluationRunTrend, EvaluationTrendSummary,
-    TraceAction, TraceListFilter, TraceStatus, TraceStore,
+    TraceAction, TraceFailureItem, TraceListFilter, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1239,6 +1239,7 @@ impl MasterSkillApp {
 
     fn show_trace_center(&mut self, ui: &mut egui::Ui) {
         let summary = self.traces.summary();
+        let failure_queue = self.traces.trace_failure_queue(6);
         let can_clear = summary.total > 0 && summary.running == 0;
         Self::show_workspace_header(
             ui,
@@ -1292,6 +1293,9 @@ impl MasterSkillApp {
             },
         ];
         Self::show_metric_cards(ui, &cards);
+
+        ui.separator();
+        self.show_trace_failure_queue(ui, &failure_queue);
 
         ui.separator();
         ui.horizontal_wrapped(|ui| {
@@ -1405,6 +1409,79 @@ impl MasterSkillApp {
                     ui.separator();
                 }
             });
+        if let Some(action) = action_to_rerun {
+            self.start_trace_action(action);
+        }
+        if let Some(slug) = skill_to_open {
+            self.console_section = ConsoleSection::SkillDetail;
+            self.start_inspect(slug);
+        }
+    }
+
+    fn show_trace_failure_queue(&mut self, ui: &mut egui::Ui, failure_queue: &[TraceFailureItem]) {
+        ui.heading("Failure Queue");
+        if failure_queue.is_empty() {
+            ui.small("No failed traces require recovery.");
+            return;
+        }
+
+        let busy = self.is_busy();
+        let mut action_to_rerun = None;
+        let mut skill_to_open = None;
+        egui::ScrollArea::horizontal()
+            .max_width(ui.available_width())
+            .show(ui, |ui| {
+                egui::ScrollArea::vertical()
+                    .max_height(180.0)
+                    .show(ui, |ui| {
+                        egui::Grid::new("trace-failure-queue-grid")
+                            .num_columns(6)
+                            .striped(true)
+                            .min_col_width(96.0)
+                            .show(ui, |ui| {
+                                ui.strong("Trace");
+                                ui.strong("Issue");
+                                ui.strong("Operation");
+                                ui.strong("Summary");
+                                ui.strong("Duration");
+                                ui.strong("Actions");
+                                ui.end_row();
+
+                                for item in failure_queue {
+                                    ui.label(format!("#{}", item.trace_id));
+                                    ui.colored_label(
+                                        Self::trace_color(TraceStatus::Failed),
+                                        item.kind.label(),
+                                    );
+                                    ui.label(&item.label);
+                                    ui.label(first_line(&item.summary));
+                                    ui.label(
+                                        item.duration_ms
+                                            .map(|duration| format!("{duration} ms"))
+                                            .unwrap_or_else(|| "running".to_string()),
+                                    );
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .add_enabled(
+                                                !busy && item.action.is_some(),
+                                                egui::Button::new("Rerun"),
+                                            )
+                                            .clicked()
+                                        {
+                                            action_to_rerun = item.action.clone();
+                                        }
+                                        if let Some(slug) = &item.related_skill_slug {
+                                            if ui.button("Open Skill").clicked() {
+                                                skill_to_open = Some(slug.clone());
+                                            }
+                                        }
+                                    });
+                                    ui.end_row();
+                                }
+                            });
+                    });
+            });
+
         if let Some(action) = action_to_rerun {
             self.start_trace_action(action);
         }

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -595,6 +595,17 @@ pub struct TraceSummary {
     pub last_status: Option<TraceStatus>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TraceFailureItem {
+    pub trace_id: u64,
+    pub kind: FailureKind,
+    pub label: String,
+    pub summary: String,
+    pub duration_ms: Option<u128>,
+    pub action: Option<TraceAction>,
+    pub related_skill_slug: Option<String>,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EvaluationRunCoverage {
     pub total_skill_count: usize,
@@ -823,6 +834,26 @@ impl TraceStore {
             .rev()
             .filter(|record| record.matches_filter(filter))
             .cloned()
+            .collect()
+    }
+
+    pub fn trace_failure_queue(&self, limit: usize) -> Vec<TraceFailureItem> {
+        self.records
+            .iter()
+            .rev()
+            .filter_map(|record| {
+                let kind = record.failure_kind()?;
+                Some(TraceFailureItem {
+                    trace_id: record.id,
+                    kind,
+                    label: record.label.clone(),
+                    summary: record.summary.clone(),
+                    duration_ms: record.duration_ms,
+                    action: record.action.clone(),
+                    related_skill_slug: record.related_skill_slug().map(str::to_string),
+                })
+            })
+            .take(limit)
             .collect()
     }
 
@@ -1249,6 +1280,71 @@ mod tests {
         assert_eq!(recent[0].failure_kind(), Some(FailureKind::Install));
         assert_eq!(recent[1].failure_kind(), Some(FailureKind::Fidelity));
         assert_eq!(recent[2].failure_kind(), Some(FailureKind::Validation));
+    }
+
+    #[test]
+    fn lists_latest_failed_traces_for_recovery_queue() {
+        let mut store = TraceStore::new(10);
+
+        let validation = store.begin_with_action(
+            "Running full validation",
+            TraceAction::FullValidation,
+            Some("npm test"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            validation,
+            "npm test failed",
+            "validate.py failed",
+            Duration::from_millis(100),
+        );
+
+        let refresh = store.begin_with_action(
+            "Refreshing runtime data",
+            TraceAction::Refresh,
+            None::<String>,
+            "Queued.",
+        );
+        store.finish_success(
+            refresh,
+            "Runtime data refreshed.",
+            Duration::from_millis(20),
+        );
+
+        let install = store.begin_with_action(
+            "Installing master-huineng",
+            TraceAction::InstallSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("master-skill install huineng"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            install,
+            "install failed",
+            "failed to run master-skill CLI",
+            Duration::from_millis(30),
+        );
+
+        let queue = store.trace_failure_queue(5);
+
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue[0].trace_id, install);
+        assert_eq!(queue[0].kind, FailureKind::Install);
+        assert_eq!(queue[0].label, "Installing master-huineng");
+        assert_eq!(queue[0].summary, "install failed");
+        assert_eq!(queue[0].duration_ms, Some(30));
+        assert_eq!(queue[0].related_skill_slug.as_deref(), Some("huineng"));
+        assert_eq!(
+            queue[0].action,
+            Some(TraceAction::InstallSkill {
+                slug: "huineng".to_string()
+            })
+        );
+
+        assert_eq!(queue[1].trace_id, validation);
+        assert_eq!(queue[1].kind, FailureKind::Validation);
+        assert_eq!(queue[1].related_skill_slug, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add structured failed-trace recovery queue data in TraceStore
- surface failed desktop operations at the top of Run Trace Center
- include failure kind, operation summary, duration, rerun action, and related skill navigation

## Validation
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test