### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "master-skill",
       "description": "FoJin-powered Buddhist AI persona framework — source-grounded, boundary-aware, fidelity-tested, runtime-ready. 15 prebuilt masters across 印度/汉传/藏传/南传 plus compare, debate, and curriculum meta-skills.",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "source": "./",
       "author": {
         "name": "xr843",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "master-skill",
   "description": "FoJin-powered Buddhist AI persona framework — source-grounded, boundary-aware, fidelity-tested, runtime-ready. 15 prebuilt masters across 印度/汉传/藏传/南传 plus compare, debate, and curriculum meta-skills.",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": {
     "name": "xr843",
     "email": "xr843@users.noreply.github.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "master-skill",
   "displayName": "Master Skill",
   "description": "FoJin-powered Buddhist AI persona framework — source-grounded, boundary-aware, fidelity-tested, runtime-ready. 15 prebuilt masters across 印度/汉传/藏传/南传.",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": {
     "name": "xr843",
     "email": "xr843@users.noreply.github.com"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -75,7 +75,10 @@ jobs:
           cargo --version
 
       - name: Build desktop app
-        run: cargo build --release --manifest-path desktop/Cargo.toml
+        # --locked: desktop/Cargo.lock is committed, so release builds must
+        # use exactly those dependency versions instead of silently
+        # re-resolving (and potentially drifting from what CI/tests used).
+        run: cargo build --release --locked --manifest-path desktop/Cargo.toml
 
       - name: Stage renamed binary
         shell: bash
@@ -83,12 +86,29 @@ jobs:
           mkdir -p dist
           cp "${{ matrix.binary_path }}" "dist/${{ matrix.artifact_name }}"
 
+      - name: Smoke-test staged binary (Linux only)
+        if: runner.os == 'Linux'
+        # Guards against non-portable binaries (e.g. one that bakes in a
+        # compile-time repo path that only exists on this runner) reaching
+        # a release: run the staged artifact's headless `--baseline` from
+        # the checkout root, the same way a downloaded release binary is
+        # documented to be run, with an isolated store so it can't read or
+        # write a real user's trace history. `python3` is preinstalled on
+        # GitHub-hosted Linux runners, which `--baseline` shells out to.
+        shell: bash
+        run: |
+          chmod +x "dist/${{ matrix.artifact_name }}"
+          XDG_DATA_HOME="$(mktemp -d)" "./dist/${{ matrix.artifact_name }}" --baseline
+
       - name: Upload release asset
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
-        run: gh release upload "$GITHUB_REF_NAME" "dist/${{ matrix.artifact_name }}"
+        # --clobber: re-runs of this workflow (e.g. after a transient
+        # failure on another matrix leg) must not fail just because this
+        # leg's asset was already uploaded by a previous attempt.
+        run: gh release upload "$GITHUB_REF_NAME" "dist/${{ matrix.artifact_name }}" --clobber
 
       - name: Upload workflow artifact
         if: github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ## [0.10.0] — 2026-07-10
 
+### Fixed — release binary repo-root resolution
+- Fixed `master-skill-desktop` release binaries baking in the compile-time build path (`CARGO_MANIFEST_DIR`), which produced a broken GUI shell and a `--baseline` that silently found zero skills on any machine other than the one that built the binary. The repo root is now resolved at runtime by walking up from the current working directory for a directory containing both `prebuilt/` and `scripts/test-fidelity.py`, falling back to the compile-time path only so source builds and dev workflows keep working unchanged.
+- Fixed headless `--baseline` reporting a false `baseline: 0/0 ok` success (exit 0) when no master skills could be discovered under the resolved repo root; it now exits non-zero with a clear error naming the resolved path and the requirement to run from inside a cloned Master-skill repo.
+
 ### Added — native desktop manager
 - Added a pure Rust `desktop/` app skeleton using `egui/eframe` as the first native Master-skill Desktop Manager shell.
 - Added Rust models and tests for the CLI JSON contracts consumed by the desktop app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Added `--locked` to the desktop release build so it uses the committed `desktop/Cargo.lock` exactly, instead of allowing dependency re-resolution at release time.
 - Added a Linux-only smoke test that runs the staged release binary's `--baseline` from the checkout root before the job is considered successful, catching non-portable (compile-time-path) binaries before they reach a release.
 
+### Changed — desktop download docs
+- Documented the `chmod +x` step (Linux/macOS) and the macOS unsigned-binary first-run workaround (right-click → Open, or `xattr -d com.apple.quarantine`) needed after downloading a release binary.
+- Changed the desktop screenshot in README/README_EN to reference the absolute GitHub raw URL instead of a relative path, since README.md ships to npm where relative image paths break.
+- Corrected README's desktop section from "17 位法师" to "17 个 master skill" — 2 of the 17 are meta-skills, not personas.
+
 ### Added — native desktop manager
 - Added a pure Rust `desktop/` app skeleton using `egui/eframe` as the first native Master-skill Desktop Manager shell.
 - Added Rust models and tests for the CLI JSON contracts consumed by the desktop app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-10
+
 ### Added — native desktop manager
 - Added a pure Rust `desktop/` app skeleton using `egui/eframe` as the first native Master-skill Desktop Manager shell.
 - Added Rust models and tests for the CLI JSON contracts consumed by the desktop app.
@@ -463,5 +465,14 @@ Iteration layer between initial skeleton and full v0.3 rebuild. Highlights:
 
 ---
 
-[Unreleased]: https://github.com/xr843/Master-skill/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/xr843/Master-skill/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/xr843/Master-skill/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/xr843/Master-skill/releases/tag/v0.9.1
+[0.9.0]: https://github.com/xr843/Master-skill/releases/tag/v0.9.0
+[0.8.0]: https://github.com/xr843/Master-skill/releases/tag/v0.8.0
+[0.7.1]: https://github.com/xr843/Master-skill/releases/tag/v0.7.1
+[0.7.0]: https://github.com/xr843/Master-skill/releases/tag/v0.7.0
+[0.6.0]: https://github.com/xr843/Master-skill/releases/tag/v0.6.0
+[0.5.0]: https://github.com/xr843/Master-skill/releases/tag/v0.5.0
+[0.4.0]: https://github.com/xr843/Master-skill/releases/tag/v0.4.0
 [0.3.0]: https://github.com/xr843/Master-skill/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - Fixed `master-skill-desktop` release binaries baking in the compile-time build path (`CARGO_MANIFEST_DIR`), which produced a broken GUI shell and a `--baseline` that silently found zero skills on any machine other than the one that built the binary. The repo root is now resolved at runtime by walking up from the current working directory for a directory containing both `prebuilt/` and `scripts/test-fidelity.py`, falling back to the compile-time path only so source builds and dev workflows keep working unchanged.
 - Fixed headless `--baseline` reporting a false `baseline: 0/0 ok` success (exit 0) when no master skills could be discovered under the resolved repo root; it now exits non-zero with a clear error naming the resolved path and the requirement to run from inside a cloned Master-skill repo.
 
+### Changed — release workflow hardening
+- Added `--clobber` to the desktop release asset upload so re-running `release-desktop.yml` after a partial failure no longer fails on assets a previous attempt already uploaded.
+- Added `--locked` to the desktop release build so it uses the committed `desktop/Cargo.lock` exactly, instead of allowing dependency re-resolution at release time.
+- Added a Linux-only smoke test that runs the staged release binary's `--baseline` from the checkout root before the job is considered successful, catching non-portable (compile-time-path) binaries before they reach a release.
+
 ### Added — native desktop manager
 - Added a pure Rust `desktop/` app skeleton using `egui/eframe` as the first native Master-skill Desktop Manager shell.
 - Added Rust models and tests for the CLI JSON contracts consumed by the desktop app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ## [Unreleased]
 
-## [0.10.0] - 2026-07-10
+## [0.10.0] — 2026-07-10
 
 ### Added — native desktop manager
 - Added a pure Rust `desktop/` app skeleton using `egui/eframe` as the first native Master-skill Desktop Manager shell.

--- a/README.md
+++ b/README.md
@@ -303,11 +303,11 @@ git clone https://github.com/xr843/Master-skill ~/Master-skill
 
 ## 桌面管理器
 
-原生桌面控制台(纯 Rust,egui,单二进制,无 Electron),统一管理 17 位法师 skill 的安装状态、fidelity 评测覆盖率、运行追踪与质量门禁:
+原生桌面控制台(纯 Rust,egui,单二进制,无 Electron),统一管理 17 个 master skill 的安装状态、fidelity 评测覆盖率、运行追踪与质量门禁:
 
-![Master-skill Desktop Manager](docs/assets/desktop-manager.png)
+![Master-skill Desktop Manager](https://raw.githubusercontent.com/xr843/Master-skill/master/docs/assets/desktop-manager.png)
 
-**下载**:[Releases](https://github.com/xr843/Master-skill/releases) 提供 Linux / Windows / macOS 预编译二进制,下载后直接运行(仓库根目录下执行,需本地已 clone 本仓库)。
+**下载**:[Releases](https://github.com/xr843/Master-skill/releases) 提供 Linux / Windows / macOS 预编译二进制,下载后直接运行(仓库根目录下执行,需本地已 clone 本仓库)。Linux / macOS 下载后需先 `chmod +x` 赋予可执行权限;macOS 上二进制未签名,首次运行需右键"打开"或执行 `xattr -d com.apple.quarantine <文件名>` 解除隔离。
 
 **从源码构建**:
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -283,9 +283,9 @@ The system will guide you through a three-step intake, then automatically collec
 
 A native desktop console (pure Rust, egui, single binary, no Electron) that unifies management of installation status, fidelity evaluation coverage, run tracing, and the quality gate across all 17 master skills:
 
-![Master-skill Desktop Manager](docs/assets/desktop-manager.png)
+![Master-skill Desktop Manager](https://raw.githubusercontent.com/xr843/Master-skill/master/docs/assets/desktop-manager.png)
 
-**Download**: [Releases](https://github.com/xr843/Master-skill/releases) provides pre-built binaries for Linux / Windows / macOS — download and run directly (execute from the repository root; requires a local clone of this repo).
+**Download**: [Releases](https://github.com/xr843/Master-skill/releases) provides pre-built binaries for Linux / Windows / macOS — download and run directly (execute from the repository root; requires a local clone of this repo). On Linux/macOS you'll need to `chmod +x` the downloaded binary first; on macOS it's unsigned, so the first run needs right-click → Open, or `xattr -d com.apple.quarantine <file>` to clear the quarantine flag.
 
 **Build from source**:
 

--- a/desktop/src/baseline.rs
+++ b/desktop/src/baseline.rs
@@ -16,7 +16,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use crate::app::{
     desktop_trace_store_path, first_line, summarize_command_output, TRACE_STORE_CAPACITY,
@@ -55,6 +55,17 @@ pub(crate) fn skill_dry_run_success_message(slug: &str, output: &str) -> String 
 pub fn run_headless_baseline() -> Result<i32> {
     let client = CliClient::default();
     let slugs = discover_master_skill_slugs(client.repo_root());
+
+    if slugs.is_empty() {
+        return Err(anyhow!(
+            "no master-* skills with tests/fidelity.jsonl were found under {:?} \
+             (resolved repo root: {:?}). --baseline must be run from inside a \
+             cloned Master-skill repo (needs prebuilt/ and scripts/test-fidelity.py); \
+             refusing to report a false 0/0 success.",
+            client.repo_root().join("prebuilt"),
+            client.repo_root()
+        ));
+    }
 
     let store_path = desktop_trace_store_path();
     let mut traces = TraceStore::load_from_path(&store_path, TRACE_STORE_CAPACITY)?;

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -137,11 +137,127 @@ impl CliClient {
 
 impl Default for CliClient {
     fn default() -> Self {
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let repo_root = manifest_dir
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or(manifest_dir);
-        Self::new(repo_root)
+        Self::new(resolve_repo_root())
+    }
+}
+
+/// Resolves the Master-skill repo root a released binary should treat as
+/// its working repo.
+///
+/// Contract: a `master-skill-desktop` binary downloaded from GitHub
+/// Releases must be run from inside a clone of the Master-skill repo (the
+/// README says as much). `env!("CARGO_MANIFEST_DIR")` is a *compile-time*
+/// constant baked in by whichever machine built the binary (e.g. a GitHub
+/// Actions runner) — on a user's machine that path almost never exists, so
+/// it cannot be used directly to find the repo the binary is actually
+/// running from.
+///
+/// Instead this walks upward from the current working directory looking
+/// for the first ancestor (inclusive) that looks like a Master-skill repo
+/// root: one containing both a `prebuilt/` directory and a
+/// `scripts/test-fidelity.py` file. First match wins.
+///
+/// If no ancestor qualifies (or the current directory can't be read),
+/// falls back to the compile-time `CARGO_MANIFEST_DIR`-based path so
+/// `cargo run` / `cargo test` source builds and other dev workflows keep
+/// behaving exactly as they did before runtime resolution was added.
+fn resolve_repo_root() -> PathBuf {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| find_repo_root_from(&cwd))
+        .unwrap_or_else(compile_time_repo_root)
+}
+
+/// The compile-time fallback: the parent of `desktop/` (this crate's
+/// `CARGO_MANIFEST_DIR`), i.e. the repo root as seen by whatever machine
+/// built this binary.
+fn compile_time_repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(manifest_dir)
+}
+
+/// Walks upward from `start` (inclusive), returning the first ancestor
+/// that contains both a `prebuilt/` directory and a
+/// `scripts/test-fidelity.py` file, or `None` if no ancestor qualifies.
+fn find_repo_root_from(start: &Path) -> Option<PathBuf> {
+    let mut candidate = Some(start);
+    while let Some(dir) = candidate {
+        if dir.join("prebuilt").is_dir() && dir.join("scripts").join("test-fidelity.py").is_file() {
+            return Some(dir.to_path_buf());
+        }
+        candidate = dir.parent();
+    }
+    None
+}
+
+#[cfg(test)]
+mod resolve_repo_root_tests {
+    use super::find_repo_root_from;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "master-skill-desktop-resolve-root-{label}-{suffix}"
+        ))
+    }
+
+    /// Builds `<root>/prebuilt` and `<root>/scripts/test-fidelity.py` so
+    /// `root` satisfies the repo-root marker check.
+    fn make_repo_markers(root: &std::path::Path) {
+        fs::create_dir_all(root.join("prebuilt")).unwrap();
+        fs::create_dir_all(root.join("scripts")).unwrap();
+        fs::write(root.join("scripts").join("test-fidelity.py"), "# stub\n").unwrap();
+    }
+
+    #[test]
+    fn finds_repo_root_by_walking_up_from_a_nested_subdirectory() {
+        let root = temp_dir("nested");
+        make_repo_markers(&root);
+        let nested = root.join("desktop").join("target").join("debug");
+        fs::create_dir_all(&nested).unwrap();
+
+        let found = find_repo_root_from(&nested);
+
+        assert_eq!(found, Some(root.clone()));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn matches_the_starting_directory_itself_when_it_has_both_markers() {
+        let root = temp_dir("self-match");
+        make_repo_markers(&root);
+
+        let found = find_repo_root_from(&root);
+
+        assert_eq!(found, Some(root.clone()));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn returns_none_when_no_ancestor_has_both_markers() {
+        let root = temp_dir("no-markers");
+        let nested = root.join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+
+        // Only a `prebuilt/` dir, no `scripts/test-fidelity.py` — must not
+        // match on a partial marker set.
+        fs::create_dir_all(root.join("prebuilt")).unwrap();
+
+        let found = find_repo_root_from(&nested);
+
+        assert_eq!(found, None);
+
+        fs::remove_dir_all(&root).ok();
     }
 }

--- a/desktop/tests/baseline_cli.rs
+++ b/desktop/tests/baseline_cli.rs
@@ -153,3 +153,72 @@ fn baseline_flag_runs_headless_and_records_traces_for_all_master_skills() {
 
     fs::remove_dir_all(&xdg_data_home).ok();
 }
+
+/// Builds a directory that *looks* like a Master-skill repo root to the
+/// runtime resolver (has `prebuilt/` and `scripts/test-fidelity.py`) but
+/// has no `master-*` skills under `prebuilt/`. This is how a released
+/// binary run outside a real clone behaves once repo-root resolution is
+/// runtime-based: `find_repo_root_from` can match an ancestor that merely
+/// has the two marker paths (e.g. a stray/incomplete checkout) while
+/// discovering zero skills underneath it.
+///
+/// A literal, fully empty `cwd` is deliberately *not* used here: this
+/// integration test runs the locally built `cargo test` binary, whose
+/// compile-time `CARGO_MANIFEST_DIR` fallback always points at this very
+/// dev checkout (which does have real `prebuilt/` skills). Walking up from
+/// a marker-less empty directory would find nothing and fall through to
+/// that fallback by design (see `resolve_repo_root`'s doc comment in
+/// `src/cli.rs`) — masking the bug this test exists to catch. Planting the
+/// markers directly in `cwd` makes discovery genuinely, deterministically
+/// empty regardless of which machine built the test binary.
+fn empty_master_skill_repo_dir(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("master-skill-desktop-empty-repo-{label}-{suffix}"));
+    fs::create_dir_all(root.join("prebuilt")).unwrap();
+    fs::create_dir_all(root.join("scripts")).unwrap();
+    fs::write(root.join("scripts").join("test-fidelity.py"), "# stub\n").unwrap();
+    root
+}
+
+#[test]
+fn baseline_flag_with_no_discovered_skills_fails_loudly_instead_of_reporting_zero_of_zero() {
+    let empty_repo = empty_master_skill_repo_dir("baseline");
+    let xdg_data_home = temp_xdg_data_home();
+    fs::create_dir_all(&xdg_data_home).unwrap();
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_master-skill-desktop"));
+    command
+        .arg("--baseline")
+        .current_dir(&empty_repo)
+        .env("XDG_DATA_HOME", &xdg_data_home);
+
+    let output = run_with_timeout(command, Duration::from_secs(30));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(
+        !output.status.success(),
+        "expected a nonzero exit when no master skills are discovered under the \
+         resolved repo root, got {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
+    assert!(
+        !stdout.contains("baseline: 0/0 ok"),
+        "must never silently report a false 0/0 success, got stdout:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("cloned Master-skill repo"),
+        "expected a clear error naming the cloned-repo requirement, got stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&empty_repo.to_string_lossy().to_string()),
+        "expected the error to name the resolved repo-root path {empty_repo:?}, got stderr:\n{stderr}"
+    );
+
+    fs::remove_dir_all(&empty_repo).ok();
+    fs::remove_dir_all(&xdg_data_home).ok();
+}

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "master-skill",
   "description": "FoJin-powered Buddhist AI persona framework — source-grounded, boundary-aware, fidelity-tested, runtime-ready. 15 prebuilt masters across 印度/汉传/藏传/南传.",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-skill",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "description": "FoJin-powered Buddhist AI persona framework — source-grounded, boundary-aware, fidelity-tested, runtime-ready. 15 pre-built masters across 印度 / 汉传 / 藏传 / 南传, plus /compare-masters, /master-debate, and /master-curriculum.",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumped version 0.9.1 → 0.10.0 across all 5 manifest files
- Restructured CHANGELOG.md: created [0.10.0] - 2026-07-10 section and moved all Unreleased content under it
- Updated CHANGELOG link references to include all released versions

## Test plan
- ✅ python3 scripts/check-manifest-versions.py (all 5 manifests agree on 0.10.0)
- ✅ npm test (25 CLI tests passed, all validations passed)
- ✅ No files modified outside scope (.version-bump.json, desktop/Cargo.toml unchanged)

Generated with [Claude Code](https://claude.com/claude-code)