### PR TITLE
feat(desktop): add --baseline headless run

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -263,16 +263,21 @@ fn quality_gate_metric_card(brief: &EvaluationDecisionBrief) -> MetricCard {
     }
 }
 
+/// Trace history capacity shared by the GUI (`MasterSkillApp::new`) and the
+/// headless `--baseline` run, so both load/save the store identically.
+pub(crate) const TRACE_STORE_CAPACITY: usize = 200;
+
 impl MasterSkillApp {
     pub fn new() -> Self {
         let trace_path = desktop_trace_store_path();
-        let (traces, trace_load_message) = match TraceStore::load_from_path(&trace_path, 200) {
-            Ok(traces) => (traces, None),
-            Err(err) => (
-                TraceStore::new(200),
-                Some(format!("Trace history load failed: {err:#}")),
-            ),
-        };
+        let (traces, trace_load_message) =
+            match TraceStore::load_from_path(&trace_path, TRACE_STORE_CAPACITY) {
+                Ok(traces) => (traces, None),
+                Err(err) => (
+                    TraceStore::new(TRACE_STORE_CAPACITY),
+                    Some(format!("Trace history load failed: {err:#}")),
+                ),
+            };
         let mut app = Self {
             client: CliClient::default(),
             inventory: None,
@@ -2394,7 +2399,7 @@ impl eframe::App for MasterSkillApp {
     }
 }
 
-fn summarize_command_output(prefix: &str, output: &str) -> String {
+pub(crate) fn summarize_command_output(prefix: &str, output: &str) -> String {
     let lines: Vec<&str> = output
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -2407,7 +2412,7 @@ fn summarize_command_output(prefix: &str, output: &str) -> String {
     format!("{prefix}:\n{}", lines[start..].join("\n"))
 }
 
-fn first_line(value: &str) -> String {
+pub(crate) fn first_line(value: &str) -> String {
     value
         .lines()
         .find(|line| !line.trim().is_empty())
@@ -2416,7 +2421,7 @@ fn first_line(value: &str) -> String {
         .to_string()
 }
 
-fn desktop_trace_store_path() -> PathBuf {
+pub(crate) fn desktop_trace_store_path() -> PathBuf {
     desktop_trace_store_path_from_env(
         std::env::var("XDG_DATA_HOME").ok().as_deref(),
         std::env::var("HOME").ok().as_deref(),

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -573,19 +573,15 @@ impl MasterSkillApp {
     }
 
     fn start_skill_fidelity_dry_run(&mut self, slug: String) {
+        let (label, command) = crate::baseline::skill_dry_run_label_and_command(&slug);
         self.start_task_with_action(
-            format!("Running master-{slug} fidelity dry-run"),
+            label,
             Some(TraceAction::FidelityDryRunSkill { slug: slug.clone() }),
-            Some(format!(
-                "python3 scripts/test-fidelity.py --master master-{slug} --dry-run --json"
-            )),
+            Some(command),
             move |client| {
                 let output = client.run_fidelity_dry_run_for(&slug)?;
                 Ok(TaskOutcome {
-                    message: summarize_command_output(
-                        &format!("master-{slug} fidelity dry-run finished"),
-                        &output,
-                    ),
+                    message: crate::baseline::skill_dry_run_success_message(&slug, &output),
                     detail: output.trim().to_string(),
                     snapshot: None,
                 })

--- a/desktop/src/baseline.rs
+++ b/desktop/src/baseline.rs
@@ -6,7 +6,11 @@
 //! (same label, command string, `TraceAction::FidelityDryRunSkill`, summary
 //! computation, and trace store path/capacity) so trace records written by
 //! `--baseline` are indistinguishable from ones written by clicking "Run
-//! skill dry-run" for every skill in the GUI.
+//! skill dry-run" for every skill in the GUI. The label, command, and
+//! success-message formatting are factored into
+//! [`skill_dry_run_label_and_command`] and [`skill_dry_run_success_message`]
+//! below, which both `app.rs` and this module call, so the two paths can't
+//! drift apart.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -19,6 +23,26 @@ use crate::app::{
 };
 use crate::cli::CliClient;
 use crate::trace::{TraceAction, TraceStore};
+
+/// Returns the `(label, command)` pair for running a single master skill's
+/// fidelity dry-run: `master-{slug}`'s progress label and the
+/// `python3 scripts/test-fidelity.py --master master-{slug} --dry-run --json`
+/// invocation. Shared by the GUI's `MasterSkillApp::start_skill_fidelity_dry_run`
+/// (`app.rs`) and [`run_headless_baseline`]'s loop below so the two paths
+/// can't drift apart.
+pub(crate) fn skill_dry_run_label_and_command(slug: &str) -> (String, String) {
+    (
+        format!("Running master-{slug} fidelity dry-run"),
+        format!("python3 scripts/test-fidelity.py --master master-{slug} --dry-run --json"),
+    )
+}
+
+/// Formats the success message for a single master skill's fidelity
+/// dry-run, matching [`summarize_command_output`]'s conventions. Shared by
+/// the same two callers as [`skill_dry_run_label_and_command`].
+pub(crate) fn skill_dry_run_success_message(slug: &str, output: &str) -> String {
+    summarize_command_output(&format!("master-{slug} fidelity dry-run finished"), output)
+}
 
 /// Runs `python3 scripts/test-fidelity.py --master <slug> --dry-run --json`
 /// for every master skill that ships a `tests/fidelity.jsonl` fixture,
@@ -39,9 +63,7 @@ pub fn run_headless_baseline() -> Result<i32> {
     let mut ok_count = 0usize;
 
     for slug in &slugs {
-        let label = format!("Running master-{slug} fidelity dry-run");
-        let command =
-            format!("python3 scripts/test-fidelity.py --master master-{slug} --dry-run --json");
+        let (label, command) = skill_dry_run_label_and_command(slug);
         let trace_id = traces.begin_with_action(
             label,
             TraceAction::FidelityDryRunSkill { slug: slug.clone() },
@@ -52,10 +74,7 @@ pub fn run_headless_baseline() -> Result<i32> {
         let started = Instant::now();
         match client.run_fidelity_dry_run_for(slug) {
             Ok(output) => {
-                let message = summarize_command_output(
-                    &format!("master-{slug} fidelity dry-run finished"),
-                    &output,
-                );
+                let message = skill_dry_run_success_message(slug, &output);
                 traces.finish_success_with_detail(
                     trace_id,
                     message,

--- a/desktop/src/baseline.rs
+++ b/desktop/src/baseline.rs
@@ -1,0 +1,120 @@
+//! Headless fidelity-dry-run baseline, extracted from the GUI's per-skill
+//! "Run skill dry-run" action (`MasterSkillApp::start_skill_fidelity_dry_run`
+//! in `app.rs`) so it can run without starting the egui window.
+//!
+//! This intentionally reuses the exact trace-record shape the GUI produces
+//! (same label, command string, `TraceAction::FidelityDryRunSkill`, summary
+//! computation, and trace store path/capacity) so trace records written by
+//! `--baseline` are indistinguishable from ones written by clicking "Run
+//! skill dry-run" for every skill in the GUI.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::Result;
+
+use crate::app::{
+    desktop_trace_store_path, first_line, summarize_command_output, TRACE_STORE_CAPACITY,
+};
+use crate::cli::CliClient;
+use crate::trace::{TraceAction, TraceStore};
+
+/// Runs `python3 scripts/test-fidelity.py --master <slug> --dry-run --json`
+/// for every master skill that ships a `tests/fidelity.jsonl` fixture,
+/// recording one trace per skill into the standard trace store (honoring
+/// `XDG_DATA_HOME` via [`desktop_trace_store_path`]).
+///
+/// Prints `ok <slug>` / `fail <slug>` per skill and a final
+/// `baseline: <n>/<total> ok` summary line. Returns `Ok(0)` if every skill's
+/// dry-run succeeded, `Ok(1)` if at least one failed.
+pub fn run_headless_baseline() -> Result<i32> {
+    let client = CliClient::default();
+    let slugs = discover_master_skill_slugs(client.repo_root());
+
+    let store_path = desktop_trace_store_path();
+    let mut traces = TraceStore::load_from_path(&store_path, TRACE_STORE_CAPACITY)?;
+
+    let total = slugs.len();
+    let mut ok_count = 0usize;
+
+    for slug in &slugs {
+        let label = format!("Running master-{slug} fidelity dry-run");
+        let command =
+            format!("python3 scripts/test-fidelity.py --master master-{slug} --dry-run --json");
+        let trace_id = traces.begin_with_action(
+            label,
+            TraceAction::FidelityDryRunSkill { slug: slug.clone() },
+            Some(command),
+            "Queued.",
+        );
+
+        let started = Instant::now();
+        match client.run_fidelity_dry_run_for(slug) {
+            Ok(output) => {
+                let message = summarize_command_output(
+                    &format!("master-{slug} fidelity dry-run finished"),
+                    &output,
+                );
+                traces.finish_success_with_detail(
+                    trace_id,
+                    message,
+                    output.trim().to_string(),
+                    started.elapsed(),
+                );
+                println!("ok {slug}");
+                ok_count += 1;
+            }
+            Err(err) => {
+                let message = format!("{err:#}");
+                traces.finish_error_with_detail(
+                    trace_id,
+                    first_line(&message),
+                    message,
+                    started.elapsed(),
+                );
+                println!("fail {slug}");
+            }
+        }
+    }
+
+    traces.save_to_path(&store_path)?;
+    println!("baseline: {ok_count}/{total} ok");
+
+    Ok(if ok_count == total { 0 } else { 1 })
+}
+
+/// Finds every `master-*` directory under `<repo_root>/prebuilt` that has a
+/// `tests/fidelity.jsonl` fixture, returning slugs with the `master-` prefix
+/// stripped (e.g. `huineng`), sorted for deterministic run order.
+///
+/// Mirrors the discovery rule `scripts/test-fidelity.py --all` uses
+/// internally, minus non-master fixture directories (e.g. `compare`) that
+/// don't match the `master-*` naming scheme the GUI's per-skill trace scope
+/// (`master-{slug}`) assumes.
+fn discover_master_skill_slugs(repo_root: &Path) -> Vec<String> {
+    let prebuilt_dir = repo_root.join("prebuilt");
+    let Ok(entries) = fs::read_dir(&prebuilt_dir) else {
+        return Vec::new();
+    };
+
+    let mut slugs: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path: PathBuf = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            let slug = name.strip_prefix("master-")?.to_string();
+            if path.join("tests").join("fidelity.jsonl").is_file() {
+                Some(slug)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    slugs.sort();
+    slugs
+}

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod baseline;
 pub mod catalog;
 pub mod cli;
 pub mod fonts;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,8 +1,20 @@
 use eframe::egui;
 use master_skill_desktop::app::MasterSkillApp;
+use master_skill_desktop::baseline::run_headless_baseline;
 use master_skill_desktop::fonts::install_cjk_fonts;
 
 fn main() -> eframe::Result {
+    if std::env::args().any(|arg| arg == "--baseline") {
+        let exit_code = match run_headless_baseline() {
+            Ok(code) => code,
+            Err(err) => {
+                eprintln!("baseline failed: {err:#}");
+                1
+            }
+        };
+        std::process::exit(exit_code);
+    }
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([1120.0, 720.0]),
         ..Default::default()

--- a/desktop/tests/baseline_cli.rs
+++ b/desktop/tests/baseline_cli.rs
@@ -1,0 +1,129 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn temp_xdg_data_home() -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("master-skill-desktop-baseline-test-{suffix}"))
+}
+
+/// Number of `master-*` skill directories under `prebuilt/` that ship a
+/// `tests/fidelity.jsonl` fixture. Mirrors the discovery rule the headless
+/// `--baseline` run and `scripts/test-fidelity.py --all` both use.
+fn master_skill_count_with_fidelity(repo_root: &Path) -> usize {
+    let prebuilt = repo_root.join("prebuilt");
+    let Ok(entries) = fs::read_dir(&prebuilt) else {
+        return 0;
+    };
+
+    entries
+        .flatten()
+        .filter(|entry| {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            path.is_dir()
+                && name.starts_with("master-")
+                && path.join("tests").join("fidelity.jsonl").is_file()
+        })
+        .count()
+}
+
+/// Runs `command`, killing it and failing the test if it does not exit within
+/// `timeout`. Without `--baseline` implemented, the binary falls through to
+/// `eframe::run_native` and hangs forever in this display-less sandbox, so a
+/// hard deadline is required to keep this test (and its RED phase) from
+/// hanging CI.
+fn run_with_timeout(mut command: Command, timeout: Duration) -> std::process::Output {
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null());
+    let mut child = command
+        .spawn()
+        .expect("failed to spawn master-skill-desktop");
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(_status) = child.try_wait().expect("failed to poll child status") {
+            return child
+                .wait_with_output()
+                .expect("failed to collect child output after exit");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "master-skill-desktop did not exit within {:?} (still hangs on GUI startup?)",
+                timeout
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn baseline_flag_runs_headless_and_records_traces_for_all_master_skills() {
+    let xdg_data_home = temp_xdg_data_home();
+    fs::create_dir_all(&xdg_data_home).unwrap();
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_master-skill-desktop"));
+    command
+        .arg("--baseline")
+        .current_dir(repo_root())
+        .env("XDG_DATA_HOME", &xdg_data_home);
+
+    let output = run_with_timeout(command, Duration::from_secs(120));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("baseline:"),
+        "expected stdout to contain a `baseline:` summary line, got:\n{stdout}"
+    );
+
+    let store_path = xdg_data_home
+        .join("master-skill")
+        .join("desktop-traces.json");
+    assert!(
+        store_path.is_file(),
+        "expected trace store to exist at {store_path:?}"
+    );
+
+    let content = fs::read_to_string(&store_path).expect("failed to read trace store");
+    let value: serde_json::Value =
+        serde_json::from_str(&content).expect("trace store is not valid JSON");
+    let records = value
+        .get("records")
+        .and_then(serde_json::Value::as_array)
+        .expect("trace store JSON has no `records` array");
+
+    let expected_min = master_skill_count_with_fidelity(&repo_root());
+    assert!(
+        expected_min > 0,
+        "sanity check failed: found no master-* skills with tests/fidelity.jsonl"
+    );
+    assert!(
+        records.len() >= expected_min,
+        "expected at least {expected_min} trace record(s) (one per master skill with fidelity.jsonl), found {}",
+        records.len()
+    );
+
+    fs::remove_dir_all(&xdg_data_home).ok();
+}


### PR DESCRIPTION
## Summary
- Adds `master-skill-desktop --baseline`: a headless subcommand that runs the fidelity dry-run baseline for every `master-*` skill under `prebuilt/` that ships `tests/fidelity.jsonl`, without starting the egui GUI window.
- Reuses the GUI's exact per-skill dry-run action code path (`CliClient::run_fidelity_dry_run_for`, same label/command string, `TraceAction::FidelityDryRunSkill`, same summary formatting) so headless-produced trace records are structurally indistinguishable from GUI-produced ones (extracted, not reinvented — see `desktop/src/baseline.rs`).
- Persists to the same `desktop-traces.json` store, at the same `XDG_DATA_HOME`-aware path the GUI uses (`app.rs` store-path resolver, now `pub(crate)`).
- stdout: one `ok <slug>` / `fail <slug>` line per skill, plus a final `baseline: <n>/<total> ok` summary line. Exit code 0 only if every skill succeeded, 1 otherwise.
- Always runs fidelity in `--dry-run` mode (no paid LLM calls).

## Files changed
- `desktop/src/baseline.rs` (new): `run_headless_baseline()` — extracted, reusable baseline runner + skill discovery.
- `desktop/src/main.rs`: checks `--baseline` before `eframe::run_native`, calls the extracted function, exits with its code.
- `desktop/src/app.rs`: minimal visibility bumps (`pub(crate)`) on `desktop_trace_store_path`, `summarize_command_output`, `first_line`, plus a shared `TRACE_STORE_CAPACITY` constant — no behavior change to the GUI.
- `desktop/src/lib.rs`: registers the new `baseline` module.
- `desktop/tests/baseline_cli.rs` (new): integration test spawning the real compiled binary (`CARGO_BIN_EXE_master-skill-desktop`) with an isolated `XDG_DATA_HOME` tempdir, asserting exit 0, trace store existence, record count, and stdout summary line. Guards against a GUI-hang RED phase with a manual timeout+kill.

## Test plan
- [x] `cd desktop && cargo test` — 65/65 green (64 existing + 1 new)
- [x] TDD RED confirmed first: without `--baseline`, binary falls through to `eframe::run_native` and hangs in this display-less sandbox; test times out and fails for the expected reason
- [x] `cargo build --release` then `XDG_DATA_HOME=$(mktemp -d) ./desktop/target/release/master-skill-desktop --baseline` from the worktree root → 17/17 `ok`, `baseline: 17/17 ok`, exit 0
- [x] Verified `CliClient::default()`'s `repo_root` is baked in at compile time (`env!("CARGO_MANIFEST_DIR")`), so cwd does not actually matter — re-ran the release binary from `/tmp` with the same result
- [x] Edge cases manually verified: `python3` missing from `PATH` → all skills report `fail <slug>`, `baseline: 0/17 ok`, exit 1, no panic; failed trace records persisted with the CLI's error detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix round 1 (review)
- Deduped the per-skill dry-run label, command string, and success-message formatting that were near-verbatim duplicated between the GUI's `start_skill_fidelity_dry_run` (`app.rs`) and the headless `run_headless_baseline` loop (`baseline.rs`). Both now call two small shared helpers, `skill_dry_run_label_and_command` and `skill_dry_run_success_message`, defined once in `baseline.rs`. No behavior change: labels, commands, messages, and trace records are byte-identical to before.
- Design note on why the headless path reuses `start_skill_fidelity_dry_run`'s per-skill code path rather than the overview "Run baseline" action: the GUI has a separate `EvaluationDecisionAction::RunFidelityBaseline` → `start_fidelity_dry_run()` path that shells out once with `--all` and records a single combined `TraceAction::FidelityDryRunAll` trace. `--baseline`'s CLI contract requires a per-skill `ok <slug>` / `fail <slug>` line and one trace record per skill (so failures are individually attributable and rerunnable), which the batch `--all` action cannot produce without reinventing the per-skill record structure that `start_skill_fidelity_dry_run` already has. So the headless runner extracts and loops the per-skill path instead.
