### PR TITLE
feat(desktop): show remediation plan panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added an actionable Overview Decision Brief backed by the shared evaluation gate snapshot, including the primary gate action and copyable evidence report from the main console surface.
 - Added an Evaluation Center evidence window selector for 8, 16, or 32 recent runs, shared by trend summaries, regression queues, run history, and copied evidence reports.
 - Added a copyable Evaluation Remediation Plan that turns regressions, failing cases, latest trace context, and verification steps into a Markdown action checklist.
+- Added a visible Remediation Plan panel to Overview and Evaluation Center so current gate actions are scannable before copying them out.
 
 ### Changed — framework positioning and v1.0 planning
 - Repositioned Master-skill as a **FoJin-powered Buddhist AI persona framework**: source-grounded, boundary-aware, fidelity-tested, and runtime-ready.

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -915,6 +915,9 @@ impl MasterSkillApp {
                 &gate.evidence_report,
                 &gate.remediation_plan,
             );
+
+            ui.separator();
+            Self::show_evaluation_remediation_plan(ui, &gate.remediation_plan);
         } else {
             ui.label("No runtime report loaded.");
         }
@@ -1013,6 +1016,9 @@ impl MasterSkillApp {
         );
 
         ui.separator();
+        Self::show_evaluation_remediation_plan(ui, &gate.remediation_plan);
+
+        ui.separator();
         Self::show_evaluation_trend_summary(ui, &gate.trend_summary);
 
         ui.separator();
@@ -1101,6 +1107,22 @@ impl MasterSkillApp {
                 remediation_plan.item_count
             ));
         }
+    }
+
+    fn show_evaluation_remediation_plan(ui: &mut egui::Ui, plan: &EvaluationRemediationPlan) {
+        ui.heading("Remediation Plan");
+        ui.small(format!("{} action item(s)", plan.item_count));
+        egui::Grid::new("evaluation-remediation-plan-grid")
+            .num_columns(2)
+            .striped(true)
+            .min_col_width(32.0)
+            .show(ui, |ui| {
+                for (index, item) in plan.items.iter().enumerate() {
+                    ui.strong(format!("{}", index + 1));
+                    ui.label(item);
+                    ui.end_row();
+                }
+            });
     }
 
     fn show_evaluation_trend_summary(ui: &mut egui::Ui, summary: &EvaluationTrendSummary) {

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -882,6 +882,7 @@ pub struct EvaluationEvidenceReport {
 pub struct EvaluationRemediationPlan {
     pub markdown: String,
     pub item_count: usize,
+    pub items: Vec<String>,
 }
 
 impl EvaluationEvidenceReport {
@@ -993,6 +994,7 @@ impl EvaluationRemediationPlan {
     ) -> Self {
         let mut markdown = String::new();
         let mut item_count = 0;
+        let mut items = Vec::new();
 
         markdown.push_str("# Master-skill Evaluation Remediation Plan\n\n");
         markdown.push_str("## Gate Decision\n");
@@ -1017,6 +1019,7 @@ impl EvaluationRemediationPlan {
             append_remediation_item(
                 &mut markdown,
                 &mut item_count,
+                &mut items,
                 &default_remediation_action(brief),
             );
         } else {
@@ -1024,6 +1027,7 @@ impl EvaluationRemediationPlan {
                 append_remediation_item(
                     &mut markdown,
                     &mut item_count,
+                    &mut items,
                     &format!(
                         "Rerun {} and compare trace #{} against #{} (failed {:+}, pass rate {:+} pts)",
                         item.scope,
@@ -1038,6 +1042,7 @@ impl EvaluationRemediationPlan {
                 append_remediation_item(
                     &mut markdown,
                     &mut item_count,
+                    &mut items,
                     &format!(
                         "Fix master-{} case #{} ({}): {}",
                         item.slug,
@@ -1053,20 +1058,28 @@ impl EvaluationRemediationPlan {
         append_remediation_item(
             &mut markdown,
             &mut item_count,
+            &mut items,
             "Rerun affected fidelity scopes",
         );
-        append_remediation_item(&mut markdown, &mut item_count, "Run `npm test`");
+        append_remediation_item(&mut markdown, &mut item_count, &mut items, "Run `npm test`");
         markdown.push_str("- Attach the copied evidence report to the PR or release note.\n");
 
         Self {
             markdown,
             item_count,
+            items,
         }
     }
 }
 
-fn append_remediation_item(markdown: &mut String, item_count: &mut usize, text: &str) {
+fn append_remediation_item(
+    markdown: &mut String,
+    item_count: &mut usize,
+    items: &mut Vec<String>,
+    text: &str,
+) {
     *item_count += 1;
+    items.push(text.to_string());
     markdown.push_str(&format!("- [ ] {text}\n"));
 }
 
@@ -2947,6 +2960,15 @@ mod tests {
         );
 
         assert_eq!(plan.item_count, 4);
+        assert_eq!(
+            plan.items,
+            vec![
+                "Rerun master-huineng and compare trace #42 against #40 (failed +2, pass rate -20 pts)",
+                "Fix master-huineng case #3 (critical): fabricated cites: X9",
+                "Rerun affected fidelity scopes",
+                "Run `npm test`",
+            ]
+        );
         assert!(plan
             .markdown
             .contains("# Master-skill Evaluation Remediation Plan"));


### PR DESCRIPTION
## Summary
- expose structured Evaluation Remediation Plan items for UI rendering
- show a visible Remediation Plan panel in Overview and Evaluation Center
- keep the copyable Markdown action plan path intact

## Verification
- cargo fmt --manifest-path desktop/Cargo.toml --check
- cargo test --manifest-path desktop/Cargo.toml
- cargo build --release --manifest-path desktop/Cargo.toml
- npm test