### PR TITLE
feat(desktop): filter evaluation run history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Run Trace Center search across operation labels, commands, summaries, details, and related skill slugs.
 - Added Evaluation Center Skill Suites filters for ready, attention, missing, not-run, and failed latest-run states.
 - Added Evaluation Center Skill Suites search across skill metadata and diagnostic gap summaries.
+- Added Evaluation Center Run History filters for regressed, improved, stable, new, and failed evaluation runs.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -22,9 +22,9 @@ use crate::theme::{
 };
 use crate::trace::{
     EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
-    EvaluationRegressionItem, EvaluationRunHistoryItem, EvaluationRunResult, EvaluationRunTrend,
-    EvaluationTrendSummary, TraceAction, TraceFailureItem, TraceListFilter, TraceStatus,
-    TraceStore,
+    EvaluationRegressionItem, EvaluationRunHistoryFilter, EvaluationRunHistoryItem,
+    EvaluationRunResult, EvaluationRunTrend, EvaluationTrendSummary, TraceAction, TraceFailureItem,
+    TraceListFilter, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -130,6 +130,7 @@ pub struct MasterSkillApp {
     trace_query: String,
     suite_filter: SuiteFilter,
     suite_query: String,
+    run_history_filter: EvaluationRunHistoryFilter,
     traces: TraceStore,
     trace_path: PathBuf,
 }
@@ -193,6 +194,7 @@ impl MasterSkillApp {
             trace_query: String::new(),
             suite_filter: SuiteFilter::All,
             suite_query: String::new(),
+            run_history_filter: EvaluationRunHistoryFilter::All,
             traces,
             trace_path,
         };
@@ -789,7 +791,9 @@ impl MasterSkillApp {
         let run_coverage = self.traces.evaluation_run_coverage(summary.skill_count);
         let failure_insights = self.traces.evaluation_failure_insights();
         let failure_queue = self.traces.evaluation_failure_queue();
-        let run_history = self.traces.evaluation_run_history(8);
+        let run_history = self
+            .traces
+            .evaluation_run_history_filtered(8, self.run_history_filter);
         let trend_summary = self.traces.evaluation_trend_summary(8);
         let regressions = self.traces.evaluation_regressions(8);
         Self::show_workspace_header(
@@ -1148,8 +1152,21 @@ impl MasterSkillApp {
         run_history: &[EvaluationRunHistoryItem],
     ) {
         ui.heading("Run History");
+        ui.horizontal_wrapped(|ui| {
+            ui.label("Filter");
+            for filter in [
+                EvaluationRunHistoryFilter::All,
+                EvaluationRunHistoryFilter::Regressed,
+                EvaluationRunHistoryFilter::Improved,
+                EvaluationRunHistoryFilter::Stable,
+                EvaluationRunHistoryFilter::New,
+                EvaluationRunHistoryFilter::Failed,
+            ] {
+                ui.selectable_value(&mut self.run_history_filter, filter, filter.label());
+            }
+        });
         if run_history.is_empty() {
-            ui.small("No evaluation runs recorded yet.");
+            ui.small("No evaluation runs match the current filter.");
             return;
         }
 

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -170,6 +170,19 @@ impl EvaluationRunHistoryItem {
             self.passed_count * 10_000 / self.total_count
         }
     }
+
+    pub fn matches_filter(&self, filter: EvaluationRunHistoryFilter) -> bool {
+        match filter {
+            EvaluationRunHistoryFilter::All => true,
+            EvaluationRunHistoryFilter::Regressed => self.trend == EvaluationRunTrend::Regressed,
+            EvaluationRunHistoryFilter::Improved => self.trend == EvaluationRunTrend::Improved,
+            EvaluationRunHistoryFilter::Stable => self.trend == EvaluationRunTrend::Stable,
+            EvaluationRunHistoryFilter::New => self.trend == EvaluationRunTrend::New,
+            EvaluationRunHistoryFilter::Failed => {
+                self.status == TraceStatus::Failed || self.failed_count > 0
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -187,6 +200,29 @@ impl EvaluationRunTrend {
             Self::Improved => "improved",
             Self::Stable => "stable",
             Self::Regressed => "regressed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvaluationRunHistoryFilter {
+    All,
+    Regressed,
+    Improved,
+    Stable,
+    New,
+    Failed,
+}
+
+impl EvaluationRunHistoryFilter {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Regressed => "Regressed",
+            Self::Improved => "Improved",
+            Self::Stable => "Stable",
+            Self::New => "New",
+            Self::Failed => "Failed",
         }
     }
 }
@@ -918,6 +954,17 @@ impl TraceStore {
         history
     }
 
+    pub fn evaluation_run_history_filtered(
+        &self,
+        limit: usize,
+        filter: EvaluationRunHistoryFilter,
+    ) -> Vec<EvaluationRunHistoryItem> {
+        self.evaluation_run_history(limit)
+            .into_iter()
+            .filter(|item| item.matches_filter(filter))
+            .collect()
+    }
+
     pub fn evaluation_trend_summary(&self, limit: usize) -> EvaluationTrendSummary {
         let history = self.evaluation_run_history(limit);
         let mut summary = EvaluationTrendSummary {
@@ -1159,7 +1206,10 @@ mod tests {
     use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{FailureKind, TraceAction, TraceListFilter, TraceStatus, TraceStore};
+    use super::{
+        EvaluationRunHistoryFilter, FailureKind, TraceAction, TraceListFilter, TraceStatus,
+        TraceStore,
+    };
 
     fn temp_path(name: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -2132,6 +2182,93 @@ mod tests {
         assert_eq!(history[2].trend.label(), "new");
         assert_eq!(history[3].trace_id, old_huineng);
         assert_eq!(history[3].trend.label(), "new");
+    }
+
+    #[test]
+    fn filters_evaluation_run_history_by_trend_and_failed_results() {
+        let mut store = TraceStore::new(10);
+
+        let old_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_huineng,
+            "master-huineng fidelity run finished",
+            r#"[{"master": "master-huineng", "results": [
+              {"index": 0, "question": "失败一", "status": "FAIL"},
+              {"index": 1, "question": "失败二", "status": "FAIL"}
+            ]}]"#,
+            Duration::from_millis(40),
+        );
+
+        let old_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_all,
+            "fidelity run finished",
+            r#"[{"master": "master-huineng", "results": [
+              {"index": 0, "question": "通过", "status": "PASS"}
+            ]}]"#,
+            Duration::from_millis(45),
+        );
+
+        let new_huineng = store.begin_with_action(
+            "Running master-huineng fidelity run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_huineng,
+            "master-huineng fidelity run finished",
+            r#"[{"master": "master-huineng", "results": [
+              {"index": 0, "question": "通过", "status": "PASS"},
+              {"index": 1, "question": "仍失败", "status": "FAIL"}
+            ]}]"#,
+            Duration::from_millis(35),
+        );
+
+        let new_all = store.begin_with_action(
+            "Running fidelity run",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_all,
+            "fidelity run finished",
+            r#"[{"master": "master-huineng", "results": [
+              {"index": 0, "question": "失败", "status": "FAIL"}
+            ]}]"#,
+            Duration::from_millis(50),
+        );
+
+        let regressed =
+            store.evaluation_run_history_filtered(4, EvaluationRunHistoryFilter::Regressed);
+        assert_eq!(regressed.len(), 1);
+        assert_eq!(regressed[0].trace_id, new_all);
+
+        let improved =
+            store.evaluation_run_history_filtered(4, EvaluationRunHistoryFilter::Improved);
+        assert_eq!(improved.len(), 1);
+        assert_eq!(improved[0].trace_id, new_huineng);
+
+        let failed = store.evaluation_run_history_filtered(4, EvaluationRunHistoryFilter::Failed);
+        assert_eq!(failed.len(), 3);
+        assert_eq!(failed[0].trace_id, new_all);
+        assert_eq!(failed[1].trace_id, new_huineng);
+        assert_eq!(failed[2].trace_id, old_huineng);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Evaluation Center Run History filters for trend states and failed evaluation runs
- expose reusable TraceStore run history filtering API
- add coverage for regressed, improved, and failed run filters

## Validation
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test