### PR TITLE
feat(desktop): add decision brief actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added Evaluation Center Skill Suites search across skill metadata and diagnostic gap summaries.
 - Added Evaluation Center Run History filters for regressed, improved, stable, new, and failed evaluation runs.
 - Added an Evaluation Center Decision Brief that turns coverage, trend, and failure signals into a quality-gate posture with primary risk and next action.
+- Added a Decision Brief primary action that reruns regressed scopes, opens top failing skills, runs coverage baselines, or starts full validation based on the current quality-gate posture.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -21,11 +21,11 @@ use crate::theme::{
     apply_console_theme, sidebar_default_width, sidebar_row_height, status_badge_width,
 };
 use crate::trace::{
-    EvaluationDecisionBrief, EvaluationDecisionPosture, EvaluationFailureInsights,
-    EvaluationFailureItem, EvaluationFailurePriority, EvaluationRegressionItem,
-    EvaluationRunHistoryFilter, EvaluationRunHistoryItem, EvaluationRunResult, EvaluationRunTrend,
-    EvaluationTrendSummary, TraceAction, TraceFailureItem, TraceListFilter, TraceStatus,
-    TraceStore,
+    EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
+    EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
+    EvaluationRegressionItem, EvaluationRunHistoryFilter, EvaluationRunHistoryItem,
+    EvaluationRunResult, EvaluationRunTrend, EvaluationTrendSummary, TraceAction, TraceFailureItem,
+    TraceListFilter, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -649,6 +649,22 @@ impl MasterSkillApp {
         }
     }
 
+    fn start_evaluation_decision_action(&mut self, action: EvaluationDecisionAction) {
+        match action {
+            EvaluationDecisionAction::RerunAll | EvaluationDecisionAction::RunFidelityBaseline => {
+                self.start_fidelity_dry_run()
+            }
+            EvaluationDecisionAction::RerunSkill { slug } => {
+                self.start_skill_fidelity_dry_run(slug)
+            }
+            EvaluationDecisionAction::OpenSkill { slug } => {
+                self.console_section = ConsoleSection::SkillDetail;
+                self.start_inspect(slug);
+            }
+            EvaluationDecisionAction::RunFullValidation => self.start_full_validation(),
+        }
+    }
+
     fn show_workspace_header(
         ui: &mut egui::Ui,
         title: &str,
@@ -873,7 +889,7 @@ impl MasterSkillApp {
         Self::show_metric_cards(ui, &cards);
 
         ui.separator();
-        Self::show_evaluation_decision_brief(ui, &decision_brief);
+        self.show_evaluation_decision_brief(ui, &decision_brief);
 
         ui.separator();
         Self::show_evaluation_trend_summary(ui, &trend_summary);
@@ -901,8 +917,14 @@ impl MasterSkillApp {
         }
     }
 
-    fn show_evaluation_decision_brief(ui: &mut egui::Ui, brief: &EvaluationDecisionBrief) {
+    fn show_evaluation_decision_brief(
+        &mut self,
+        ui: &mut egui::Ui,
+        brief: &EvaluationDecisionBrief,
+    ) {
         ui.heading("Decision Brief");
+        let busy = self.is_busy();
+        let mut decision_action = None;
         ui.horizontal_wrapped(|ui| {
             ui.colored_label(
                 Self::decision_posture_color(brief.posture),
@@ -910,6 +932,13 @@ impl MasterSkillApp {
             );
             ui.separator();
             ui.strong(&brief.headline);
+            ui.separator();
+            if ui
+                .add_enabled(!busy, egui::Button::new(brief.action.label()))
+                .clicked()
+            {
+                decision_action = Some(brief.action.clone());
+            }
         });
         egui::Grid::new("evaluation-decision-brief-grid")
             .num_columns(2)
@@ -926,6 +955,10 @@ impl MasterSkillApp {
                 ui.label(&brief.recommendation);
                 ui.end_row();
             });
+
+        if let Some(action) = decision_action {
+            self.start_evaluation_decision_action(action);
+        }
     }
 
     fn show_evaluation_trend_summary(ui: &mut egui::Ui, summary: &EvaluationTrendSummary) {

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -770,6 +770,28 @@ pub struct EvaluationDecisionBrief {
     pub primary_risk: String,
     pub evidence: String,
     pub recommendation: String,
+    pub action: EvaluationDecisionAction,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvaluationDecisionAction {
+    RerunAll,
+    RerunSkill { slug: String },
+    OpenSkill { slug: String },
+    RunFidelityBaseline,
+    RunFullValidation,
+}
+
+impl EvaluationDecisionAction {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::RerunAll => "Rerun all",
+            Self::RerunSkill { .. } => "Rerun skill",
+            Self::OpenSkill { .. } => "Open skill",
+            Self::RunFidelityBaseline => "Run baseline",
+            Self::RunFullValidation => "Run validation",
+        }
+    }
 }
 
 impl EvaluationDecisionBrief {
@@ -783,6 +805,7 @@ impl EvaluationDecisionBrief {
                 .latest_regression_scope
                 .clone()
                 .unwrap_or_else(|| "recent scope".to_string());
+            let action = decision_action_for_regressed_scope(&scope);
             return Self {
                 posture: EvaluationDecisionPosture::Blocked,
                 headline: "Regression detected".to_string(),
@@ -793,10 +816,16 @@ impl EvaluationDecisionBrief {
                 ),
                 recommendation:
                     "Rerun the regressed scope and inspect failed cases before release.".to_string(),
+                action,
             };
         }
 
         if insights.failed_cases > 0 {
+            let action = insights
+                .top_failure_skill_slug
+                .as_ref()
+                .map(|slug| EvaluationDecisionAction::OpenSkill { slug: slug.clone() })
+                .unwrap_or(EvaluationDecisionAction::RunFidelityBaseline);
             return Self {
                 posture: EvaluationDecisionPosture::Attention,
                 headline: "Failing fidelity cases".to_string(),
@@ -808,6 +837,7 @@ impl EvaluationDecisionBrief {
                 recommendation:
                     "Open the top failing skill, resolve evidence gaps, then rerun fidelity."
                         .to_string(),
+                action,
             };
         }
 
@@ -821,6 +851,7 @@ impl EvaluationDecisionBrief {
                 primary_risk: format!("{} skills have latest runs", coverage.label()),
                 evidence: format!("{missing_runs} skill(s) without a current run"),
                 recommendation: "Run fidelity dry-run to establish a current baseline.".to_string(),
+                action: EvaluationDecisionAction::RunFidelityBaseline,
             };
         }
 
@@ -833,11 +864,24 @@ impl EvaluationDecisionBrief {
                 coverage.run_skill_count, trend.total_runs
             ),
             recommendation: "Proceed with release review and keep monitoring new runs.".to_string(),
+            action: EvaluationDecisionAction::RunFullValidation,
         }
     }
 
     pub fn status_label(&self) -> &'static str {
         self.posture.label()
+    }
+}
+
+fn decision_action_for_regressed_scope(scope: &str) -> EvaluationDecisionAction {
+    if scope == "all" {
+        EvaluationDecisionAction::RerunAll
+    } else if let Some(slug) = scope.strip_prefix("master-") {
+        EvaluationDecisionAction::RerunSkill {
+            slug: slug.to_string(),
+        }
+    } else {
+        EvaluationDecisionAction::RunFidelityBaseline
     }
 }
 
@@ -1308,9 +1352,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        EvaluationDecisionBrief, EvaluationDecisionPosture, EvaluationFailureInsights,
-        EvaluationRunCoverage, EvaluationRunHistoryFilter, EvaluationTrendSummary, FailureKind,
-        TraceAction, TraceListFilter, TraceStatus, TraceStore,
+        EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
+        EvaluationFailureInsights, EvaluationRunCoverage, EvaluationRunHistoryFilter,
+        EvaluationTrendSummary, FailureKind, TraceAction, TraceListFilter, TraceStatus, TraceStore,
     };
 
     fn temp_path(name: &str) -> PathBuf {
@@ -2491,6 +2535,12 @@ mod tests {
         assert_eq!(brief.status_label(), "blocked");
         assert_eq!(brief.headline, "Regression detected");
         assert_eq!(brief.primary_risk, "master-huineng regressed");
+        assert_eq!(
+            brief.action,
+            EvaluationDecisionAction::RerunSkill {
+                slug: "huineng".to_string()
+            }
+        );
 
         trend.regressed_count = 0;
         trend.latest_regression_scope = None;
@@ -2498,6 +2548,12 @@ mod tests {
         assert_eq!(brief.posture, EvaluationDecisionPosture::Attention);
         assert_eq!(brief.headline, "Failing fidelity cases");
         assert_eq!(brief.primary_risk, "master-huineng (1)");
+        assert_eq!(
+            brief.action,
+            EvaluationDecisionAction::OpenSkill {
+                slug: "huineng".to_string()
+            }
+        );
 
         insights.failed_cases = 0;
         insights.failing_skill_count = 0;
@@ -2511,11 +2567,13 @@ mod tests {
         assert_eq!(brief.posture, EvaluationDecisionPosture::Unproven);
         assert_eq!(brief.headline, "Evaluation coverage incomplete");
         assert_eq!(brief.primary_risk, "2/3 skills have latest runs");
+        assert_eq!(brief.action, EvaluationDecisionAction::RunFidelityBaseline);
 
         let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
         assert_eq!(brief.posture, EvaluationDecisionPosture::Ready);
         assert_eq!(brief.status_label(), "ready");
         assert_eq!(brief.headline, "Evaluation baseline clear");
+        assert_eq!(brief.action, EvaluationDecisionAction::RunFullValidation);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a primary action model to the Evaluation Center Decision Brief
- wire decision actions to existing desktop workflows for rerun all, rerun skill, open skill, baseline run, and full validation
- expand tests to cover action selection for blocked, attention, unproven, and ready states

## Validation
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test