### PR TITLE
fix: parse frontmatter with pyyaml, and run the curriculum gate that claimed to be running

### DIFF
--- a/prebuilt/master-curriculum/SKILL.md
+++ b/prebuilt/master-curriculum/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: master-curriculum
-description: Use when user asks for a sequenced learning path within a Buddhist tradition — 学修次第, 先学什么, 从哪入门, 下一步读什么, curriculum, 学习计划, 路径推荐. Differs from /compare-masters (parallel opinion) and /master-debate (adversarial dialectic) by being 纵向 / 时序: stage-by-stage plan keyed on tradition × level (L0-L3) → foundation → intermediate → advanced + blind spots. Trigger is planning intent — "禅宗对比" goes to /compare-masters; "禅宗从哪开始学" goes here.
+description: 'Use when user asks for a sequenced learning path within a Buddhist tradition — 学修次第, 先学什么, 从哪入门, 下一步读什么, curriculum, 学习计划, 路径推荐. Differs from /compare-masters (parallel opinion) and /master-debate (adversarial dialectic) by being 纵向 / 时序: stage-by-stage plan keyed on tradition × level (L0-L3) → foundation → intermediate → advanced + blind spots. Trigger is planning intent — "禅宗对比" goes to /compare-masters; "禅宗从哪开始学" goes here.'
 version: 0.7.0
 license: MIT
 kind: meta-skill

--- a/prebuilt/master-debate/SKILL.md
+++ b/prebuilt/master-debate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: master-debate
-description: Use when user explicitly asks for an adversarial / multi-round dialectic between masters — 祖师辩论, 各执一词, 谁更对, debate, 应成 vs 顿悟, 顿渐之争. Differs from /compare-masters (parallel single-round) by being adversarial multi-round via fresh-subagent orchestration. Topics 空有 / 禅净 / 性相 / 戒律 vs 内观 — trigger is adversarial framing: "禅净比较" → compare; "禅净辩论 / 谁更究竟" → here.
+description: 'Use when user explicitly asks for an adversarial / multi-round dialectic between masters — 祖师辩论, 各执一词, 谁更对, debate, 应成 vs 顿悟, 顿渐之争. Differs from /compare-masters (parallel single-round) by being adversarial multi-round via fresh-subagent orchestration. Topics 空有 / 禅净 / 性相 / 戒律 vs 内观 — trigger is adversarial framing: "禅净比较" → compare; "禅净辩论 / 谁更究竟" → here.'
 version: 0.8.0
 license: MIT
 kind: meta-skill

--- a/scripts/tests/test_validate.py
+++ b/scripts/tests/test_validate.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/validate.py — the strict gate `npm run validate` runs.
+
+parse_frontmatter had no tests, which is how it kept only the last entry of
+`sources:` and dropped every `cbeta_id`. The sources[] checks in lint_master
+were reading a shape the file never had.
+"""
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "validate.py"
+SPEC = importlib.util.spec_from_file_location("validate_module", MODULE_PATH)
+validate_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_module)
+
+parse_frontmatter = validate_module.parse_frontmatter
+
+FRONTMATTER = """---
+name: master-test
+description: Test master.
+version: 0.5.0
+license: MIT
+lineage: 测试宗
+dates: 638-713
+sources:
+  - title: 六祖大师法宝坛经
+    cbeta_id: T48n2008
+    fojin_text_id: 58
+  - title: 金刚般若波罗蜜经
+    cbeta_id: T08n0235
+    fojin_text_id: 7
+  - title: 维摩诘所说经
+    cbeta_id: T14n0475
+    fojin_text_id: 28
+citation_format: "【《{title}》{section}，{cbeta_id}】"
+verified_by: xr843
+verified_at: 2026-04-06
+---
+
+# Body
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "SKILL.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_parse_frontmatter_keeps_every_source(tmp_path):
+    """All three declared sources survive, not just the last one."""
+    fm, _, _ = parse_frontmatter(_write(tmp_path, FRONTMATTER))
+
+    titles = [s["title"] for s in fm["sources"]]
+    assert titles == ["六祖大师法宝坛经", "金刚般若波罗蜜经", "维摩诘所说经"]
+
+
+def test_parse_frontmatter_keeps_continuation_keys(tmp_path):
+    """cbeta_id and fojin_text_id sit on continuation lines and must survive.
+
+    Every citation check downstream keys off cbeta_id; dropping it silently
+    empties the data the sources[] rules are supposed to inspect.
+    """
+    fm, _, _ = parse_frontmatter(_write(tmp_path, FRONTMATTER))
+
+    assert [s.get("cbeta_id") for s in fm["sources"]] == [
+        "T48n2008",
+        "T08n0235",
+        "T14n0475",
+    ]
+    assert fm["sources"][0].get("fojin_text_id") == 58
+
+
+def test_parse_frontmatter_reads_scalar_keys(tmp_path):
+    """Scalar keys around the list keep working."""
+    fm, _, _ = parse_frontmatter(_write(tmp_path, FRONTMATTER))
+
+    assert fm["name"] == "master-test"
+    assert fm["lineage"] == "测试宗"
+    assert fm["citation_format"] == "【《{title}》{section}，{cbeta_id}】"
+
+
+def test_parse_frontmatter_surfaces_a_malformed_source_before_the_last(tmp_path):
+    """A source with neither title nor cbeta_id must reach lint_master.
+
+    lint_master flags `sources[i] missing 'title' or 'cbeta_id'`, but only
+    ever saw the final entry — a malformed one anywhere earlier was invisible.
+    """
+    text = FRONTMATTER.replace(
+        "  - title: 六祖大师法宝坛经\n    cbeta_id: T48n2008\n    fojin_text_id: 58\n",
+        "  - fojin_text_id: 58\n    note: no title and no cbeta_id\n",
+    )
+    fm, _, _ = parse_frontmatter(_write(tmp_path, text))
+
+    assert len(fm["sources"]) == 3
+    bad = fm["sources"][0]
+    assert "title" not in bad and "cbeta_id" not in bad
+
+
+def test_parse_frontmatter_without_frontmatter(tmp_path):
+    """A file with no frontmatter yields an empty dict, not a crash."""
+    fm, body, _ = parse_frontmatter(_write(tmp_path, "# Just a body\n"))
+
+    assert fm == {}
+    assert "Just a body" in body
+
+
+def test_parse_frontmatter_rejects_invalid_yaml(tmp_path):
+    """Malformed frontmatter raises instead of being silently mis-parsed.
+
+    The old parser accepted anything, which let two skills ship a description
+    holding a bare `: ` — YAML reads that as a nested mapping and rejects the
+    whole block. Clients that parse frontmatter strictly see no frontmatter
+    at all, so this must fail loudly here.
+    """
+    text = "---\nname: master-test\ndescription: keyed on 时序: staged plan\n---\n"
+    try:
+        parse_frontmatter(_write(tmp_path, text))
+    except ValueError as exc:
+        assert "invalid YAML frontmatter" in str(exc)
+    else:
+        raise AssertionError("invalid YAML frontmatter was accepted")
+
+
+def test_every_prebuilt_skill_has_parseable_frontmatter():
+    """Every shipped SKILL.md must parse — this is the case that would have
+    caught master-curriculum and master-debate before they shipped."""
+    prebuilt = Path(__file__).resolve().parents[2] / "prebuilt"
+    skills = sorted(prebuilt.glob("*/SKILL.md"))
+    assert skills, f"no SKILL.md found under {prebuilt}"
+
+    for skill in skills:
+        fm, _, _ = parse_frontmatter(skill)
+        assert fm.get("name"), f"{skill.parent.name}: frontmatter has no name"

--- a/scripts/tests/test_validate.py
+++ b/scripts/tests/test_validate.py
@@ -122,6 +122,17 @@ def test_parse_frontmatter_rejects_invalid_yaml(tmp_path):
         raise AssertionError("invalid YAML frontmatter was accepted")
 
 
+def test_curriculum_sources_subcheck_is_wired_in():
+    """The curriculum gate must be reachable from validate.py.
+
+    master-curriculum/SKILL.md claims CI enforces it, but the script was in no
+    workflow, no npm script and no sub-check — only unit tests over synthetic
+    trees. It passed against the real references/ by luck, never by check.
+    """
+    assert hasattr(validate_module, "_run_curriculum_sources_subcheck")
+    assert validate_module._run_curriculum_sources_subcheck() == []
+
+
 def test_every_prebuilt_skill_has_parseable_frontmatter():
     """Every shipped SKILL.md must parse — this is the case that would have
     caught master-curriculum and master-debate before they shipped."""

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -254,6 +254,32 @@ def _run_promptfoo_configs_subcheck() -> list[str]:
         return [f"promptfoo-configs sub-check failed to run: {exc}"]
 
 
+def _run_curriculum_sources_subcheck() -> list[str]:
+    """Run the curriculum source validator as a sub-check.
+
+    master-curriculum/SKILL.md claims CI enforces this, but the script was
+    wired into no workflow, no npm script and no sub-check — only its own unit
+    tests, which build synthetic trees under tmp_path. It has never run against
+    the real references/, so a curriculum recommending a sutra no master
+    declares would have shipped unnoticed. Returns a list of error strings.
+    """
+    curriculum_dir = PREBUILT_DIR / "master-curriculum"
+    if not curriculum_dir.exists():
+        return []
+    try:
+        import importlib.util
+
+        spec_path = (
+            Path(__file__).resolve().parent / "validate-curriculum-sources.py"
+        )
+        spec = importlib.util.spec_from_file_location("vcs", spec_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.validate(PREBUILT_DIR)
+    except Exception as exc:  # pragma: no cover — surfaces to user
+        return [f"curriculum-sources sub-check failed to run: {exc}"]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Master-skill SKILL.md linter")
     parser.add_argument("--master", type=str, help="Lint a specific master only")
@@ -273,6 +299,11 @@ def main():
         "--skip-manifest-versions",
         action="store_true",
         help="Skip the v0.8 manifest version-drift gate",
+    )
+    parser.add_argument(
+        "--skip-curriculum-sources",
+        action="store_true",
+        help="Skip the curriculum source gate",
     )
     parser.add_argument(
         "--skip-lore-triggers-content",
@@ -320,6 +351,13 @@ def main():
         if manifest_errors:
             has_errors = True
 
+    # --- curriculum source gate (full-tree only, HARD gate) ---
+    curriculum_errors: list[str] = []
+    if not args.master and not args.skip_curriculum_sources:
+        curriculum_errors = _run_curriculum_sources_subcheck()
+        if curriculum_errors:
+            has_errors = True
+
     # --- v0.8 lore_triggers-content advisory sub-check ---
     # ADVISORY ONLY: warnings printed but never affect has_errors.
     lore_warnings: list[str] = []
@@ -334,6 +372,8 @@ def main():
             out["promptfoo_configs"] = promptfoo_errors
         if manifest_errors:
             out["manifest_versions"] = manifest_errors
+        if curriculum_errors:
+            out["curriculum_sources"] = curriculum_errors
         if lore_warnings:
             out["lore_triggers_content_advisory"] = lore_warnings
         print(json.dumps(out, indent=2, ensure_ascii=False))
@@ -343,6 +383,7 @@ def main():
             and not persona_errors
             and not promptfoo_errors
             and not manifest_errors
+            and not curriculum_errors
             and not lore_warnings
         )
         if nothing_to_report:
@@ -366,6 +407,11 @@ def main():
                 print("Manifest version-drift gate (v0.8):")
                 for e in manifest_errors:
                     print(f"  [ERROR] {e}")
+            if curriculum_errors:
+                print()
+                print("Curriculum source gate:")
+                for e in curriculum_errors:
+                    print(f"  [ERROR] {e}")
             if lore_warnings:
                 print()
                 print(
@@ -381,6 +427,7 @@ def main():
                 len(persona_errors)
                 + len(promptfoo_errors)
                 + len(manifest_errors)
+                + len(curriculum_errors)
             )
             total_warns += len(lore_warnings)
             print(

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
+
+import yaml
 
 PREBUILT_DIR = Path(__file__).resolve().parent.parent / "prebuilt"
 
@@ -48,41 +49,20 @@ def parse_frontmatter(path: Path) -> tuple[dict, str, list[str]]:
     if end is None:
         return {}, text, lines
 
-    # Minimal YAML parse (no pyyaml dependency)
-    fm: dict = {}
-    current_key = None
-    current_list: list | None = None
-    for line in lines[1:end]:
-        # list item
-        if line.startswith("  - ") and current_key:
-            if current_list is None:
-                current_list = []
-            item = line.strip().lstrip("- ").strip()
-            # Try inline dict (title: xxx)
-            if ":" in item:
-                parts = item.split(":", 1)
-                if current_list and isinstance(current_list[-1], dict):
-                    current_list[-1][parts[0].strip()] = parts[1].strip()
-                else:
-                    current_list.append({parts[0].strip(): parts[1].strip()})
-            else:
-                current_list.append(item)
-            continue
-        # Save accumulated list
-        if current_list is not None and current_key:
-            fm[current_key] = current_list
-            current_list = None
-        # key: value
-        match = re.match(r"^(\w[\w_-]*):\s*(.*)", line)
-        if match:
-            current_key = match.group(1)
-            value = match.group(2).strip().strip('"').strip("'")
-            if value:
-                fm[current_key] = value
-            # If empty value, might be a list starting next line
-    # Flush last list
-    if current_list is not None and current_key:
-        fm[current_key] = current_list
+    # This was a hand-rolled parser, from back when pyyaml was not a
+    # dependency. It matched list items only as `  - `, so a 4-space
+    # continuation line like `    cbeta_id: T48n2008` matched neither that nor
+    # the `key:` regex (which is anchored at column 0) and fell through to the
+    # list-flush branch — clearing the accumulated list on every continuation
+    # and letting the next `  - ` overwrite it. Every master kept exactly one
+    # source and no cbeta_id at all, so the sources[] rules below inspected
+    # data that was never in the file.
+    try:
+        fm = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: invalid YAML frontmatter — {exc}") from exc
+    if not isinstance(fm, dict):
+        raise ValueError(f"{path}: frontmatter is not a mapping")
 
     body = "\n".join(lines[end + 1 :])
     return fm, body, lines


### PR DESCRIPTION
## Summary

Two validator gaps from the audit, plus a content bug the first one surfaced.

### `parse_frontmatter` was dropping most of `sources:`

It was hand-rolled from when pyyaml was not a dependency. List items matched only as `  - `, so a 4-space continuation line like `    cbeta_id: T48n2008` matched neither that nor the `key:` regex (anchored at column 0) and fell through to the list-flush branch — clearing the accumulated list on every continuation and letting the next `  - ` overwrite it.

master-huineng declares three sources with three cbeta_ids:

```
sources = [{'title': '维摩诘所说经'}]
```

Two sources gone, every `cbeta_id` gone. So `lint_master`'s `sources[i] missing 'title' or 'cbeta_id'` only ever inspected the last entry — a malformed one anywhere earlier was invisible. pyyaml has been in `requirements.txt` since v0.8, and `validate-promptfoo-configs.py` already imports it.

### Which surfaced two shipped skills whose frontmatter is not valid YAML

`master-curriculum` and `master-debate` each hold a bare `: ` inside an unquoted description (`时序: stage-by-stage`, `framing: "禅净比较"`). YAML reads that as a nested mapping and rejects it, taking the whole frontmatter with it — **2 of 18 shipped SKILL.md files do not parse**. The old parser split on the first colon and never noticed. Both contain double quotes and no single quotes, so single quotes wrap them without touching the text; verified byte-identical to what the frontmatter declared before.

### The curriculum gate was never wired to anything

`prebuilt/master-curriculum/SKILL.md` states that CI enforces every CBETA/SC/Toh id in the curriculum to exist in some master's `meta.json`, via `validate-curriculum-sources.py`. That script was in no workflow, no npm script and no sub-check — only its own unit tests, which build synthetic trees under `tmp_path`. It had never run against the real `references/`. It passes today by luck, not by check. Now validate.py's fifth sub-check, matching the other four, so one hookup covers `npm run validate` and the CI step already running `validate.py --strict`.

## Validation

Each commit is independently green — `validate.py --strict` passes and `scripts/tests/` grows 174 → 181 → 182:

| commit | validate --strict | scripts/tests |
|---|---|---|
| quote the two descriptions | PASS | 174 |
| pyyaml parser + first tests for validate.py | PASS | 181 |
| wire the curriculum gate | PASS | 182 |

Both new gates were checked for teeth rather than trusted:

- Removing the quotes again fails `test_every_prebuilt_skill_has_parseable_frontmatter`.
- Injecting `T99n9999` into `prebuilt/master-curriculum/references/chan.md` makes `validate.py --strict` **exit 1** and name the id. (Checked on the exit code directly — piping through `tail` reports the pipe's status, not the validator's.)

Full suite: 369 pytest, `npm test`, `npm run test:cli`, `npm run test:hook`, and all four other validators pass.

`validate.py` had no tests at all before this — which is how a parser this broken survived as the repo's strict gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)