### PR TITLE
feat(desktop): add evaluation remediation plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added an Overview Quality Gate card so the main console surface shows the current evaluation gate posture and primary risk without opening Evaluation Center.
 - Added an actionable Overview Decision Brief backed by the shared evaluation gate snapshot, including the primary gate action and copyable evidence report from the main console surface.
 - Added an Evaluation Center evidence window selector for 8, 16, or 32 recent runs, shared by trend summaries, regression queues, run history, and copied evidence reports.
+- Added a copyable Evaluation Remediation Plan that turns regressions, failing cases, latest trace context, and verification steps into a Markdown action checklist.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -23,10 +23,10 @@ use crate::theme::{
 use crate::trace::{
     EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
     EvaluationEvidenceReport, EvaluationFailureInsights, EvaluationFailureItem,
-    EvaluationFailurePriority, EvaluationRegressionItem, EvaluationRunCoverage,
-    EvaluationRunHistoryFilter, EvaluationRunHistoryItem, EvaluationRunResult, EvaluationRunTrend,
-    EvaluationTrendSummary, TraceAction, TraceFailureItem, TraceListFilter, TraceStatus,
-    TraceStore,
+    EvaluationFailurePriority, EvaluationRegressionItem, EvaluationRemediationPlan,
+    EvaluationRunCoverage, EvaluationRunHistoryFilter, EvaluationRunHistoryItem,
+    EvaluationRunResult, EvaluationRunTrend, EvaluationTrendSummary, TraceAction, TraceFailureItem,
+    TraceListFilter, TraceStatus, TraceStore,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -201,6 +201,7 @@ struct EvaluationGateSnapshot {
     all_run_history: Vec<EvaluationRunHistoryItem>,
     regressions: Vec<EvaluationRegressionItem>,
     evidence_report: EvaluationEvidenceReport,
+    remediation_plan: EvaluationRemediationPlan,
 }
 
 fn evaluation_gate_snapshot(
@@ -227,6 +228,12 @@ fn evaluation_gate_snapshot(
         &failure_queue,
         &all_run_history,
     );
+    let remediation_plan = EvaluationRemediationPlan::from_signals(
+        &decision_brief,
+        &regressions,
+        &failure_queue,
+        &all_run_history,
+    );
 
     EvaluationGateSnapshot {
         run_coverage,
@@ -237,6 +244,7 @@ fn evaluation_gate_snapshot(
         all_run_history,
         regressions,
         evidence_report,
+        remediation_plan,
     }
 }
 
@@ -901,7 +909,12 @@ impl MasterSkillApp {
             Self::show_metric_cards(ui, &cards);
 
             ui.separator();
-            self.show_evaluation_decision_brief(ui, &gate.decision_brief, &gate.evidence_report);
+            self.show_evaluation_decision_brief(
+                ui,
+                &gate.decision_brief,
+                &gate.evidence_report,
+                &gate.remediation_plan,
+            );
         } else {
             ui.label("No runtime report loaded.");
         }
@@ -992,7 +1005,12 @@ impl MasterSkillApp {
         Self::show_metric_cards(ui, &cards);
 
         ui.separator();
-        self.show_evaluation_decision_brief(ui, &gate.decision_brief, &gate.evidence_report);
+        self.show_evaluation_decision_brief(
+            ui,
+            &gate.decision_brief,
+            &gate.evidence_report,
+            &gate.remediation_plan,
+        );
 
         ui.separator();
         Self::show_evaluation_trend_summary(ui, &gate.trend_summary);
@@ -1025,11 +1043,13 @@ impl MasterSkillApp {
         ui: &mut egui::Ui,
         brief: &EvaluationDecisionBrief,
         evidence_report: &EvaluationEvidenceReport,
+        remediation_plan: &EvaluationRemediationPlan,
     ) {
         ui.heading("Decision Brief");
         let busy = self.is_busy();
         let mut decision_action = None;
         let mut copy_report = false;
+        let mut copy_plan = false;
         ui.horizontal_wrapped(|ui| {
             ui.colored_label(
                 Self::decision_posture_color(brief.posture),
@@ -1046,6 +1066,9 @@ impl MasterSkillApp {
             }
             if ui.button("Copy report").clicked() {
                 copy_report = true;
+            }
+            if ui.button("Copy action plan").clicked() {
+                copy_plan = true;
             }
         });
         egui::Grid::new("evaluation-decision-brief-grid")
@@ -1070,6 +1093,13 @@ impl MasterSkillApp {
         if copy_report {
             ui.ctx().copy_text(evidence_report.markdown.clone());
             self.set_log("Evaluation evidence report copied.");
+        }
+        if copy_plan {
+            ui.ctx().copy_text(remediation_plan.markdown.clone());
+            self.set_log(format!(
+                "Evaluation remediation plan copied ({} action item(s)).",
+                remediation_plan.item_count
+            ));
         }
     }
 
@@ -2583,6 +2613,10 @@ mod tests {
         assert_eq!(snapshot.failure_queue.len(), 1);
         assert_eq!(snapshot.all_run_history.len(), 2);
         assert!(snapshot.evidence_report.markdown.contains("master-huineng"));
+        assert!(snapshot
+            .remediation_plan
+            .markdown
+            .contains("# Master-skill Evaluation Remediation Plan"));
     }
 
     #[test]

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -878,6 +878,12 @@ pub struct EvaluationEvidenceReport {
     pub markdown: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationRemediationPlan {
+    pub markdown: String,
+    pub item_count: usize,
+}
+
 impl EvaluationEvidenceReport {
     pub fn from_signals(
         brief: &EvaluationDecisionBrief,
@@ -975,6 +981,106 @@ impl EvaluationEvidenceReport {
         }
 
         Self { markdown }
+    }
+}
+
+impl EvaluationRemediationPlan {
+    pub fn from_signals(
+        brief: &EvaluationDecisionBrief,
+        regressions: &[EvaluationRegressionItem],
+        failure_queue: &[EvaluationFailureItem],
+        run_history: &[EvaluationRunHistoryItem],
+    ) -> Self {
+        let mut markdown = String::new();
+        let mut item_count = 0;
+
+        markdown.push_str("# Master-skill Evaluation Remediation Plan\n\n");
+        markdown.push_str("## Gate Decision\n");
+        markdown.push_str(&format!("- Status: {}\n", brief.status_label()));
+        markdown.push_str(&format!("- Headline: {}\n", brief.headline));
+        markdown.push_str(&format!("- Primary risk: {}\n", brief.primary_risk));
+        markdown.push_str(&format!("- Evidence: {}\n", brief.evidence));
+        markdown.push_str(&format!(
+            "- Recommended next action: {}\n",
+            brief.recommendation
+        ));
+        if let Some(latest) = run_history.first() {
+            markdown.push_str(&format!(
+                "- Latest run: {} from latest trace #{}\n",
+                latest.scope, latest.trace_id
+            ));
+        }
+        markdown.push('\n');
+
+        markdown.push_str("## Action Items\n");
+        if regressions.is_empty() && failure_queue.is_empty() {
+            append_remediation_item(
+                &mut markdown,
+                &mut item_count,
+                &default_remediation_action(brief),
+            );
+        } else {
+            for item in regressions {
+                append_remediation_item(
+                    &mut markdown,
+                    &mut item_count,
+                    &format!(
+                        "Rerun {} and compare trace #{} against #{} (failed {:+}, pass rate {:+} pts)",
+                        item.scope,
+                        item.current_trace_id,
+                        item.previous_trace_id,
+                        item.failed_delta,
+                        item.pass_rate_delta_points
+                    ),
+                );
+            }
+            for item in failure_queue.iter().take(10) {
+                append_remediation_item(
+                    &mut markdown,
+                    &mut item_count,
+                    &format!(
+                        "Fix master-{} case #{} ({}): {}",
+                        item.slug,
+                        item.case_index,
+                        item.priority.label(),
+                        item.failure_summary
+                    ),
+                );
+            }
+        }
+
+        markdown.push_str("\n## Verification\n");
+        append_remediation_item(
+            &mut markdown,
+            &mut item_count,
+            "Rerun affected fidelity scopes",
+        );
+        append_remediation_item(&mut markdown, &mut item_count, "Run `npm test`");
+        markdown.push_str("- Attach the copied evidence report to the PR or release note.\n");
+
+        Self {
+            markdown,
+            item_count,
+        }
+    }
+}
+
+fn append_remediation_item(markdown: &mut String, item_count: &mut usize, text: &str) {
+    *item_count += 1;
+    markdown.push_str(&format!("- [ ] {text}\n"));
+}
+
+fn default_remediation_action(brief: &EvaluationDecisionBrief) -> String {
+    match brief.posture {
+        EvaluationDecisionPosture::Ready => {
+            "Run full validation before release approval".to_string()
+        }
+        EvaluationDecisionPosture::Unproven => {
+            "Run fidelity baseline for all skills to establish current coverage".to_string()
+        }
+        EvaluationDecisionPosture::Attention | EvaluationDecisionPosture::Blocked => {
+            brief.recommendation.clone()
+        }
     }
 }
 
@@ -1459,9 +1565,10 @@ mod tests {
     use super::{
         EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
         EvaluationEvidenceReport, EvaluationFailureInsights, EvaluationFailureItem,
-        EvaluationFailurePriority, EvaluationRegressionItem, EvaluationRunCoverage,
-        EvaluationRunHistoryFilter, EvaluationRunHistoryItem, EvaluationRunTrend,
-        EvaluationTrendSummary, FailureKind, TraceAction, TraceListFilter, TraceStatus, TraceStore,
+        EvaluationFailurePriority, EvaluationRegressionItem, EvaluationRemediationPlan,
+        EvaluationRunCoverage, EvaluationRunHistoryFilter, EvaluationRunHistoryItem,
+        EvaluationRunTrend, EvaluationTrendSummary, FailureKind, TraceAction, TraceListFilter,
+        TraceStatus, TraceStore,
     };
 
     fn temp_path(name: &str) -> PathBuf {
@@ -2779,6 +2886,74 @@ mod tests {
         assert!(report
             .markdown
             .contains("- #9 master-huineng: success, 10/12 N/A, 2 failed, regressed"));
+    }
+
+    #[test]
+    fn builds_copyable_evaluation_remediation_plan() {
+        let brief = EvaluationDecisionBrief {
+            posture: EvaluationDecisionPosture::Blocked,
+            headline: "Regression detected".to_string(),
+            primary_risk: "master-huineng regressed".to_string(),
+            evidence: "1 regression across 8 recent runs".to_string(),
+            recommendation: "Rerun the regressed scope and inspect failed cases before release."
+                .to_string(),
+            action: EvaluationDecisionAction::RerunSkill {
+                slug: "huineng".to_string(),
+            },
+        };
+        let regressions = vec![EvaluationRegressionItem {
+            scope: "master-huineng".to_string(),
+            current_trace_id: 42,
+            previous_trace_id: 40,
+            current_failed_count: 2,
+            previous_failed_count: 0,
+            failed_delta: 2,
+            current_pass_rate: 80,
+            previous_pass_rate: 100,
+            pass_rate_delta_points: -20,
+            action: Some(TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            }),
+        }];
+        let failure_queue = vec![EvaluationFailureItem {
+            slug: "huineng".to_string(),
+            case_index: 3,
+            question: "如何见性?".to_string(),
+            status: "FAIL".to_string(),
+            priority: EvaluationFailurePriority::Critical,
+            failure_summary: "fabricated cites: X9".to_string(),
+            trace_id: 42,
+        }];
+        let run_history = vec![EvaluationRunHistoryItem {
+            trace_id: 42,
+            scope: "master-huineng".to_string(),
+            status: TraceStatus::Succeeded,
+            passed_count: 8,
+            total_count: 10,
+            failed_count: 2,
+            dry_run: false,
+            duration_ms: Some(120),
+            action: Some(TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            }),
+            trend: EvaluationRunTrend::Regressed,
+        }];
+
+        let plan = EvaluationRemediationPlan::from_signals(
+            &brief,
+            &regressions,
+            &failure_queue,
+            &run_history,
+        );
+
+        assert_eq!(plan.item_count, 4);
+        assert!(plan
+            .markdown
+            .contains("# Master-skill Evaluation Remediation Plan"));
+        assert!(plan.markdown.contains("- [ ] Rerun master-huineng"));
+        assert!(plan.markdown.contains("- [ ] Fix master-huineng case #3"));
+        assert!(plan.markdown.contains("- [ ] Run `npm test`"));
+        assert!(plan.markdown.contains("latest trace #42"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a copyable Evaluation Remediation Plan derived from decision brief, regressions, failure queue, and recent run history
- surface a Copy action plan button beside the existing evidence report action
- include latest trace context and verification checklist items for PR/release workflows

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test