### PR TITLE
ci: gate npm publish on the full suite

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,7 +42,49 @@ permissions:
   id-token: write
 
 jobs:
+  # Nothing gated `publish` before v0.10.1: it ran on `release: published`
+  # with no `needs:`, so a red tag published anyway — and npm publishes are
+  # permanent, with no token to revoke under OIDC. Validate & Test runs on
+  # push, but a release is its own event and never waited for it. Re-run the
+  # suites here rather than inspect the tag's check-runs: this also covers
+  # workflow_dispatch, where no push run need exist at all. Releases are rare,
+  # so the duplicated minutes are worth a gate that cannot be skipped.
+  gate:
+    name: Full suite (publish gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest
+
+      # Validators, the fidelity dry-run, and the node suite — which packs a
+      # real tarball, installs it, deletes the extracted source and exercises
+      # what is left. That is the artifact this workflow is about to publish.
+      - name: npm test
+        run: npm test
+
+      # Not in `npm test`: the hooks ship in the tarball, and the wrapper
+      # hung on every Unix install for all of v0.10.0 with nothing to catch it.
+      - name: Hook suites
+        run: npm run test:hook
+
+      # Not in `npm test` either: scripts/ and tools/ ship too.
+      - name: Python suites
+        run: python -m pytest tests/ scripts/tests/ -v
+
   publish:
+    needs: gate
     runs-on: ubuntu-latest
     environment:
       name: npm


### PR DESCRIPTION
## Summary

`jobs.publish` had no `needs:`. It triggers on `release: published` — its own event, which never waited for Validate & Test — so a release cut from a red tag would publish anyway. Under OIDC Trusted Publishing there is no token to revoke afterwards, and an npm version is permanent once taken. v0.10.1 shipped green only because main's CI was watched by hand before the release was created.

## What this changes

Adds a `gate` job and makes `publish` depend on it.

The gate re-runs the suites rather than inspecting the tag's check-runs. That also covers `workflow_dispatch`, where no push run need exist at all. Releases are rare — nine in three months — so the duplicated minutes buy a gate that cannot be skipped.

It runs:

- `npm test` — validators, the fidelity dry-run, and the node suite, which packs a real tarball, installs it, deletes the extracted source and exercises what is left. That is the artifact this workflow is about to publish.
- `npm run test:hook` — not in `npm test`. The hooks ship in the tarball, and the wrapper hung on every Unix install for all of v0.10.0 with nothing to catch it.
- `pytest tests/ scripts/tests/` — not in `npm test` either. `scripts/` and `tools/` ship too.

## Validation

- YAML parses; `publish.needs` resolves to `gate`.
- All three gate steps pass locally: `npm test`, `npm run test:hook`, 361 pytest.
- Verified on a real run rather than by reading the file — see the comment below.

## Note

`Verify CLI is executable` in the publish job is now redundant: it runs `node bin/cli.mjs list` against the checkout, where `prebuilt/` is present by construction, while the gate exercises the same entrypoint from an installed tarball. Left in place; removing it is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)