### PR TITLE
fix(desktop): make evaluation evidence explicit and fail closed

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -974,14 +974,17 @@ impl MasterSkillApp {
                 healthy: summary.missing_suite_count == 0,
             },
             MetricCard {
-                title: "Run Coverage",
-                value: gate.run_coverage.label(),
-                detail: format!(
-                    "{} dry-run / {} graded",
-                    gate.run_coverage.dry_run_count, gate.run_coverage.graded_count
-                ),
-                healthy: summary.skill_count > 0
-                    && gate.run_coverage.run_skill_count == summary.skill_count,
+                title: "Structural Coverage",
+                value: gate.run_coverage.structural_label(),
+                detail: format!("{} latest dry-run", gate.run_coverage.dry_run_skill_count),
+                healthy: gate.run_coverage.is_structurally_complete(),
+            },
+            MetricCard {
+                title: "Graded Coverage",
+                value: gate.run_coverage.graded_label(),
+                detail: format!("{} current error(s)", gate.run_coverage.current_error_count),
+                healthy: gate.run_coverage.is_graded_complete()
+                    && gate.run_coverage.current_error_count == 0,
             },
             MetricCard {
                 title: "Ready",
@@ -1269,11 +1272,7 @@ impl MasterSkillApp {
             MetricCard {
                 title: "Pass Rate",
                 value: insights.pass_rate_label(),
-                detail: format!(
-                    "{} graded / {} dry-run",
-                    insights.graded_cases(),
-                    insights.dry_run_cases
-                ),
+                detail: format!("{} graded case(s)", insights.graded_cases()),
                 healthy: insights.failed_cases == 0,
             },
             MetricCard {
@@ -1292,7 +1291,7 @@ impl MasterSkillApp {
         Self::show_metric_cards(ui, &cards);
 
         if insights.total_cases == 0 {
-            ui.small("Run a fidelity dry-run with JSON output to populate case-level insights.");
+            ui.small("No graded case evidence is available. Attach a graded fidelity result to populate behavioral insights.");
             return;
         }
 
@@ -2632,7 +2631,7 @@ mod tests {
             snapshot.decision_brief.posture,
             EvaluationDecisionPosture::Attention
         );
-        assert_eq!(snapshot.run_coverage.label(), "1/1");
+        assert_eq!(snapshot.run_coverage.structural_label(), "1/1");
         assert_eq!(snapshot.failure_insights.failed_cases, 1);
         assert_eq!(snapshot.failure_queue.len(), 1);
         assert_eq!(snapshot.all_run_history.len(), 2);

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -108,7 +108,9 @@ fn suite_matches_filter(
         SuiteFilter::Missing => row.quality_level() == QualityLevel::Missing,
         SuiteFilter::NotRun => latest_result.is_none(),
         SuiteFilter::FailedRun => latest_result.is_some_and(|result| {
-            !result.dry_run && result.total_count > 0 && result.passed_count < result.total_count
+            !result.is_dry_run()
+                && result.total_count > 0
+                && result.passed_count < result.total_count
         }),
     }
 }
@@ -1447,7 +1449,7 @@ impl MasterSkillApp {
                                         Self::evaluation_trend_color(item.trend),
                                         item.trend.label(),
                                     );
-                                    ui.label(if item.dry_run { "dry-run" } else { "graded" });
+                                    ui.label(item.mode.label());
                                     ui.label(
                                         item.duration_ms
                                             .map(|duration| format!("{duration} ms"))
@@ -2112,14 +2114,14 @@ impl MasterSkillApp {
                             ui.label(case.citation_assertion_count.to_string());
                             ui.label(case.keyword_assertion_count.to_string());
                             if let Some(result) = case_results.get(&case.index) {
-                                ui.label(result.status.as_str());
+                                ui.label(result.status.label());
                                 ui.label(result.failure_summary());
                             } else {
                                 ui.label(
                                     latest_result
                                         .as_ref()
                                         .map(|result| {
-                                            if result.dry_run {
+                                            if result.is_dry_run() {
                                                 "N/A dry-run".to_string()
                                             } else {
                                                 result.label()
@@ -2466,7 +2468,7 @@ mod tests {
     use crate::catalog::{SkillKind, SkillRow};
     use crate::trace::{
         EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
-        EvaluationRunResult, TraceAction, TraceStore,
+        EvaluationMode, EvaluationRunResult, TraceAction, TraceStore,
     };
     use std::time::Duration;
 
@@ -2496,14 +2498,14 @@ mod tests {
             slug: "huineng".to_string(),
             passed_count: 12,
             total_count: 12,
-            dry_run: false,
+            mode: EvaluationMode::Graded,
             trace_id: 1,
         };
         let failed_run = EvaluationRunResult {
             slug: "zhiyi".to_string(),
             passed_count: 8,
             total_count: 10,
-            dry_run: false,
+            mode: EvaluationMode::Graded,
             trace_id: 2,
         };
 
@@ -2602,7 +2604,7 @@ mod tests {
         traces.finish_success_with_detail(
             run,
             "master-huineng fidelity dry-run finished",
-            r#"[{"master": "master-huineng", "results": [
+            r#"[{"master": "master-huineng", "passed": 1, "results": [
               {"index": 0, "question": "通过", "status": "PASS"},
               {"index": 1, "question": "失败", "status": "FAIL"}
             ]}]"#,

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -99,6 +99,7 @@ impl EvaluationWindow {
 fn suite_matches_filter(
     row: &SkillRow,
     latest_result: Option<&EvaluationRunResult>,
+    latest_graded_result: Option<&EvaluationRunResult>,
     filter: SuiteFilter,
 ) -> bool {
     match filter {
@@ -107,7 +108,7 @@ fn suite_matches_filter(
         SuiteFilter::Attention => row.quality_level() == QualityLevel::Attention,
         SuiteFilter::Missing => row.quality_level() == QualityLevel::Missing,
         SuiteFilter::NotRun => latest_result.is_none(),
-        SuiteFilter::FailedRun => latest_result.is_some_and(|result| {
+        SuiteFilter::FailedRun => latest_graded_result.is_some_and(|result| {
             !result.is_dry_run()
                 && result.total_count > 0
                 && result.passed_count < result.total_count
@@ -1521,6 +1522,12 @@ impl MasterSkillApp {
             .into_iter()
             .map(|result| (result.slug.clone(), result))
             .collect();
+        let latest_graded_results: BTreeMap<_, _> = self
+            .traces
+            .latest_graded_evaluation_results_by_slug()
+            .into_iter()
+            .map(|result| (result.slug.clone(), result))
+            .collect();
         ui.horizontal_wrapped(|ui| {
             ui.label("Filter");
             for filter in [
@@ -1543,8 +1550,12 @@ impl MasterSkillApp {
             .clone()
             .into_iter()
             .filter(|row| {
-                suite_matches_filter(row, latest_results.get(&row.slug), self.suite_filter)
-                    && suite_matches_query(row, &self.suite_query)
+                suite_matches_filter(
+                    row,
+                    latest_results.get(&row.slug),
+                    latest_graded_results.get(&row.slug),
+                    self.suite_filter,
+                ) && suite_matches_query(row, &self.suite_query)
             })
             .collect();
         if rows.is_empty() {
@@ -2507,34 +2518,47 @@ mod tests {
             mode: EvaluationMode::Graded,
             trace_id: 2,
         };
+        let later_dry_run = EvaluationRunResult {
+            slug: "zhiyi".to_string(),
+            passed_count: 0,
+            total_count: 10,
+            mode: EvaluationMode::DryRun,
+            trace_id: 3,
+        };
 
         assert!(super::suite_matches_filter(
             &ready,
+            Some(&passing_run),
             Some(&passing_run),
             super::SuiteFilter::Ready
         ));
         assert!(super::suite_matches_filter(
             &attention,
+            Some(&later_dry_run),
             Some(&failed_run),
             super::SuiteFilter::Attention
         ));
         assert!(super::suite_matches_filter(
             &missing,
             None,
+            None,
             super::SuiteFilter::Missing
         ));
         assert!(super::suite_matches_filter(
             &missing,
             None,
+            None,
             super::SuiteFilter::NotRun
         ));
         assert!(super::suite_matches_filter(
             &attention,
+            Some(&later_dry_run),
             Some(&failed_run),
             super::SuiteFilter::FailedRun
         ));
         assert!(!super::suite_matches_filter(
             &ready,
+            Some(&passing_run),
             Some(&passing_run),
             super::SuiteFilter::FailedRun
         ));

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -2706,6 +2706,7 @@ mod tests {
             has_citation_format: complete_contract,
             fidelity_case_count: case_count,
             fidelity_cases: Vec::new(),
+            fidelity_error: None,
             source_index_present: complete_contract,
             kind: SkillKind::Persona,
         }

--- a/desktop/src/catalog.rs
+++ b/desktop/src/catalog.rs
@@ -66,6 +66,7 @@ impl FidelityCase {
 pub struct SkillDiagnostics {
     pub fidelity_case_count: usize,
     pub fidelity_cases: Vec<FidelityCase>,
+    pub fidelity_error: Option<String>,
     pub source_index_present: bool,
     pub kind: SkillKind,
 }
@@ -74,13 +75,25 @@ impl SkillDiagnostics {
     pub fn from_prebuilt_dir(prebuilt_dir: &Path, slug: &str) -> Self {
         let skill_dir = prebuilt_dir.join(format!("master-{slug}"));
         let fidelity_path = skill_dir.join("tests").join("fidelity.jsonl");
-        let fidelity_cases = fs::read_to_string(fidelity_path)
-            .map(|content| parse_fidelity_cases(&content))
-            .unwrap_or_default();
+        let (fidelity_cases, fidelity_error) = match fs::read_to_string(&fidelity_path) {
+            Ok(content) => match parse_fidelity_cases(&content) {
+                Ok(cases) => (cases, None),
+                Err(error) => (Vec::new(), Some(error)),
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (Vec::new(), None),
+            Err(error) => (
+                Vec::new(),
+                Some(format!(
+                    "failed to read {}: {error}",
+                    fidelity_path.display()
+                )),
+            ),
+        };
 
         Self {
             fidelity_case_count: fidelity_cases.len(),
             fidelity_cases,
+            fidelity_error,
             source_index_present: skill_dir.join("sources").join("INDEX.md").is_file(),
             kind: detect_skill_kind(&skill_dir),
         }
@@ -106,39 +119,49 @@ fn detect_skill_kind(skill_dir: &Path) -> SkillKind {
     }
 }
 
-fn parse_fidelity_cases(content: &str) -> Vec<FidelityCase> {
-    content
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .enumerate()
-        .map(|(index, line)| {
-            let value = serde_json::from_str::<serde_json::Value>(line).unwrap_or_default();
-            FidelityCase {
-                index: index + 1,
-                question: value
-                    .get("q")
-                    .or_else(|| value.get("prompt"))
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("untitled case")
-                    .to_string(),
-                difficulty: value
-                    .get("difficulty")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
-                citation_assertion_count: json_array_len(&value, "must_cite"),
-                keyword_assertion_count: json_array_len(&value, "must_mention"),
-                structure_assertion_count: json_array_len(&value, "must_select_pair")
-                    + json_array_len(&value, "must_have_rounds")
-                    + json_array_len(&value, "must_have_sections")
-                    + usize::from(
-                        value
-                            .get("must_cite_per_round")
-                            .and_then(serde_json::Value::as_bool)
-                            .unwrap_or(false),
-                    ),
-            }
-        })
-        .collect()
+fn parse_fidelity_cases(content: &str) -> Result<Vec<FidelityCase>, String> {
+    let mut cases = Vec::new();
+    for (line_index, line) in content.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value = serde_json::from_str::<serde_json::Value>(line)
+            .map_err(|error| format!("line {}: invalid JSON: {error}", line_index + 1))?;
+        let question = value
+            .get("q")
+            .or_else(|| value.get("prompt"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|question| !question.is_empty())
+            .ok_or_else(|| {
+                format!(
+                    "line {}: expected a non-empty string q or prompt",
+                    line_index + 1
+                )
+            })?;
+
+        cases.push(FidelityCase {
+            index: cases.len() + 1,
+            question: question.to_string(),
+            difficulty: value
+                .get("difficulty")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            citation_assertion_count: json_array_len(&value, "must_cite"),
+            keyword_assertion_count: json_array_len(&value, "must_mention"),
+            structure_assertion_count: json_array_len(&value, "must_select_pair")
+                + json_array_len(&value, "must_have_rounds")
+                + json_array_len(&value, "must_have_sections")
+                + usize::from(
+                    value
+                        .get("must_cite_per_round")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false),
+                ),
+        });
+    }
+
+    Ok(cases)
 }
 
 fn json_array_len(value: &serde_json::Value, key: &str) -> usize {
@@ -179,6 +202,7 @@ pub struct SkillRow {
     pub has_citation_format: bool,
     pub fidelity_case_count: usize,
     pub fidelity_cases: Vec<FidelityCase>,
+    pub fidelity_error: Option<String>,
     pub source_index_present: bool,
     pub kind: SkillKind,
 }
@@ -205,6 +229,7 @@ impl SkillRow {
                 .unwrap_or(false),
             fidelity_case_count: 0,
             fidelity_cases: Vec::new(),
+            fidelity_error: None,
             source_index_present: false,
             kind: SkillKind::Persona,
         }
@@ -217,6 +242,7 @@ impl SkillRow {
     pub fn apply_diagnostics(&mut self, diagnostics: SkillDiagnostics) {
         self.fidelity_case_count = diagnostics.fidelity_case_count;
         self.fidelity_cases = diagnostics.fidelity_cases;
+        self.fidelity_error = diagnostics.fidelity_error;
         self.source_index_present = diagnostics.source_index_present;
         self.kind = diagnostics.kind;
     }
@@ -227,7 +253,7 @@ impl SkillRow {
         }
 
         if self.kind == SkillKind::MetaSkill {
-            return if self.fidelity_case_count > 0 {
+            return if self.fidelity_case_count > 0 && self.fidelity_error.is_none() {
                 QualityLevel::Ready
             } else {
                 QualityLevel::Attention
@@ -239,6 +265,7 @@ impl SkillRow {
             && self.source_index_present
             && self.has_citation_format
             && self.fidelity_case_count > 0
+            && self.fidelity_error.is_none()
         {
             QualityLevel::Ready
         } else {
@@ -246,31 +273,33 @@ impl SkillRow {
         }
     }
 
-    pub fn diagnostic_gaps(&self) -> Vec<&'static str> {
+    pub fn diagnostic_gaps(&self) -> Vec<String> {
         let mut gaps = Vec::new();
 
         if !self.installed {
-            gaps.push("not installed");
+            gaps.push("not installed".to_string());
             return gaps;
         }
 
         if self.kind == SkillKind::Persona {
             if self.source_count == 0 {
-                gaps.push("missing sources");
+                gaps.push("missing sources".to_string());
             }
             if !self.source_index_present {
-                gaps.push("missing source index");
+                gaps.push("missing source index".to_string());
             }
             if !self.has_citation_format {
-                gaps.push("missing citation format");
+                gaps.push("missing citation format".to_string());
             }
             if !self.live_grounding {
-                gaps.push("live grounding off");
+                gaps.push("live grounding off".to_string());
             }
         }
 
-        if self.fidelity_case_count == 0 {
-            gaps.push("missing fidelity suite");
+        if let Some(error) = &self.fidelity_error {
+            gaps.push(format!("invalid fidelity suite: {error}"));
+        } else if self.fidelity_case_count == 0 {
+            gaps.push("missing fidelity suite".to_string());
         }
 
         gaps
@@ -334,7 +363,14 @@ impl SkillRow {
             }
         }
 
-        if self.fidelity_case_count == 0 {
+        if let Some(error) = &self.fidelity_error {
+            actions.push(DiagnosticAction {
+                title: "Repair fidelity suite".to_string(),
+                detail: format!("Fix tests/fidelity.jsonl before running the suite: {error}"),
+                operation: DiagnosticOperation::Manual,
+                command: None,
+            });
+        } else if self.fidelity_case_count == 0 {
             actions.push(DiagnosticAction {
                 title: "Add fidelity suite".to_string(),
                 detail: "Create tests/fidelity.jsonl, then dry-run the suite for this skill."
@@ -564,6 +600,7 @@ mod tests {
             has_citation_format: true,
             fidelity_case_count: 4,
             fidelity_cases: Vec::new(),
+            fidelity_error: None,
             source_index_present: true,
             kind: SkillKind::Persona,
         }
@@ -674,6 +711,44 @@ mod tests {
         assert_eq!(diagnostics.fidelity_cases[0].citation_assertion_count, 2);
         assert_eq!(diagnostics.fidelity_cases[0].keyword_assertion_count, 2);
         assert_eq!(diagnostics.fidelity_cases[0].total_assertion_count(), 4);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn invalid_fidelity_jsonl_fails_closed() {
+        let root = temp_dir();
+        let skill_dir = root.join("master-huineng");
+        fs::create_dir_all(skill_dir.join("tests")).unwrap();
+        fs::write(
+            skill_dir.join("tests").join("fidelity.jsonl"),
+            "{\"q\":\"valid case\"}\n{\"q\":\n",
+        )
+        .unwrap();
+
+        let diagnostics = SkillDiagnostics::from_prebuilt_dir(Path::new(&root), "huineng");
+
+        assert_eq!(diagnostics.fidelity_case_count, 0);
+        assert!(diagnostics.fidelity_cases.is_empty());
+        assert!(diagnostics
+            .fidelity_error
+            .as_deref()
+            .is_some_and(|error| error.contains("line 2")));
+
+        let mut skill = row("huineng", "慧能大师", "汉传", true);
+        skill.apply_diagnostics(diagnostics);
+        assert_eq!(skill.quality_level(), QualityLevel::Attention);
+        assert!(skill
+            .diagnostic_summary()
+            .contains("invalid fidelity suite"));
+        assert!(skill.diagnostic_summary().contains("line 2"));
+        let actions = skill.diagnostic_actions();
+        assert_eq!(actions.last().unwrap().title, "Repair fidelity suite");
+        assert_eq!(
+            actions.last().unwrap().operation,
+            DiagnosticOperation::Manual
+        );
+        assert!(actions.last().unwrap().command.is_none());
 
         fs::remove_dir_all(root).unwrap();
     }
@@ -823,7 +898,11 @@ mod tests {
             "---\nname: master-curriculum\nkind: meta-skill\n---\n",
         )
         .unwrap();
-        fs::write(curriculum_dir.join("tests").join("fidelity.jsonl"), "{}\n").unwrap();
+        fs::write(
+            curriculum_dir.join("tests").join("fidelity.jsonl"),
+            "{\"prompt\":\"curriculum case\"}\n",
+        )
+        .unwrap();
 
         let debate_dir = root.join("master-debate");
         fs::create_dir_all(debate_dir.join("tests")).unwrap();
@@ -837,7 +916,11 @@ mod tests {
             "{\n  \"kind\": \"meta-skill\"\n}\n",
         )
         .unwrap();
-        fs::write(debate_dir.join("tests").join("fidelity.jsonl"), "{}\n").unwrap();
+        fs::write(
+            debate_dir.join("tests").join("fidelity.jsonl"),
+            "{\"prompt\":\"debate case\"}\n",
+        )
+        .unwrap();
 
         let curriculum = SkillDiagnostics::from_prebuilt_dir(Path::new(&root), "curriculum");
         let debate = SkillDiagnostics::from_prebuilt_dir(Path::new(&root), "debate");

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -123,19 +123,67 @@ pub struct TraceRecord {
     pub duration_ms: Option<u128>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvaluationMode {
+    DryRun,
+    Graded,
+}
+
+impl EvaluationMode {
+    pub fn is_dry_run(self) -> bool {
+        self == Self::DryRun
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::DryRun => "dry-run",
+            Self::Graded => "graded",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvaluationSuiteOutcome {
+    Completed,
+    Error(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvaluationEvidenceErrorKind {
+    Execution,
+    MalformedPayload,
+    UnsupportedVersion,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvaluationEvidenceError {
+    pub trace_id: u64,
+    pub slug: Option<String>,
+    pub kind: EvaluationEvidenceErrorKind,
+    pub message: String,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EvaluationRunResult {
     pub slug: String,
     pub passed_count: usize,
     pub total_count: usize,
-    pub dry_run: bool,
+    pub mode: EvaluationMode,
     pub trace_id: u64,
 }
 
 impl EvaluationRunResult {
     pub fn label(&self) -> String {
-        let mode = if self.dry_run { "N/A" } else { "graded" };
+        let mode = if self.mode.is_dry_run() {
+            "N/A"
+        } else {
+            "graded"
+        };
         format!("{}/{} {mode}", self.passed_count, self.total_count)
+    }
+
+    pub fn is_dry_run(&self) -> bool {
+        self.mode.is_dry_run()
     }
 }
 
@@ -147,7 +195,7 @@ pub struct EvaluationRunHistoryItem {
     pub passed_count: usize,
     pub total_count: usize,
     pub failed_count: usize,
-    pub dry_run: bool,
+    pub mode: EvaluationMode,
     pub duration_ms: Option<u128>,
     pub action: Option<TraceAction>,
     pub trend: EvaluationRunTrend,
@@ -155,8 +203,16 @@ pub struct EvaluationRunHistoryItem {
 
 impl EvaluationRunHistoryItem {
     pub fn result_label(&self) -> String {
-        let mode = if self.dry_run { "N/A" } else { "graded" };
+        let mode = if self.mode.is_dry_run() {
+            "N/A"
+        } else {
+            "graded"
+        };
         format!("{}/{} {mode}", self.passed_count, self.total_count)
+    }
+
+    pub fn is_dry_run(&self) -> bool {
+        self.mode.is_dry_run()
     }
 
     pub fn pass_rate_percent(&self) -> usize {
@@ -262,12 +318,47 @@ pub struct EvaluationRegressionItem {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvaluationCaseStatus {
+    Pass,
+    Fail,
+    DryRun,
+    ApiError,
+    Unknown(String),
+}
+
+impl EvaluationCaseStatus {
+    fn from_wire(value: &str) -> Self {
+        match value {
+            value if value.eq_ignore_ascii_case("PASS") => Self::Pass,
+            value if value.eq_ignore_ascii_case("FAIL") => Self::Fail,
+            value if value.eq_ignore_ascii_case("dry_run") => Self::DryRun,
+            value if value.eq_ignore_ascii_case("api_error") => Self::ApiError,
+            value => Self::Unknown(value.to_string()),
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Fail => "FAIL",
+            Self::DryRun => "dry_run",
+            Self::ApiError => "api_error",
+            Self::Unknown(value) => value,
+        }
+    }
+
+    fn is_failure(&self) -> bool {
+        matches!(self, Self::Fail | Self::ApiError)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EvaluationCaseResult {
     pub slug: String,
     pub case_index: usize,
     pub question: String,
     pub difficulty: Option<String>,
-    pub status: String,
+    pub status: EvaluationCaseStatus,
     pub missing_cites: Vec<String>,
     pub missing_mentions: Vec<String>,
     pub forbidden_found: Vec<String>,
@@ -286,10 +377,10 @@ impl EvaluationCaseResult {
         push_detail_part(&mut parts, "fabricated cites", &self.fabricated_cites);
 
         if parts.is_empty() {
-            match self.status.as_str() {
-                "PASS" => "pass".to_string(),
-                "dry_run" => "dry-run only".to_string(),
-                value => value.to_string(),
+            match &self.status {
+                EvaluationCaseStatus::Pass => "pass".to_string(),
+                EvaluationCaseStatus::DryRun => "dry-run only".to_string(),
+                value => value.label().to_string(),
             }
         } else {
             parts.join("; ")
@@ -396,25 +487,27 @@ impl TraceRecord {
     }
 
     pub fn evaluation_results(&self) -> Vec<EvaluationRunResult> {
-        if !matches!(
-            self.action,
-            Some(TraceAction::FidelityDryRunAll | TraceAction::FidelityDryRunSkill { .. })
-        ) {
-            return Vec::new();
-        }
-
-        parse_evaluation_results(self.id, &self.detail)
+        self.parsed_evaluation_evidence().runs
     }
 
     pub fn evaluation_case_results(&self) -> Vec<EvaluationCaseResult> {
+        self.parsed_evaluation_evidence().cases
+    }
+
+    pub fn evaluation_errors(&self) -> Vec<EvaluationEvidenceError> {
+        self.parsed_evaluation_evidence().errors
+    }
+
+    fn parsed_evaluation_evidence(&self) -> ParsedEvaluationEvidence {
         if !matches!(
             self.action,
             Some(TraceAction::FidelityDryRunAll | TraceAction::FidelityDryRunSkill { .. })
-        ) {
-            return Vec::new();
+        ) || self.status == TraceStatus::Running
+        {
+            return ParsedEvaluationEvidence::default();
         }
 
-        parse_evaluation_case_results(self.id, &self.detail)
+        parse_evaluation_evidence(self)
     }
 
     fn evaluation_run_history_item(&self) -> Option<EvaluationRunHistoryItem> {
@@ -427,12 +520,22 @@ impl TraceRecord {
 
         let cases = self.evaluation_case_results();
         if !cases.is_empty() {
-            let passed_count = cases.iter().filter(|case| case.status == "PASS").count();
+            let passed_count = cases
+                .iter()
+                .filter(|case| case.status == EvaluationCaseStatus::Pass)
+                .count();
             let failed_count = cases
                 .iter()
-                .filter(|case| case.status == "FAIL" || case.has_failure_evidence())
+                .filter(|case| case.status.is_failure() || case.has_failure_evidence())
                 .count();
-            let dry_run = cases.iter().all(|case| case.status == "dry_run");
+            let mode = if cases
+                .iter()
+                .all(|case| case.status == EvaluationCaseStatus::DryRun)
+            {
+                EvaluationMode::DryRun
+            } else {
+                EvaluationMode::Graded
+            };
             return Some(EvaluationRunHistoryItem {
                 trace_id: self.id,
                 scope: self.evaluation_scope_label(),
@@ -440,7 +543,7 @@ impl TraceRecord {
                 passed_count,
                 total_count: cases.len(),
                 failed_count,
-                dry_run,
+                mode,
                 duration_ms: self.duration_ms,
                 action: self.action.clone(),
                 trend: EvaluationRunTrend::New,
@@ -454,8 +557,12 @@ impl TraceRecord {
 
         let passed_count: usize = results.iter().map(|result| result.passed_count).sum();
         let total_count: usize = results.iter().map(|result| result.total_count).sum();
-        let dry_run = results.iter().all(|result| result.dry_run);
-        let failed_count = if dry_run {
+        let mode = if results.iter().all(EvaluationRunResult::is_dry_run) {
+            EvaluationMode::DryRun
+        } else {
+            EvaluationMode::Graded
+        };
+        let failed_count = if mode.is_dry_run() {
             0
         } else {
             total_count.saturating_sub(passed_count)
@@ -468,7 +575,7 @@ impl TraceRecord {
             passed_count,
             total_count,
             failed_count,
-            dry_run,
+            mode,
             duration_ms: self.duration_ms,
             action: self.action.clone(),
             trend: EvaluationRunTrend::New,
@@ -484,127 +591,563 @@ impl TraceRecord {
     }
 }
 
-fn parse_evaluation_case_results(trace_id: u64, detail: &str) -> Vec<EvaluationCaseResult> {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(detail) else {
-        return Vec::new();
-    };
-    let Some(suites) = value.as_array() else {
-        return Vec::new();
-    };
+#[derive(Clone, Debug, Deserialize)]
+struct EvaluationCaseWire {
+    index: usize,
+    #[serde(default)]
+    question: Option<String>,
+    #[serde(default)]
+    difficulty: Option<String>,
+    status: String,
+    #[serde(default)]
+    missing_cites: Vec<String>,
+    #[serde(default)]
+    missing_mentions: Vec<String>,
+    #[serde(default)]
+    forbidden_found: Vec<String>,
+    #[serde(default)]
+    boundary_violations: Vec<String>,
+    #[serde(default)]
+    fabricated_cites: Vec<String>,
+}
 
-    let mut case_results = Vec::new();
-    for suite in suites {
-        let Some(master_name) = suite.get("master").and_then(serde_json::Value::as_str) else {
-            continue;
-        };
-        let Some(slug) = master_name.strip_prefix("master-") else {
-            continue;
-        };
-        let Some(results) = suite.get("results").and_then(serde_json::Value::as_array) else {
-            continue;
-        };
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum EvaluationModeWire {
+    DryRun,
+    Graded,
+}
 
-        for result in results {
-            let Some(index) = result.get("index").and_then(serde_json::Value::as_u64) else {
-                continue;
-            };
-            let Some(status) = result.get("status").and_then(serde_json::Value::as_str) else {
-                continue;
-            };
-            case_results.push(EvaluationCaseResult {
-                slug: slug.to_string(),
-                case_index: index as usize + 1,
-                question: result
-                    .get("question")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("untitled case")
-                    .to_string(),
-                difficulty: result
-                    .get("difficulty")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
-                status: status.to_string(),
-                missing_cites: json_string_array(result, "missing_cites"),
-                missing_mentions: json_string_array(result, "missing_mentions"),
-                forbidden_found: json_string_array(result, "forbidden_found"),
-                boundary_violations: json_string_array(result, "boundary_violations"),
-                fabricated_cites: json_string_array(result, "fabricated_cites"),
-                trace_id,
-            });
+impl From<EvaluationModeWire> for EvaluationMode {
+    fn from(value: EvaluationModeWire) -> Self {
+        match value {
+            EvaluationModeWire::DryRun => Self::DryRun,
+            EvaluationModeWire::Graded => Self::Graded,
         }
     }
-
-    case_results
 }
 
-fn json_string_array(value: &serde_json::Value, key: &str) -> Vec<String> {
-    value
-        .get(key)
-        .and_then(serde_json::Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(serde_json::Value::as_str)
-                .map(str::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum EvaluationOutcomeWire {
+    Completed,
+    Error,
 }
 
-/// Parses a trace record's `detail` into per-skill evaluation results.
-///
-/// The GUI (`app.rs`) and headless `--baseline` (`baseline.rs`) both run
-/// `scripts/test-fidelity.py ... --json` and store the *full* raw stdout as
-/// `detail` (see `output.trim().to_string()` in both call sites -
-/// `summarize_command_output` only truncates the separate summary message).
-/// So real dry-runs always produce JSON here; the plain-text `Testing: /
-/// Result:` format only appears in trace records persisted before `--json`
-/// was added to every dry-run invocation. Try JSON first, then fall back to
-/// the legacy text format for backward compatibility with those old records.
-fn parse_evaluation_results(trace_id: u64, detail: &str) -> Vec<EvaluationRunResult> {
-    parse_evaluation_results_json(trace_id, detail)
-        .unwrap_or_else(|| parse_evaluation_results_text(trace_id, detail))
+#[derive(Debug, Deserialize)]
+struct EvaluationSuiteV1 {
+    schema_version: u64,
+    master: String,
+    mode: EvaluationModeWire,
+    outcome: EvaluationOutcomeWire,
+    total: usize,
+    results: Vec<EvaluationCaseWire>,
+    #[serde(default)]
+    passed: Option<usize>,
+    #[serde(default)]
+    failed: Option<usize>,
+    #[serde(default)]
+    error: Option<String>,
 }
 
-/// Parses the real `--json` shape produced by `scripts/test-fidelity.py`:
-/// a top-level array of `{"master": "master-<slug>", "total": N, "results":
-/// [...], "passed": N}` objects (`"passed"` is only present for graded runs;
-/// dry-runs omit it and every result has `"status": "dry_run"`). Returns
-/// `None` when `detail` is not that JSON shape at all, so the caller can fall
-/// back to the legacy text parser.
-fn parse_evaluation_results_json(trace_id: u64, detail: &str) -> Option<Vec<EvaluationRunResult>> {
-    let value = serde_json::from_str::<serde_json::Value>(detail).ok()?;
-    let suites = value.as_array()?;
+#[derive(Debug, Deserialize)]
+struct LegacyEvaluationSuite {
+    master: String,
+    #[serde(default)]
+    total: Option<usize>,
+    #[serde(default)]
+    results: Vec<EvaluationCaseWire>,
+    #[serde(default)]
+    passed: Option<usize>,
+    #[serde(default)]
+    error: Option<String>,
+}
 
-    let mut results = Vec::new();
-    for suite in suites {
-        let Some(master_name) = suite.get("master").and_then(serde_json::Value::as_str) else {
-            continue;
-        };
-        let Some(slug) = master_name.strip_prefix("master-") else {
-            continue;
-        };
-        let Some(results_array) = suite.get("results").and_then(serde_json::Value::as_array) else {
-            continue;
-        };
+#[derive(Debug)]
+struct CompletedEvaluationSuite {
+    run: EvaluationRunResult,
+    cases: Vec<EvaluationCaseResult>,
+}
 
-        let total_count = suite
-            .get("total")
-            .and_then(serde_json::Value::as_u64)
-            .map(|value| value as usize)
-            .unwrap_or(results_array.len());
-        let passed = suite.get("passed").and_then(serde_json::Value::as_u64);
+#[derive(Default)]
+struct ParsedEvaluationEvidence {
+    runs: Vec<EvaluationRunResult>,
+    cases: Vec<EvaluationCaseResult>,
+    errors: Vec<EvaluationEvidenceError>,
+}
 
-        results.push(EvaluationRunResult {
-            slug: slug.to_string(),
-            passed_count: passed.unwrap_or(0) as usize,
-            total_count,
-            dry_run: passed.is_none(),
-            trace_id,
-        });
+impl ParsedEvaluationEvidence {
+    fn push_completed(&mut self, suite: CompletedEvaluationSuite) {
+        self.runs.push(suite.run);
+        self.cases.extend(suite.cases);
+    }
+}
+
+fn parse_evaluation_evidence(record: &TraceRecord) -> ParsedEvaluationEvidence {
+    let fallback_slug = record.related_skill_slug();
+    match serde_json::from_str::<serde_json::Value>(&record.detail) {
+        Ok(value) => parse_evaluation_json_value(record.id, value, fallback_slug),
+        Err(json_error) => {
+            let runs = parse_evaluation_results_text(record.id, &record.detail);
+            if !runs.is_empty() {
+                return ParsedEvaluationEvidence {
+                    runs,
+                    ..ParsedEvaluationEvidence::default()
+                };
+            }
+
+            let looks_like_json =
+                matches!(record.detail.trim_start().chars().next(), Some('[' | '{'));
+            let kind = if record.status == TraceStatus::Failed && !looks_like_json {
+                EvaluationEvidenceErrorKind::Execution
+            } else {
+                EvaluationEvidenceErrorKind::MalformedPayload
+            };
+            let message = if kind == EvaluationEvidenceErrorKind::Execution {
+                nonempty_evaluation_error_message(&record.detail, &record.summary)
+            } else {
+                format!("invalid fidelity JSON: {json_error}")
+            };
+            ParsedEvaluationEvidence {
+                errors: vec![evaluation_evidence_error(
+                    record.id,
+                    fallback_slug,
+                    kind,
+                    message,
+                )],
+                ..ParsedEvaluationEvidence::default()
+            }
+        }
+    }
+}
+
+fn parse_evaluation_json_value(
+    trace_id: u64,
+    value: serde_json::Value,
+    fallback_slug: Option<&str>,
+) -> ParsedEvaluationEvidence {
+    let Some(suites) = value.as_array() else {
+        return ParsedEvaluationEvidence {
+            errors: vec![evaluation_evidence_error(
+                trace_id,
+                fallback_slug,
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                "invalid fidelity suite: expected a top-level JSON array",
+            )],
+            ..ParsedEvaluationEvidence::default()
+        };
+    };
+
+    if suites.is_empty() {
+        return ParsedEvaluationEvidence {
+            errors: vec![evaluation_evidence_error(
+                trace_id,
+                fallback_slug,
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                "invalid fidelity suite: the suite array is empty",
+            )],
+            ..ParsedEvaluationEvidence::default()
+        };
     }
 
-    Some(results)
+    let mut parsed = ParsedEvaluationEvidence::default();
+    for (suite_index, suite) in suites.iter().enumerate() {
+        let result = if suite.get("schema_version").is_some() {
+            parse_evaluation_suite_v1(trace_id, suite.clone(), fallback_slug)
+        } else {
+            parse_legacy_evaluation_suite(trace_id, suite.clone(), fallback_slug)
+        };
+        match result {
+            Ok(completed) => parsed.push_completed(completed),
+            Err(mut error) => {
+                error.message = format!("suite {}: {}", suite_index + 1, error.message);
+                parsed.errors.push(error);
+            }
+        }
+    }
+    parsed
+}
+
+fn parse_evaluation_suite_v1(
+    trace_id: u64,
+    value: serde_json::Value,
+    fallback_slug: Option<&str>,
+) -> Result<CompletedEvaluationSuite, EvaluationEvidenceError> {
+    let slug = evaluation_slug_from_value(&value, fallback_slug);
+    let version = value
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            evaluation_evidence_error(
+                trace_id,
+                slug.as_deref(),
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                "invalid fidelity v1 suite: schema_version must be an integer",
+            )
+        })?;
+    if version != 1 {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            slug.as_deref(),
+            EvaluationEvidenceErrorKind::UnsupportedVersion,
+            format!("unsupported fidelity schema version {version}"),
+        ));
+    }
+
+    let suite: EvaluationSuiteV1 = serde_json::from_value(value).map_err(|error| {
+        evaluation_evidence_error(
+            trace_id,
+            slug.as_deref(),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            format!("invalid fidelity v1 suite: {error}"),
+        )
+    })?;
+    if suite.schema_version != version {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            slug.as_deref(),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "invalid fidelity v1 suite: schema_version changed during parsing",
+        ));
+    }
+    let slug = normalized_master_slug(&suite.master).ok_or_else(|| {
+        evaluation_evidence_error(
+            trace_id,
+            fallback_slug,
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "invalid fidelity v1 suite: master must start with master-",
+        )
+    })?;
+    let outcome = match suite.outcome {
+        EvaluationOutcomeWire::Completed => EvaluationSuiteOutcome::Completed,
+        EvaluationOutcomeWire::Error => {
+            EvaluationSuiteOutcome::Error(suite.error.clone().unwrap_or_default())
+        }
+    };
+    if let EvaluationSuiteOutcome::Error(message) = outcome {
+        if suite.total != 0 || !suite.results.is_empty() || message.trim().is_empty() {
+            return Err(evaluation_evidence_error(
+                trace_id,
+                Some(&slug),
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                "invalid fidelity error suite: expected total 0, empty results, and a non-empty error",
+            ));
+        }
+        return Err(evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::Execution,
+            message.trim(),
+        ));
+    }
+
+    if suite.error.is_some() {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "invalid completed fidelity suite: error must be omitted",
+        ));
+    }
+    let mode = EvaluationMode::from(suite.mode);
+    let statuses = evaluation_case_statuses(&suite.results).map_err(|message| {
+        evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            message,
+        )
+    })?;
+    if suite.total != suite.results.len() {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            format!(
+                "invalid fidelity suite: total {} does not match {} result(s)",
+                suite.total,
+                suite.results.len()
+            ),
+        ));
+    }
+
+    let passed_count = match mode {
+        EvaluationMode::DryRun => {
+            if suite.passed.is_some()
+                || suite.failed.is_some()
+                || statuses
+                    .iter()
+                    .any(|status| !matches!(status, EvaluationCaseStatus::DryRun))
+            {
+                return Err(evaluation_evidence_error(
+                    trace_id,
+                    Some(&slug),
+                    EvaluationEvidenceErrorKind::MalformedPayload,
+                    "invalid dry-run suite: graded counts must be omitted and every status must be dry_run",
+                ));
+            }
+            0
+        }
+        EvaluationMode::Graded => {
+            let passed = suite.passed.ok_or_else(|| {
+                evaluation_evidence_error(
+                    trace_id,
+                    Some(&slug),
+                    EvaluationEvidenceErrorKind::MalformedPayload,
+                    "invalid graded suite: passed is required",
+                )
+            })?;
+            let failed = suite.failed.ok_or_else(|| {
+                evaluation_evidence_error(
+                    trace_id,
+                    Some(&slug),
+                    EvaluationEvidenceErrorKind::MalformedPayload,
+                    "invalid graded suite: failed is required",
+                )
+            })?;
+            if passed.saturating_add(failed) != suite.total
+                || statuses
+                    .iter()
+                    .any(|status| matches!(status, EvaluationCaseStatus::DryRun))
+            {
+                return Err(evaluation_evidence_error(
+                    trace_id,
+                    Some(&slug),
+                    EvaluationEvidenceErrorKind::MalformedPayload,
+                    "invalid graded suite: counts or case modes are inconsistent",
+                ));
+            }
+            let parsed_passed = statuses
+                .iter()
+                .filter(|status| matches!(status, EvaluationCaseStatus::Pass))
+                .count();
+            let parsed_failed = statuses
+                .iter()
+                .filter(|status| {
+                    matches!(
+                        status,
+                        EvaluationCaseStatus::Fail | EvaluationCaseStatus::ApiError
+                    )
+                })
+                .count();
+            if parsed_passed != passed || parsed_failed != failed {
+                return Err(evaluation_evidence_error(
+                    trace_id,
+                    Some(&slug),
+                    EvaluationEvidenceErrorKind::MalformedPayload,
+                    "invalid graded suite: passed/failed counts do not match case statuses",
+                ));
+            }
+            passed
+        }
+    };
+
+    Ok(completed_evaluation_suite(
+        trace_id,
+        slug,
+        mode,
+        passed_count,
+        suite.total,
+        suite.results,
+        statuses,
+    ))
+}
+
+fn parse_legacy_evaluation_suite(
+    trace_id: u64,
+    value: serde_json::Value,
+    fallback_slug: Option<&str>,
+) -> Result<CompletedEvaluationSuite, EvaluationEvidenceError> {
+    let value_slug = evaluation_slug_from_value(&value, fallback_slug);
+    if let Some(error) = value.get("error") {
+        let message = error.as_str().map(str::trim).unwrap_or_default();
+        if message.is_empty() {
+            return Err(evaluation_evidence_error(
+                trace_id,
+                value_slug.as_deref(),
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                "invalid legacy fidelity error suite: error must be a non-empty string",
+            ));
+        }
+        return Err(evaluation_evidence_error(
+            trace_id,
+            value_slug.as_deref(),
+            EvaluationEvidenceErrorKind::Execution,
+            message,
+        ));
+    }
+
+    let suite: LegacyEvaluationSuite = serde_json::from_value(value).map_err(|error| {
+        evaluation_evidence_error(
+            trace_id,
+            value_slug.as_deref(),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            format!("invalid legacy fidelity suite: {error}"),
+        )
+    })?;
+    if suite.error.is_some() {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            value_slug.as_deref(),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "invalid legacy fidelity suite: error cannot accompany results",
+        ));
+    }
+    let slug = normalized_master_slug(&suite.master).ok_or_else(|| {
+        evaluation_evidence_error(
+            trace_id,
+            fallback_slug,
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "invalid legacy fidelity suite: master must start with master-",
+        )
+    })?;
+    let statuses = evaluation_case_statuses(&suite.results).map_err(|message| {
+        evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            message,
+        )
+    })?;
+    let mode = if suite.passed.is_some() {
+        if statuses
+            .iter()
+            .any(|status| matches!(status, EvaluationCaseStatus::DryRun))
+        {
+            return Err(evaluation_evidence_error(
+                trace_id,
+                Some(&slug),
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                "invalid legacy graded suite: dry_run status conflicts with passed",
+            ));
+        }
+        EvaluationMode::Graded
+    } else if !statuses.is_empty()
+        && statuses
+            .iter()
+            .all(|status| matches!(status, EvaluationCaseStatus::DryRun))
+    {
+        EvaluationMode::DryRun
+    } else {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "ambiguous legacy fidelity suite: expected passed or all dry_run statuses",
+        ));
+    };
+    let total_count = suite.total.unwrap_or(suite.results.len());
+    let passed_count = suite.passed.unwrap_or(0);
+    if passed_count > total_count {
+        return Err(evaluation_evidence_error(
+            trace_id,
+            Some(&slug),
+            EvaluationEvidenceErrorKind::MalformedPayload,
+            "invalid legacy fidelity suite: passed exceeds total",
+        ));
+    }
+
+    Ok(completed_evaluation_suite(
+        trace_id,
+        slug,
+        mode,
+        passed_count,
+        total_count,
+        suite.results,
+        statuses,
+    ))
+}
+
+fn evaluation_case_statuses(
+    cases: &[EvaluationCaseWire],
+) -> Result<Vec<EvaluationCaseStatus>, String> {
+    cases
+        .iter()
+        .map(|case| match EvaluationCaseStatus::from_wire(&case.status) {
+            EvaluationCaseStatus::Unknown(status) => Err(format!(
+                "invalid fidelity suite: unknown case status {status:?}"
+            )),
+            status => Ok(status),
+        })
+        .collect()
+}
+
+fn completed_evaluation_suite(
+    trace_id: u64,
+    slug: String,
+    mode: EvaluationMode,
+    passed_count: usize,
+    total_count: usize,
+    cases: Vec<EvaluationCaseWire>,
+    statuses: Vec<EvaluationCaseStatus>,
+) -> CompletedEvaluationSuite {
+    let cases = cases
+        .into_iter()
+        .zip(statuses)
+        .map(|(case, status)| EvaluationCaseResult {
+            slug: slug.clone(),
+            case_index: case.index + 1,
+            question: case.question.unwrap_or_else(|| "untitled case".to_string()),
+            difficulty: case.difficulty,
+            status,
+            missing_cites: case.missing_cites,
+            missing_mentions: case.missing_mentions,
+            forbidden_found: case.forbidden_found,
+            boundary_violations: case.boundary_violations,
+            fabricated_cites: case.fabricated_cites,
+            trace_id,
+        })
+        .collect();
+
+    CompletedEvaluationSuite {
+        run: EvaluationRunResult {
+            slug,
+            passed_count,
+            total_count,
+            mode,
+            trace_id,
+        },
+        cases,
+    }
+}
+
+fn normalized_master_slug(master: &str) -> Option<String> {
+    let slug = master.strip_prefix("master-")?;
+    (!slug.is_empty()).then(|| slug.to_string())
+}
+
+fn evaluation_slug_from_value(
+    value: &serde_json::Value,
+    fallback_slug: Option<&str>,
+) -> Option<String> {
+    value
+        .get("master")
+        .and_then(serde_json::Value::as_str)
+        .and_then(normalized_master_slug)
+        .or_else(|| fallback_slug.map(str::to_string))
+}
+
+fn evaluation_evidence_error(
+    trace_id: u64,
+    slug: Option<&str>,
+    kind: EvaluationEvidenceErrorKind,
+    message: impl Into<String>,
+) -> EvaluationEvidenceError {
+    EvaluationEvidenceError {
+        trace_id,
+        slug: slug.map(str::to_string),
+        kind,
+        message: message.into(),
+    }
+}
+
+fn nonempty_evaluation_error_message(detail: &str, summary: &str) -> String {
+    let detail = detail.trim();
+    if detail.is_empty() {
+        summary.trim().to_string()
+    } else {
+        detail.to_string()
+    }
 }
 
 fn parse_evaluation_results_text(trace_id: u64, detail: &str) -> Vec<EvaluationRunResult> {
@@ -624,7 +1167,11 @@ fn parse_evaluation_results_text(trace_id: u64, detail: &str) -> Vec<EvaluationR
                         slug,
                         passed_count,
                         total_count,
-                        dry_run: rest.contains("(N/A)"),
+                        mode: if rest.contains("(N/A)") {
+                            EvaluationMode::DryRun
+                        } else {
+                            EvaluationMode::Graded
+                        },
                         trace_id,
                     });
                 }
@@ -1465,8 +2012,8 @@ impl TraceStore {
         EvaluationRunCoverage {
             total_skill_count,
             run_skill_count: results.len(),
-            dry_run_count: results.iter().filter(|result| result.dry_run).count(),
-            graded_count: results.iter().filter(|result| !result.dry_run).count(),
+            dry_run_count: results.iter().filter(|result| result.is_dry_run()).count(),
+            graded_count: results.iter().filter(|result| !result.is_dry_run()).count(),
         }
     }
 
@@ -1478,13 +2025,13 @@ impl TraceStore {
         for result in latest_cases.into_values().flatten() {
             insights.total_cases += 1;
 
-            match result.status.as_str() {
-                "PASS" => insights.pass_cases += 1,
-                "dry_run" => insights.dry_run_cases += 1,
+            match &result.status {
+                EvaluationCaseStatus::Pass => insights.pass_cases += 1,
+                EvaluationCaseStatus::DryRun => insights.dry_run_cases += 1,
                 _ => {}
             }
 
-            if result.status == "FAIL" || result.has_failure_evidence() {
+            if result.status.is_failure() || result.has_failure_evidence() {
                 insights.failed_cases += 1;
                 *failure_counts_by_slug
                     .entry(result.slug.clone())
@@ -1514,7 +2061,7 @@ impl TraceStore {
             .latest_evaluation_case_results_by_slug()
             .into_values()
             .flatten()
-            .filter(|result| result.status == "FAIL" || result.has_failure_evidence())
+            .filter(|result| result.status.is_failure() || result.has_failure_evidence())
             .map(|result| {
                 let priority = result.failure_priority();
                 let failure_summary = result.failure_summary();
@@ -1522,7 +2069,7 @@ impl TraceStore {
                     slug: result.slug,
                     case_index: result.case_index,
                     question: result.question,
-                    status: result.status,
+                    status: result.status.label().to_string(),
                     priority,
                     failure_summary,
                     trace_id: result.trace_id,
@@ -1630,12 +2177,12 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
-        EvaluationEvidenceReport, EvaluationFailureInsights, EvaluationFailureItem,
-        EvaluationFailurePriority, EvaluationRegressionItem, EvaluationRemediationPlan,
-        EvaluationRunCoverage, EvaluationRunHistoryFilter, EvaluationRunHistoryItem,
-        EvaluationRunTrend, EvaluationTrendSummary, FailureKind, TraceAction, TraceListFilter,
-        TraceStatus, TraceStore,
+        EvaluationCaseStatus, EvaluationDecisionAction, EvaluationDecisionBrief,
+        EvaluationDecisionPosture, EvaluationEvidenceErrorKind, EvaluationEvidenceReport,
+        EvaluationFailureInsights, EvaluationFailureItem, EvaluationFailurePriority,
+        EvaluationMode, EvaluationRegressionItem, EvaluationRemediationPlan, EvaluationRunCoverage,
+        EvaluationRunHistoryFilter, EvaluationRunHistoryItem, EvaluationRunTrend,
+        EvaluationTrendSummary, FailureKind, TraceAction, TraceListFilter, TraceStatus, TraceStore,
     };
 
     fn temp_path(name: &str) -> PathBuf {
@@ -1990,7 +2537,7 @@ mod tests {
         assert_eq!(result.slug, "huineng");
         assert_eq!(result.passed_count, 0);
         assert_eq!(result.total_count, 12);
-        assert!(result.dry_run);
+        assert!(result.is_dry_run());
         assert_eq!(result.label(), "0/12 N/A");
     }
 
@@ -2077,11 +2624,264 @@ mod tests {
 
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].case_index, 1);
-        assert_eq!(results[0].status, "dry_run");
+        assert_eq!(results[0].status, EvaluationCaseStatus::DryRun);
         assert_eq!(results[0].difficulty.as_deref(), Some("basic"));
         assert_eq!(results[0].trace_id, run);
         assert_eq!(results[1].case_index, 2);
         assert_eq!(results[1].question, "顿悟怎么修？");
+    }
+
+    #[test]
+    fn parses_v1_evaluation_modes_and_case_statuses() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running fidelity suites",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "fidelity suites finished",
+            r#"[
+              {
+                "schema_version": 1,
+                "master": "master-huineng",
+                "mode": "dry_run",
+                "outcome": "completed",
+                "total": 1,
+                "results": [
+                  {"index": 0, "question": "结构检查", "status": "dry_run"}
+                ]
+              },
+              {
+                "schema_version": 1,
+                "master": "master-zhiyi",
+                "mode": "graded",
+                "outcome": "completed",
+                "total": 2,
+                "passed": 1,
+                "failed": 1,
+                "results": [
+                  {"index": 0, "question": "通过", "status": "PASS"},
+                  {"index": 1, "question": "失败", "status": "FAIL"}
+                ]
+              }
+            ]"#,
+            Duration::from_millis(50),
+        );
+
+        let results = store.latest_evaluation_results_by_slug();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].slug, "huineng");
+        assert_eq!(results[0].mode, EvaluationMode::DryRun);
+        assert_eq!(results[0].passed_count, 0);
+        assert_eq!(results[1].slug, "zhiyi");
+        assert_eq!(results[1].mode, EvaluationMode::Graded);
+        assert_eq!(results[1].passed_count, 1);
+
+        let huineng_cases = store.latest_evaluation_case_results_for("huineng");
+        assert_eq!(huineng_cases[0].status, EvaluationCaseStatus::DryRun);
+        let zhiyi_cases = store.latest_evaluation_case_results_for("zhiyi");
+        assert_eq!(zhiyi_cases[0].status, EvaluationCaseStatus::Pass);
+        assert_eq!(zhiyi_cases[1].status, EvaluationCaseStatus::Fail);
+    }
+
+    #[test]
+    fn rejects_ambiguous_legacy_evaluation_json() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "master": "master-huineng",
+              "total": 1,
+              "results": [
+                {"index": 0, "question": "模式不明确", "status": "PASS"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        assert!(store.latest_evaluation_result_for("huineng").is_none());
+        assert!(store
+            .latest_evaluation_case_results_for("huineng")
+            .is_empty());
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].kind,
+            EvaluationEvidenceErrorKind::MalformedPayload
+        );
+    }
+
+    #[test]
+    fn exposes_v1_evaluation_error_outcome_as_execution_evidence() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            run,
+            "master-huineng fidelity failed",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "error",
+              "total": 0,
+              "results": [],
+              "error": "ANTHROPIC_API_KEY environment variable not set"
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].trace_id, run);
+        assert_eq!(errors[0].slug.as_deref(), Some("huineng"));
+        assert_eq!(errors[0].kind, EvaluationEvidenceErrorKind::Execution);
+        assert!(errors[0].message.contains("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn reports_malformed_json_as_evaluation_evidence_error() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            "[",
+            Duration::from_millis(50),
+        );
+
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].slug.as_deref(), Some("huineng"));
+        assert_eq!(
+            errors[0].kind,
+            EvaluationEvidenceErrorKind::MalformedPayload
+        );
+    }
+
+    #[test]
+    fn reports_unsupported_evaluation_schema_version() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 2,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 0,
+              "passed": 0,
+              "failed": 0,
+              "results": []
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].kind,
+            EvaluationEvidenceErrorKind::UnsupportedVersion
+        );
+        assert!(errors[0].message.contains('2'));
+    }
+
+    #[test]
+    fn reports_unknown_case_status_as_malformed_evidence() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 0,
+              "failed": 1,
+              "results": [
+                {"index": 0, "question": "未知状态", "status": "SKIPPED"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        assert!(store.latest_evaluation_result_for("huineng").is_none());
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].kind,
+            EvaluationEvidenceErrorKind::MalformedPayload
+        );
+        assert!(errors[0].message.contains("SKIPPED"));
+    }
+
+    #[test]
+    fn reports_failed_evaluation_trace_as_execution_evidence() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            run,
+            "fidelity command failed",
+            "python exited before producing JSON",
+            Duration::from_millis(50),
+        );
+
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].kind, EvaluationEvidenceErrorKind::Execution);
+        assert_eq!(errors[0].slug.as_deref(), Some("huineng"));
+        assert!(errors[0].message.contains("python exited"));
     }
 
     #[test]
@@ -2102,6 +2902,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 0,
                 "total": 1,
                 "results": [
                   {
@@ -2279,7 +3080,7 @@ mod tests {
         assert_eq!(result.slug, "zhiyi");
         assert_eq!(result.passed_count, 0);
         assert_eq!(result.total_count, 3);
-        assert!(result.dry_run);
+        assert!(result.is_dry_run());
         assert_eq!(result.trace_id, run);
     }
 
@@ -2384,6 +3185,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2409,6 +3211,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 1,
                 "results": [
                   {
                     "index": 0,
@@ -2426,6 +3229,7 @@ mod tests {
               },
               {
                 "master": "master-zhiyi",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2516,6 +3320,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2541,6 +3346,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 1,
                 "results": [
                   {
                     "index": 0,
@@ -2558,6 +3364,7 @@ mod tests {
               },
               {
                 "master": "master-zhiyi",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2603,6 +3410,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2613,6 +3421,7 @@ mod tests {
               },
               {
                 "master": "master-zhiyi",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2624,6 +3433,7 @@ mod tests {
               },
               {
                 "master": "master-xuanzang",
+                "passed": 0,
                 "results": [
                   {
                     "index": 0,
@@ -2678,6 +3488,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 1,
                 "results": [
                   {"index": 0, "question": "通过", "status": "PASS"},
                   {"index": 1, "question": "失败", "status": "FAIL"}
@@ -2685,6 +3496,7 @@ mod tests {
               },
               {
                 "master": "master-zhiyi",
+                "passed": 1,
                 "results": [
                   {"index": 0, "question": "通过", "status": "PASS"}
                 ]
@@ -2701,7 +3513,7 @@ mod tests {
         assert_eq!(history[0].passed_count, 2);
         assert_eq!(history[0].total_count, 3);
         assert_eq!(history[0].failed_count, 1);
-        assert!(!history[0].dry_run);
+        assert!(!history[0].is_dry_run());
         assert_eq!(history[0].duration_ms, Some(55));
         assert_eq!(history[0].action, Some(TraceAction::FidelityDryRunAll));
 
@@ -2710,7 +3522,7 @@ mod tests {
         assert_eq!(history[1].passed_count, 0);
         assert_eq!(history[1].total_count, 12);
         assert_eq!(history[1].failed_count, 0);
-        assert!(history[1].dry_run);
+        assert!(history[1].is_dry_run());
         assert_eq!(
             history[1].action,
             Some(TraceAction::FidelityDryRunSkill {
@@ -2737,6 +3549,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 0,
                 "results": [
                   {"index": 0, "question": "失败一", "status": "FAIL"},
                   {"index": 1, "question": "失败二", "status": "FAIL"}
@@ -2758,6 +3571,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 1,
                 "results": [
                   {"index": 0, "question": "通过", "status": "PASS"}
                 ]
@@ -2780,6 +3594,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 1,
                 "results": [
                   {"index": 0, "question": "通过", "status": "PASS"},
                   {"index": 1, "question": "仍失败", "status": "FAIL"}
@@ -2801,6 +3616,7 @@ mod tests {
             r#"[
               {
                 "master": "master-huineng",
+                "passed": 0,
                 "results": [
                   {"index": 0, "question": "失败", "status": "FAIL"}
                 ]
@@ -2836,7 +3652,7 @@ mod tests {
         store.finish_success_with_detail(
             old_huineng,
             "master-huineng fidelity run finished",
-            r#"[{"master": "master-huineng", "results": [
+            r#"[{"master": "master-huineng", "passed": 0, "results": [
               {"index": 0, "question": "失败一", "status": "FAIL"},
               {"index": 1, "question": "失败二", "status": "FAIL"}
             ]}]"#,
@@ -2852,7 +3668,7 @@ mod tests {
         store.finish_success_with_detail(
             old_all,
             "fidelity run finished",
-            r#"[{"master": "master-huineng", "results": [
+            r#"[{"master": "master-huineng", "passed": 1, "results": [
               {"index": 0, "question": "通过", "status": "PASS"}
             ]}]"#,
             Duration::from_millis(45),
@@ -2869,7 +3685,7 @@ mod tests {
         store.finish_success_with_detail(
             new_huineng,
             "master-huineng fidelity run finished",
-            r#"[{"master": "master-huineng", "results": [
+            r#"[{"master": "master-huineng", "passed": 1, "results": [
               {"index": 0, "question": "通过", "status": "PASS"},
               {"index": 1, "question": "仍失败", "status": "FAIL"}
             ]}]"#,
@@ -2885,7 +3701,7 @@ mod tests {
         store.finish_success_with_detail(
             new_all,
             "fidelity run finished",
-            r#"[{"master": "master-huineng", "results": [
+            r#"[{"master": "master-huineng", "passed": 0, "results": [
               {"index": 0, "question": "失败", "status": "FAIL"}
             ]}]"#,
             Duration::from_millis(50),
@@ -2924,7 +3740,7 @@ mod tests {
             old_huineng,
             "master-huineng fidelity run finished",
             r#"[
-              {"master": "master-huineng", "results": [
+              {"master": "master-huineng", "passed": 0, "results": [
                 {"index": 0, "question": "失败一", "status": "FAIL"},
                 {"index": 1, "question": "失败二", "status": "FAIL"}
               ]}
@@ -2942,7 +3758,7 @@ mod tests {
             old_all,
             "fidelity run finished",
             r#"[
-              {"master": "master-huineng", "results": [
+              {"master": "master-huineng", "passed": 1, "results": [
                 {"index": 0, "question": "通过", "status": "PASS"}
               ]}
             ]"#,
@@ -2961,7 +3777,7 @@ mod tests {
             new_huineng,
             "master-huineng fidelity run finished",
             r#"[
-              {"master": "master-huineng", "results": [
+              {"master": "master-huineng", "passed": 1, "results": [
                 {"index": 0, "question": "通过", "status": "PASS"},
                 {"index": 1, "question": "仍失败", "status": "FAIL"}
               ]}
@@ -2979,7 +3795,7 @@ mod tests {
             new_all,
             "fidelity run finished",
             r#"[
-              {"master": "master-huineng", "results": [
+              {"master": "master-huineng", "passed": 0, "results": [
                 {"index": 0, "question": "失败", "status": "FAIL"}
               ]}
             ]"#,
@@ -3125,7 +3941,7 @@ mod tests {
             passed_count: 10,
             total_count: 12,
             failed_count: 2,
-            dry_run: true,
+            mode: EvaluationMode::DryRun,
             duration_ms: Some(150),
             action: Some(TraceAction::FidelityDryRunSkill {
                 slug: "huineng".to_string(),
@@ -3208,7 +4024,7 @@ mod tests {
             passed_count: 8,
             total_count: 10,
             failed_count: 2,
-            dry_run: false,
+            mode: EvaluationMode::Graded,
             duration_ms: Some(120),
             action: Some(TraceAction::FidelityDryRunSkill {
                 slug: "huineng".to_string(),
@@ -3258,7 +4074,7 @@ mod tests {
             old_huineng,
             "master-huineng fidelity run finished",
             r#"[
-              {"master": "master-huineng", "results": [
+              {"master": "master-huineng", "passed": 2, "results": [
                 {"index": 0, "question": "通过一", "status": "PASS"},
                 {"index": 1, "question": "通过二", "status": "PASS"}
               ]}
@@ -3276,7 +4092,7 @@ mod tests {
             old_all,
             "fidelity run finished",
             r#"[
-              {"master": "master-zhiyi", "results": [
+              {"master": "master-zhiyi", "passed": 0, "results": [
                 {"index": 0, "question": "失败", "status": "FAIL"}
               ]}
             ]"#,
@@ -3295,7 +4111,7 @@ mod tests {
             new_huineng,
             "master-huineng fidelity run finished",
             r#"[
-              {"master": "master-huineng", "results": [
+              {"master": "master-huineng", "passed": 1, "results": [
                 {"index": 0, "question": "通过", "status": "PASS"},
                 {"index": 1, "question": "回归失败", "status": "FAIL"}
               ]}
@@ -3313,7 +4129,7 @@ mod tests {
             new_all,
             "fidelity run finished",
             r#"[
-              {"master": "master-zhiyi", "results": [
+              {"master": "master-zhiyi", "passed": 1, "results": [
                 {"index": 0, "question": "通过", "status": "PASS"}
               ]}
             ]"#,

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -824,6 +824,7 @@ fn parse_evaluation_suite_v1(
             "invalid fidelity v1 suite: master must start with master-",
         )
     })?;
+    validate_evaluation_scope(trace_id, &slug, fallback_slug)?;
     let outcome = match suite.outcome {
         EvaluationOutcomeWire::Completed => EvaluationSuiteOutcome::Completed,
         EvaluationOutcomeWire::Error => {
@@ -1007,6 +1008,7 @@ fn parse_legacy_evaluation_suite(
             "invalid legacy fidelity suite: master must start with master-",
         )
     })?;
+    validate_evaluation_scope(trace_id, &slug, fallback_slug)?;
     let statuses = evaluation_case_statuses(&suite.results).map_err(|message| {
         evaluation_evidence_error(
             trace_id,
@@ -1120,6 +1122,26 @@ fn completed_evaluation_suite(
 fn normalized_master_slug(master: &str) -> Option<String> {
     let slug = master.strip_prefix("master-")?;
     (!slug.is_empty()).then(|| slug.to_string())
+}
+
+fn validate_evaluation_scope(
+    trace_id: u64,
+    actual_slug: &str,
+    expected_slug: Option<&str>,
+) -> Result<(), EvaluationEvidenceError> {
+    if let Some(expected_slug) = expected_slug {
+        if actual_slug != expected_slug {
+            return Err(evaluation_evidence_error(
+                trace_id,
+                Some(expected_slug),
+                EvaluationEvidenceErrorKind::MalformedPayload,
+                format!(
+                    "invalid fidelity suite scope: expected master-{expected_slug}, got master-{actual_slug}"
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn evaluation_slug_from_value(
@@ -1273,18 +1295,30 @@ pub struct TraceFailureItem {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EvaluationRunCoverage {
     pub total_skill_count: usize,
-    pub run_skill_count: usize,
-    pub dry_run_count: usize,
-    pub graded_count: usize,
+    pub structural_run_skill_count: usize,
+    pub graded_run_skill_count: usize,
+    pub dry_run_skill_count: usize,
+    pub current_error_count: usize,
 }
 
 impl EvaluationRunCoverage {
-    pub fn label(&self) -> String {
-        format!("{}/{}", self.run_skill_count, self.total_skill_count)
+    pub fn structural_label(&self) -> String {
+        format!(
+            "{}/{}",
+            self.structural_run_skill_count, self.total_skill_count
+        )
     }
 
-    pub fn is_complete(&self) -> bool {
-        self.total_skill_count > 0 && self.run_skill_count >= self.total_skill_count
+    pub fn graded_label(&self) -> String {
+        format!("{}/{}", self.graded_run_skill_count, self.total_skill_count)
+    }
+
+    pub fn is_structurally_complete(&self) -> bool {
+        self.total_skill_count > 0 && self.structural_run_skill_count >= self.total_skill_count
+    }
+
+    pub fn is_graded_complete(&self) -> bool {
+        self.total_skill_count > 0 && self.graded_run_skill_count >= self.total_skill_count
     }
 }
 
@@ -1430,6 +1464,24 @@ impl EvaluationDecisionBrief {
             };
         }
 
+        if coverage.current_error_count > 0 {
+            return Self {
+                posture: EvaluationDecisionPosture::Blocked,
+                headline: "Evaluation evidence error".to_string(),
+                primary_risk: format!(
+                    "{} current evaluation error(s)",
+                    coverage.current_error_count
+                ),
+                evidence:
+                    "The newest attempt for at least one evaluation scope did not produce valid evidence."
+                        .to_string(),
+                recommendation:
+                    "Rerun the affected evaluation scopes and inspect execution or payload errors before release."
+                        .to_string(),
+                action: EvaluationDecisionAction::RerunAll,
+            };
+        }
+
         if insights.failed_cases > 0 {
             let action = insights
                 .top_failure_skill_slug
@@ -1451,27 +1503,48 @@ impl EvaluationDecisionBrief {
             };
         }
 
-        if !coverage.is_complete() {
+        if !coverage.is_structurally_complete() {
             let missing_runs = coverage
                 .total_skill_count
-                .saturating_sub(coverage.run_skill_count);
+                .saturating_sub(coverage.structural_run_skill_count);
             return Self {
                 posture: EvaluationDecisionPosture::Unproven,
                 headline: "Evaluation coverage incomplete".to_string(),
-                primary_risk: format!("{} skills have latest runs", coverage.label()),
+                primary_risk: format!(
+                    "{} skills have structural runs",
+                    coverage.structural_label()
+                ),
                 evidence: format!("{missing_runs} skill(s) without a current run"),
-                recommendation: "Run fidelity dry-run to establish a current baseline.".to_string(),
+                recommendation: "Run fidelity dry-run to establish structural baseline coverage."
+                    .to_string(),
                 action: EvaluationDecisionAction::RunFidelityBaseline,
+            };
+        }
+
+        if !coverage.is_graded_complete() {
+            let missing_runs = coverage
+                .total_skill_count
+                .saturating_sub(coverage.graded_run_skill_count);
+            return Self {
+                posture: EvaluationDecisionPosture::Unproven,
+                headline: "Graded evidence incomplete".to_string(),
+                primary_risk: format!("{} skills have graded results", coverage.graded_label()),
+                evidence: format!(
+                    "Structural baseline complete; {missing_runs} skill(s) lack graded evidence"
+                ),
+                recommendation: "Attach complete graded fidelity evidence before release approval."
+                    .to_string(),
+                action: EvaluationDecisionAction::RunFullValidation,
             };
         }
 
         Self {
             posture: EvaluationDecisionPosture::Ready,
-            headline: "Evaluation baseline clear".to_string(),
+            headline: "Graded evaluation clear".to_string(),
             primary_risk: "No current regressions or failing cases".to_string(),
             evidence: format!(
-                "{} skills covered, {} recent run(s)",
-                coverage.run_skill_count, trend.total_runs
+                "{} skills graded, {} recent run(s)",
+                coverage.graded_run_skill_count, trend.total_runs
             ),
             recommendation: "Proceed with release review and keep monitoring new runs.".to_string(),
             action: EvaluationDecisionAction::RunFullValidation,
@@ -1515,10 +1588,21 @@ impl EvaluationEvidenceReport {
         markdown.push_str(&format!("- Next action: {}\n\n", brief.recommendation));
 
         markdown.push_str("## Coverage And Trend\n");
-        markdown.push_str(&format!("- Coverage: {} skills\n", coverage.label()));
         markdown.push_str(&format!(
-            "- Run modes: {} dry-run / {} graded\n",
-            coverage.dry_run_count, coverage.graded_count
+            "- Structural coverage: {} skills\n",
+            coverage.structural_label()
+        ));
+        markdown.push_str(&format!(
+            "- Graded coverage: {} skills\n",
+            coverage.graded_label()
+        ));
+        markdown.push_str(&format!(
+            "- Latest structural mode: {} dry-run skill(s)\n",
+            coverage.dry_run_skill_count
+        ));
+        markdown.push_str(&format!(
+            "- Current evaluation errors: {}\n",
+            coverage.current_error_count
         ));
         markdown.push_str(&format!(
             "- Trend: {} regressed / {} improved / {} stable / {} new\n\n",
@@ -1698,12 +1782,9 @@ fn default_remediation_action(brief: &EvaluationDecisionBrief) -> String {
         EvaluationDecisionPosture::Ready => {
             "Run full validation before release approval".to_string()
         }
-        EvaluationDecisionPosture::Unproven => {
-            "Run fidelity baseline for all skills to establish current coverage".to_string()
-        }
-        EvaluationDecisionPosture::Attention | EvaluationDecisionPosture::Blocked => {
-            brief.recommendation.clone()
-        }
+        EvaluationDecisionPosture::Unproven
+        | EvaluationDecisionPosture::Attention
+        | EvaluationDecisionPosture::Blocked => brief.recommendation.clone(),
     }
 }
 
@@ -2090,12 +2171,18 @@ impl TraceStore {
     }
 
     pub fn evaluation_run_coverage(&self, total_skill_count: usize) -> EvaluationRunCoverage {
-        let results = self.latest_evaluation_results_by_slug();
+        let structural_results = self.latest_evaluation_results_by_slug();
+        let graded_results = self.latest_graded_evaluation_results_by_slug();
         EvaluationRunCoverage {
             total_skill_count,
-            run_skill_count: results.len(),
-            dry_run_count: results.iter().filter(|result| result.is_dry_run()).count(),
-            graded_count: results.iter().filter(|result| !result.is_dry_run()).count(),
+            structural_run_skill_count: structural_results.len().min(total_skill_count),
+            graded_run_skill_count: graded_results.len().min(total_skill_count),
+            dry_run_skill_count: structural_results
+                .iter()
+                .filter(|result| result.is_dry_run())
+                .count()
+                .min(total_skill_count),
+            current_error_count: self.latest_evaluation_errors().len(),
         }
     }
 
@@ -3123,6 +3210,46 @@ mod tests {
     }
 
     #[test]
+    fn rejects_evaluation_payload_for_wrong_skill_scope() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-zhiyi",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 1,
+              "failed": 0,
+              "results": [
+                {"index": 0, "question": "错误 scope", "status": "PASS"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        assert!(store.latest_evaluation_result_for("zhiyi").is_none());
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].kind,
+            EvaluationEvidenceErrorKind::MalformedPayload
+        );
+        assert_eq!(errors[0].slug.as_deref(), Some("huineng"));
+        assert!(errors[0].message.contains("scope"));
+    }
+
+    #[test]
     fn reports_failed_evaluation_trace_as_execution_evidence() {
         let mut store = TraceStore::new(10);
         let run = store.begin_with_action(
@@ -3338,10 +3465,11 @@ mod tests {
         let coverage = store.evaluation_run_coverage(18);
 
         assert_eq!(coverage.total_skill_count, 18);
-        assert_eq!(coverage.run_skill_count, 2);
-        assert_eq!(coverage.dry_run_count, 2);
-        assert_eq!(coverage.graded_count, 0);
-        assert_eq!(coverage.label(), "2/18");
+        assert_eq!(coverage.structural_run_skill_count, 2);
+        assert_eq!(coverage.dry_run_skill_count, 2);
+        assert_eq!(coverage.graded_run_skill_count, 0);
+        assert_eq!(coverage.current_error_count, 0);
+        assert_eq!(coverage.structural_label(), "2/18");
     }
 
     /// Real (trimmed) `python3 scripts/test-fidelity.py --master master-zhiyi
@@ -3501,15 +3629,16 @@ mod tests {
         let coverage = store.evaluation_run_coverage(3);
 
         assert_eq!(coverage.total_skill_count, 3);
-        assert_eq!(coverage.run_skill_count, 3);
-        assert_eq!(coverage.dry_run_count, 3);
-        assert_eq!(coverage.graded_count, 0);
-        assert_eq!(coverage.label(), "3/3");
-        assert!(coverage.is_complete());
+        assert_eq!(coverage.structural_run_skill_count, 3);
+        assert_eq!(coverage.dry_run_skill_count, 3);
+        assert_eq!(coverage.graded_run_skill_count, 0);
+        assert_eq!(coverage.current_error_count, 0);
+        assert_eq!(coverage.structural_label(), "3/3");
+        assert!(coverage.is_structurally_complete());
     }
 
     #[test]
-    fn evaluation_gate_leaves_unproven_after_full_json_dry_run_baseline() {
+    fn complete_dry_run_coverage_is_unproven() {
         // Mirrors `master-skill-desktop --baseline` recording one real
         // `--json` dry-run trace per skill via the shared trace-store code
         // path (baseline.rs / app.rs), then computes the exact signals
@@ -3545,13 +3674,105 @@ mod tests {
         let trend = store.evaluation_trend_summary(20);
         let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
 
-        assert!(coverage.is_complete());
-        assert_ne!(
-            brief.posture,
-            EvaluationDecisionPosture::Unproven,
-            "gate should leave Unproven once every skill has a current run: {brief:?}"
+        assert!(coverage.is_structurally_complete());
+        assert!(!coverage.is_graded_complete());
+        assert_eq!(brief.posture, EvaluationDecisionPosture::Unproven);
+        assert_eq!(brief.headline, "Graded evidence incomplete");
+    }
+
+    #[test]
+    fn complete_passing_graded_coverage_is_ready() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
         );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 1,
+              "failed": 0,
+              "results": [
+                {"index": 0, "question": "已评分", "status": "PASS"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        let coverage = store.evaluation_run_coverage(1);
+        let insights = store.evaluation_failure_insights();
+        let trend = store.evaluation_trend_summary(8);
+        let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
+
+        assert!(coverage.is_structurally_complete());
+        assert!(coverage.is_graded_complete());
+        assert_eq!(coverage.current_error_count, 0);
         assert_eq!(brief.posture, EvaluationDecisionPosture::Ready);
+        assert_eq!(brief.headline, "Graded evaluation clear");
+    }
+
+    #[test]
+    fn current_evaluation_error_blocks_older_passing_evidence() {
+        let mut store = TraceStore::new(10);
+        let graded_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            graded_run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 1,
+              "failed": 0,
+              "results": [
+                {"index": 0, "question": "旧通过", "status": "PASS"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+        let failed_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            failed_run,
+            "master-huineng fidelity failed",
+            "runner failed before producing evidence",
+            Duration::from_millis(50),
+        );
+
+        let coverage = store.evaluation_run_coverage(1);
+        let insights = store.evaluation_failure_insights();
+        let trend = store.evaluation_trend_summary(8);
+        let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
+
+        assert!(coverage.is_graded_complete());
+        assert_eq!(coverage.current_error_count, 1);
+        assert_eq!(brief.posture, EvaluationDecisionPosture::Blocked);
+        assert_eq!(brief.headline, "Evaluation evidence error");
     }
 
     #[test]
@@ -4204,9 +4425,10 @@ mod tests {
     fn builds_evaluation_decision_brief_from_quality_signals() {
         let coverage = EvaluationRunCoverage {
             total_skill_count: 3,
-            run_skill_count: 3,
-            dry_run_count: 3,
-            graded_count: 0,
+            structural_run_skill_count: 3,
+            graded_run_skill_count: 3,
+            dry_run_skill_count: 0,
+            current_error_count: 0,
         };
         let mut trend = EvaluationTrendSummary {
             total_runs: 3,
@@ -4238,6 +4460,15 @@ mod tests {
 
         trend.regressed_count = 0;
         trend.latest_regression_scope = None;
+
+        let errored = EvaluationRunCoverage {
+            current_error_count: 1,
+            ..coverage.clone()
+        };
+        let brief = EvaluationDecisionBrief::from_signals(&errored, &trend, &insights);
+        assert_eq!(brief.posture, EvaluationDecisionPosture::Blocked);
+        assert_eq!(brief.headline, "Evaluation evidence error");
+
         let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
         assert_eq!(brief.posture, EvaluationDecisionPosture::Attention);
         assert_eq!(brief.headline, "Failing fidelity cases");
@@ -4254,19 +4485,27 @@ mod tests {
         insights.top_failure_skill_slug = None;
         insights.top_failure_skill_count = 0;
         let uncovered = EvaluationRunCoverage {
-            run_skill_count: 2,
+            structural_run_skill_count: 2,
             ..coverage.clone()
         };
         let brief = EvaluationDecisionBrief::from_signals(&uncovered, &trend, &insights);
         assert_eq!(brief.posture, EvaluationDecisionPosture::Unproven);
         assert_eq!(brief.headline, "Evaluation coverage incomplete");
-        assert_eq!(brief.primary_risk, "2/3 skills have latest runs");
+        assert_eq!(brief.primary_risk, "2/3 skills have structural runs");
         assert_eq!(brief.action, EvaluationDecisionAction::RunFidelityBaseline);
+
+        let graded_gap = EvaluationRunCoverage {
+            graded_run_skill_count: 2,
+            ..coverage.clone()
+        };
+        let brief = EvaluationDecisionBrief::from_signals(&graded_gap, &trend, &insights);
+        assert_eq!(brief.posture, EvaluationDecisionPosture::Unproven);
+        assert_eq!(brief.headline, "Graded evidence incomplete");
 
         let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
         assert_eq!(brief.posture, EvaluationDecisionPosture::Ready);
         assert_eq!(brief.status_label(), "ready");
-        assert_eq!(brief.headline, "Evaluation baseline clear");
+        assert_eq!(brief.headline, "Graded evaluation clear");
         assert_eq!(brief.action, EvaluationDecisionAction::RunFullValidation);
     }
 
@@ -4274,9 +4513,10 @@ mod tests {
     fn renders_evaluation_evidence_report_for_release_review() {
         let coverage = EvaluationRunCoverage {
             total_skill_count: 3,
-            run_skill_count: 2,
-            dry_run_count: 2,
-            graded_count: 0,
+            structural_run_skill_count: 2,
+            graded_run_skill_count: 0,
+            dry_run_skill_count: 2,
+            current_error_count: 0,
         };
         let trend = EvaluationTrendSummary {
             total_runs: 2,
@@ -4350,7 +4590,10 @@ mod tests {
             .markdown
             .contains("# Master-skill Evaluation Evidence Report"));
         assert!(report.markdown.contains("- Status: blocked"));
-        assert!(report.markdown.contains("- Coverage: 2/3 skills"));
+        assert!(report
+            .markdown
+            .contains("- Structural coverage: 2/3 skills"));
+        assert!(report.markdown.contains("- Graded coverage: 0/3 skills"));
         assert!(report
             .markdown
             .contains("- Trend: 1 regressed / 0 improved / 1 stable / 0 new"));
@@ -4443,6 +4686,28 @@ mod tests {
         assert!(plan.markdown.contains("- [ ] Fix master-huineng case #3"));
         assert!(plan.markdown.contains("- [ ] Run `npm test`"));
         assert!(plan.markdown.contains("latest trace #42"));
+    }
+
+    #[test]
+    fn graded_gap_remediation_does_not_recommend_another_dry_run() {
+        let coverage = EvaluationRunCoverage {
+            total_skill_count: 1,
+            structural_run_skill_count: 1,
+            graded_run_skill_count: 0,
+            dry_run_skill_count: 1,
+            current_error_count: 0,
+        };
+        let brief = EvaluationDecisionBrief::from_signals(
+            &coverage,
+            &EvaluationTrendSummary::default(),
+            &EvaluationFailureInsights::default(),
+        );
+
+        let plan = EvaluationRemediationPlan::from_signals(&brief, &[], &[], &[]);
+
+        assert_eq!(brief.headline, "Graded evidence incomplete");
+        assert!(plan.items[0].contains("graded fidelity evidence"));
+        assert!(!plan.items[0].contains("baseline"));
     }
 
     #[test]

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
@@ -161,6 +161,12 @@ pub struct EvaluationEvidenceError {
     pub slug: Option<String>,
     pub kind: EvaluationEvidenceErrorKind,
     pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum EvaluationEvidenceScope {
+    All,
+    Skill(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1212,10 +1218,13 @@ fn classify_failure_text(text: &str) -> Option<FailureKind> {
 
 fn annotate_evaluation_run_trends(history: &mut [EvaluationRunHistoryItem]) {
     for index in 0..history.len() {
-        let Some(previous) = history[index + 1..]
-            .iter()
-            .find(|candidate| candidate.scope == history[index].scope)
-        else {
+        if history[index].mode != EvaluationMode::Graded {
+            history[index].trend = EvaluationRunTrend::New;
+            continue;
+        }
+        let Some(previous) = history[index + 1..].iter().find(|candidate| {
+            candidate.scope == history[index].scope && candidate.mode == EvaluationMode::Graded
+        }) else {
             history[index].trend = EvaluationRunTrend::New;
             continue;
         };
@@ -1898,6 +1907,83 @@ impl TraceStore {
             .find(|result| result.slug == slug)
     }
 
+    pub fn latest_graded_evaluation_result_for(&self, slug: &str) -> Option<EvaluationRunResult> {
+        self.records
+            .iter()
+            .rev()
+            .flat_map(TraceRecord::evaluation_results)
+            .find(|result| result.slug == slug && result.mode == EvaluationMode::Graded)
+    }
+
+    pub fn latest_graded_evaluation_results_by_slug(&self) -> Vec<EvaluationRunResult> {
+        let mut results = BTreeMap::new();
+        for result in self
+            .records
+            .iter()
+            .rev()
+            .flat_map(TraceRecord::evaluation_results)
+            .filter(|result| result.mode == EvaluationMode::Graded)
+        {
+            results.entry(result.slug.clone()).or_insert(result);
+        }
+
+        results.into_values().collect()
+    }
+
+    pub fn latest_evaluation_errors(&self) -> Vec<EvaluationEvidenceError> {
+        let mut handled_scopes = BTreeSet::new();
+        let mut current_errors = Vec::new();
+
+        for record in self.records.iter().rev() {
+            let Some(action) = record.action.as_ref() else {
+                continue;
+            };
+            match action {
+                TraceAction::FidelityDryRunSkill { slug } => {
+                    let scope = EvaluationEvidenceScope::Skill(slug.clone());
+                    if !handled_scopes.insert(scope) {
+                        continue;
+                    }
+
+                    if let Some(mut error) = record
+                        .parsed_evaluation_evidence()
+                        .errors
+                        .into_iter()
+                        .next()
+                    {
+                        if error.slug.is_none() {
+                            error.slug = Some(slug.clone());
+                        }
+                        current_errors.push(error);
+                    }
+                }
+                TraceAction::FidelityDryRunAll => {
+                    let evidence = record.parsed_evaluation_evidence();
+                    let has_errors = !evidence.errors.is_empty();
+                    for error in evidence.errors {
+                        let scope = error
+                            .slug
+                            .as_ref()
+                            .map(|slug| EvaluationEvidenceScope::Skill(slug.clone()))
+                            .unwrap_or(EvaluationEvidenceScope::All);
+                        if handled_scopes.insert(scope) {
+                            current_errors.push(error);
+                        }
+                    }
+                    for run in evidence.runs {
+                        handled_scopes.insert(EvaluationEvidenceScope::Skill(run.slug));
+                    }
+                    if !has_errors {
+                        handled_scopes.insert(EvaluationEvidenceScope::All);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        current_errors
+    }
+
     pub fn latest_evaluation_results_by_slug(&self) -> Vec<EvaluationRunResult> {
         let mut results = BTreeMap::new();
         for result in self
@@ -1969,10 +2055,9 @@ impl TraceStore {
                 continue;
             }
 
-            let Some(previous) = history[index + 1..]
-                .iter()
-                .find(|candidate| candidate.scope == current.scope)
-            else {
+            let Some(previous) = history[index + 1..].iter().find(|candidate| {
+                candidate.scope == current.scope && candidate.mode == EvaluationMode::Graded
+            }) else {
                 continue;
             };
 
@@ -1999,12 +2084,9 @@ impl TraceStore {
     }
 
     pub fn latest_evaluation_case_results_for(&self, slug: &str) -> Vec<EvaluationCaseResult> {
-        self.records
-            .iter()
-            .rev()
-            .flat_map(TraceRecord::evaluation_case_results)
-            .filter(|result| result.slug == slug)
-            .collect()
+        self.latest_evaluation_case_results_by_slug()
+            .remove(slug)
+            .unwrap_or_default()
     }
 
     pub fn evaluation_run_coverage(&self, total_skill_count: usize) -> EvaluationRunCoverage {
@@ -2018,7 +2100,7 @@ impl TraceStore {
     }
 
     pub fn evaluation_failure_insights(&self) -> EvaluationFailureInsights {
-        let latest_cases = self.latest_evaluation_case_results_by_slug();
+        let latest_cases = self.latest_graded_evaluation_case_results_by_slug();
         let mut insights = EvaluationFailureInsights::default();
         let mut failure_counts_by_slug: BTreeMap<String, usize> = BTreeMap::new();
 
@@ -2058,7 +2140,7 @@ impl TraceStore {
 
     pub fn evaluation_failure_queue(&self) -> Vec<EvaluationFailureItem> {
         let mut queue: Vec<_> = self
-            .latest_evaluation_case_results_by_slug()
+            .latest_graded_evaluation_case_results_by_slug()
             .into_values()
             .flatten()
             .filter(|result| result.status.is_failure() || result.has_failure_evidence())
@@ -2152,12 +2234,58 @@ impl TraceStore {
     ) -> BTreeMap<String, Vec<EvaluationCaseResult>> {
         let mut latest_by_slug = BTreeMap::new();
         for record in self.records.iter().rev() {
-            let mut record_results: BTreeMap<String, Vec<EvaluationCaseResult>> = BTreeMap::new();
+            let run_slugs: Vec<_> = record
+                .evaluation_results()
+                .into_iter()
+                .map(|result| result.slug)
+                .collect();
+            let mut record_results: BTreeMap<String, Vec<EvaluationCaseResult>> = run_slugs
+                .iter()
+                .cloned()
+                .map(|slug| (slug, Vec::new()))
+                .collect();
             for result in record.evaluation_case_results() {
                 record_results
                     .entry(result.slug.clone())
                     .or_default()
                     .push(result);
+            }
+
+            for (slug, results) in record_results {
+                latest_by_slug.entry(slug).or_insert(results);
+            }
+        }
+
+        latest_by_slug
+    }
+
+    fn latest_graded_evaluation_case_results_by_slug(
+        &self,
+    ) -> BTreeMap<String, Vec<EvaluationCaseResult>> {
+        let mut latest_by_slug = BTreeMap::new();
+        for record in self.records.iter().rev() {
+            let graded_slugs: Vec<_> = record
+                .evaluation_results()
+                .into_iter()
+                .filter(|result| result.mode == EvaluationMode::Graded)
+                .map(|result| result.slug)
+                .collect();
+            if graded_slugs.is_empty() {
+                continue;
+            }
+
+            let mut record_results: BTreeMap<String, Vec<EvaluationCaseResult>> = graded_slugs
+                .iter()
+                .cloned()
+                .map(|slug| (slug, Vec::new()))
+                .collect();
+            for result in record.evaluation_case_results() {
+                if graded_slugs.contains(&result.slug) {
+                    record_results
+                        .entry(result.slug.clone())
+                        .or_default()
+                        .push(result);
+                }
             }
 
             for (slug, results) in record_results {
@@ -2632,6 +2760,141 @@ mod tests {
     }
 
     #[test]
+    fn latest_case_results_do_not_merge_history() {
+        let mut store = TraceStore::new(10);
+        let old_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 0,
+              "failed": 1,
+              "results": [
+                {"index": 0, "question": "旧结果", "status": "FAIL"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+        let new_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 1,
+              "failed": 0,
+              "results": [
+                {"index": 0, "question": "新结果", "status": "PASS"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        let cases = store.latest_evaluation_case_results_for("huineng");
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].status, EvaluationCaseStatus::Pass);
+        assert_eq!(cases[0].trace_id, new_run);
+        assert_eq!(cases[0].question, "新结果");
+    }
+
+    #[test]
+    fn later_dry_run_preserves_graded_evidence() {
+        let mut store = TraceStore::new(10);
+        let graded_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            graded_run,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "graded",
+              "outcome": "completed",
+              "total": 1,
+              "passed": 1,
+              "failed": 0,
+              "results": [
+                {"index": 0, "question": "已评分", "status": "PASS"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+        let dry_run = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            dry_run,
+            "master-huineng fidelity dry-run finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "dry_run",
+              "outcome": "completed",
+              "total": 1,
+              "results": [
+                {"index": 0, "question": "仅结构检查", "status": "dry_run"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        let latest = store.latest_evaluation_result_for("huineng").unwrap();
+        assert_eq!(latest.trace_id, dry_run);
+        assert!(latest.is_dry_run());
+
+        let latest_graded = store
+            .latest_graded_evaluation_result_for("huineng")
+            .unwrap();
+        assert_eq!(latest_graded.trace_id, graded_run);
+        assert_eq!(latest_graded.mode, EvaluationMode::Graded);
+        let graded_results = store.latest_graded_evaluation_results_by_slug();
+        assert_eq!(graded_results, vec![latest_graded]);
+
+        let insights = store.evaluation_failure_insights();
+        assert_eq!(insights.total_cases, 1);
+        assert_eq!(insights.pass_cases, 1);
+        assert_eq!(insights.dry_run_cases, 0);
+
+        let history = store.evaluation_run_history(2);
+        assert_eq!(history[0].trace_id, dry_run);
+        assert_eq!(history[0].trend, EvaluationRunTrend::New);
+    }
+
+    #[test]
     fn parses_v1_evaluation_modes_and_case_statuses() {
         let mut store = TraceStore::new(10);
         let run = store.begin_with_action(
@@ -2882,6 +3145,130 @@ mod tests {
         assert_eq!(errors[0].kind, EvaluationEvidenceErrorKind::Execution);
         assert_eq!(errors[0].slug.as_deref(), Some("huineng"));
         assert!(errors[0].message.contains("python exited"));
+    }
+
+    #[test]
+    fn selects_only_current_evaluation_errors_per_skill_scope() {
+        let mut store = TraceStore::new(10);
+
+        let huineng_error = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            huineng_error,
+            "master-huineng fidelity failed",
+            "old huineng failure",
+            Duration::from_millis(50),
+        );
+
+        let zhiyi_error = store.begin_with_action(
+            "Running master-zhiyi fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "zhiyi".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-zhiyi --json"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            zhiyi_error,
+            "master-zhiyi fidelity failed",
+            "current zhiyi failure",
+            Duration::from_millis(50),
+        );
+
+        let huineng_success = store.begin_with_action(
+            "Running master-huineng fidelity dry-run",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --dry-run --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            huineng_success,
+            "master-huineng fidelity finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "dry_run",
+              "outcome": "completed",
+              "total": 1,
+              "results": [
+                {"index": 0, "question": "结构检查", "status": "dry_run"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        let xuanzang_error = store.begin_with_action(
+            "Running master-xuanzang fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "xuanzang".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-xuanzang --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            xuanzang_error,
+            "master-xuanzang fidelity finished",
+            "[",
+            Duration::from_millis(50),
+        );
+
+        let errors = store.latest_evaluation_errors();
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[0].slug.as_deref(), Some("xuanzang"));
+        assert_eq!(errors[1].slug.as_deref(), Some("zhiyi"));
+        assert!(!errors
+            .iter()
+            .any(|error| error.slug.as_deref() == Some("huineng")));
+    }
+
+    #[test]
+    fn successful_all_scope_run_replaces_older_all_scope_error() {
+        let mut store = TraceStore::new(10);
+        let failed_all = store.begin_with_action(
+            "Running all fidelity suites",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --json"),
+            "Queued.",
+        );
+        store.finish_error_with_detail(
+            failed_all,
+            "all fidelity suites failed",
+            "runner exited before producing JSON",
+            Duration::from_millis(50),
+        );
+        assert_eq!(store.latest_evaluation_errors().len(), 1);
+
+        let successful_all = store.begin_with_action(
+            "Running all fidelity suites",
+            TraceAction::FidelityDryRunAll,
+            Some("python3 scripts/test-fidelity.py --all --dry-run --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            successful_all,
+            "all fidelity suites finished",
+            r#"[{
+              "schema_version": 1,
+              "master": "master-huineng",
+              "mode": "dry_run",
+              "outcome": "completed",
+              "total": 1,
+              "results": [
+                {"index": 0, "question": "结构检查", "status": "dry_run"}
+              ]
+            }]"#,
+            Duration::from_millis(50),
+        );
+
+        assert!(store.latest_evaluation_errors().is_empty());
     }
 
     #[test]
@@ -3260,7 +3647,7 @@ mod tests {
     }
 
     #[test]
-    fn keeps_pass_rate_not_applicable_for_dry_run_only_cases() {
+    fn keeps_graded_insights_empty_for_dry_run_only_cases() {
         let mut store = TraceStore::new(10);
 
         let run = store.begin_with_action(
@@ -3296,8 +3683,8 @@ mod tests {
 
         let insights = store.evaluation_failure_insights();
 
-        assert_eq!(insights.total_cases, 2);
-        assert_eq!(insights.dry_run_cases, 2);
+        assert_eq!(insights.total_cases, 0);
+        assert_eq!(insights.dry_run_cases, 0);
         assert_eq!(insights.graded_cases(), 0);
         assert_eq!(insights.pass_rate_label(), "N/A");
     }

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -226,9 +226,11 @@ impl EvaluationRunHistoryItem {
     }
 
     fn pass_rate_basis(&self) -> usize {
-        (self.passed_count * 10_000)
-            .checked_div(self.total_count)
-            .unwrap_or(0)
+        if self.total_count == 0 {
+            return 0;
+        }
+        let basis = (self.passed_count as u128 * 10_000) / self.total_count as u128;
+        basis.min(usize::MAX as u128) as usize
     }
 
     pub fn matches_filter(&self, filter: EvaluationRunHistoryFilter) -> bool {
@@ -1071,11 +1073,19 @@ fn evaluation_case_statuses(
 ) -> Result<Vec<EvaluationCaseStatus>, String> {
     cases
         .iter()
-        .map(|case| match EvaluationCaseStatus::from_wire(&case.status) {
-            EvaluationCaseStatus::Unknown(status) => Err(format!(
-                "invalid fidelity suite: unknown case status {status:?}"
-            )),
-            status => Ok(status),
+        .map(|case| {
+            if case.index.checked_add(1).is_none() {
+                return Err(format!(
+                    "invalid fidelity suite: case index {} cannot be displayed one-based",
+                    case.index
+                ));
+            }
+            match EvaluationCaseStatus::from_wire(&case.status) {
+                EvaluationCaseStatus::Unknown(status) => Err(format!(
+                    "invalid fidelity suite: unknown case status {status:?}"
+                )),
+                status => Ok(status),
+            }
         })
         .collect()
 }
@@ -1269,6 +1279,14 @@ fn compare_evaluation_runs(
             std::cmp::Ordering::Less => EvaluationRunTrend::Regressed,
             std::cmp::Ordering::Equal => EvaluationRunTrend::Stable,
         }
+    }
+}
+
+fn signed_usize_delta(current: usize, previous: usize) -> isize {
+    if current >= previous {
+        current.saturating_sub(previous).min(isize::MAX as usize) as isize
+    } else {
+        -(previous.saturating_sub(current).min(isize::MAX as usize) as isize)
     }
 }
 
@@ -2153,10 +2171,10 @@ impl TraceStore {
                 previous_trace_id: previous.trace_id,
                 current_failed_count,
                 previous_failed_count,
-                failed_delta: current_failed_count as isize - previous_failed_count as isize,
+                failed_delta: signed_usize_delta(current_failed_count, previous_failed_count),
                 current_pass_rate,
                 previous_pass_rate,
-                pass_rate_delta_points: current_pass_rate as isize - previous_pass_rate as isize,
+                pass_rate_delta_points: signed_usize_delta(current_pass_rate, previous_pass_rate),
                 action: current.action.clone(),
             });
         }
@@ -3210,6 +3228,47 @@ mod tests {
     }
 
     #[test]
+    fn rejects_case_index_that_cannot_be_displayed_one_based() {
+        let mut store = TraceStore::new(10);
+        let run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("python3 scripts/test-fidelity.py --master master-huineng --json"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            run,
+            "master-huineng fidelity finished",
+            format!(
+                r#"[{{
+                  "schema_version": 1,
+                  "master": "master-huineng",
+                  "mode": "graded",
+                  "outcome": "completed",
+                  "total": 1,
+                  "passed": 1,
+                  "failed": 0,
+                  "results": [
+                    {{"index": {}, "question": "overflow", "status": "PASS"}}
+                  ]
+                }}]"#,
+                usize::MAX
+            ),
+            Duration::from_millis(50),
+        );
+
+        let errors = store.records.back().unwrap().evaluation_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].kind,
+            EvaluationEvidenceErrorKind::MalformedPayload
+        );
+        assert!(errors[0].message.contains("index"));
+    }
+
+    #[test]
     fn rejects_evaluation_payload_for_wrong_skill_scope() {
         let mut store = TraceStore::new(10);
         let run = store.begin_with_action(
@@ -4140,6 +4199,24 @@ mod tests {
     }
 
     #[test]
+    fn pass_rate_calculation_handles_large_legacy_counts() {
+        let item = EvaluationRunHistoryItem {
+            trace_id: 1,
+            scope: "master-huineng".to_string(),
+            status: TraceStatus::Succeeded,
+            passed_count: usize::MAX,
+            total_count: usize::MAX,
+            failed_count: 0,
+            mode: EvaluationMode::Graded,
+            duration_ms: None,
+            action: None,
+            trend: EvaluationRunTrend::New,
+        };
+
+        assert_eq!(item.pass_rate_percent(), 100);
+    }
+
+    #[test]
     fn annotates_evaluation_run_history_with_scope_trends() {
         let mut store = TraceStore::new(10);
 
@@ -4806,6 +4883,47 @@ mod tests {
                 slug: "huineng".to_string()
             })
         );
+    }
+
+    #[test]
+    fn saturates_large_legacy_regression_deltas() {
+        let mut store = TraceStore::new(10);
+        let old_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("legacy fidelity"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            old_run,
+            "legacy fidelity finished",
+            "Testing: master-huineng\nResult: 0/1 passed (0%)",
+            Duration::from_millis(50),
+        );
+        let new_run = store.begin_with_action(
+            "Running master-huineng fidelity",
+            TraceAction::FidelityDryRunSkill {
+                slug: "huineng".to_string(),
+            },
+            Some("legacy fidelity"),
+            "Queued.",
+        );
+        store.finish_success_with_detail(
+            new_run,
+            "legacy fidelity finished",
+            format!(
+                "Testing: master-huineng\nResult: 0/{} passed (0%)",
+                usize::MAX
+            ),
+            Duration::from_millis(50),
+        );
+
+        let regressions = store.evaluation_regressions(8);
+
+        assert_eq!(regressions.len(), 1);
+        assert_eq!(regressions[0].failed_delta, isize::MAX);
     }
 
     #[test]

--- a/desktop/tests/baseline_cli.rs
+++ b/desktop/tests/baseline_cli.rs
@@ -135,20 +135,28 @@ fn baseline_flag_runs_headless_and_records_traces_for_all_master_skills() {
         .expect("failed to load trace store written by --baseline");
     let coverage = store.evaluation_run_coverage(expected_min);
     assert!(
-        coverage.is_complete(),
-        "expected full evaluation coverage after --baseline, got {}: {coverage:?}",
-        coverage.label()
+        coverage.is_structurally_complete(),
+        "expected full structural coverage after --baseline, got {}: {coverage:?}",
+        coverage.structural_label()
     );
-    assert_eq!(coverage.label(), format!("{expected_min}/{expected_min}"));
+    assert_eq!(
+        coverage.structural_label(),
+        format!("{expected_min}/{expected_min}")
+    );
+    assert!(
+        !coverage.is_graded_complete(),
+        "dry-run baseline must not count as graded evidence: {coverage:?}"
+    );
 
     let insights = store.evaluation_failure_insights();
     let trend = store.evaluation_trend_summary(expected_min * 2);
     let brief = EvaluationDecisionBrief::from_signals(&coverage, &trend, &insights);
-    assert_ne!(
+    assert_eq!(
         brief.posture,
         EvaluationDecisionPosture::Unproven,
-        "Quality Gate should leave Unproven after a full --baseline run: {brief:?}"
+        "Quality Gate must remain Unproven after a dry-run-only baseline: {brief:?}"
     );
+    assert_eq!(brief.headline, "Graded evidence incomplete");
 
     fs::remove_dir_all(&xdg_data_home).ok();
 }

--- a/docs/superpowers/plans/2026-07-30-desktop-evaluation-contract.md
+++ b/docs/superpowers/plans/2026-07-30-desktop-evaluation-contract.md
@@ -1,0 +1,758 @@
+# Desktop Evaluation Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans and superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make fidelity output and desktop evaluation evidence explicit, typed, backward compatible, fail-closed, and truthful about dry-run versus graded coverage.
+
+**Architecture:** The Python runner emits a versioned suite envelope while preserving its top-level JSON array and exit semantics. Rust dispatches versioned and legacy payloads into typed domain states, exposes current evidence errors instead of discarding them, and computes case detail, coverage, failures, trends, and release posture from deliberately selected latest runs. Catalog JSONL parsing returns diagnostics rather than inventing empty cases.
+
+**Tech Stack:** Python 3.11+, pytest, Rust 2021, serde/serde_json, Cargo, egui.
+
+## Global Constraints
+
+- Keep the top-level `scripts/test-fidelity.py --json` shape as a JSON array.
+- Do not make paid model calls.
+- Keep legacy JSON arrays and legacy `Testing:` / `Result:` trace output readable.
+- Treat ambiguity, malformed v1 fields, unsupported versions, and unknown statuses as invalid evidence.
+- A later dry-run must not erase the newest graded evidence for behavioral analytics.
+- The case-detail query must return one completed run only and never merge history.
+- Invalid or unreadable fidelity JSONL contributes zero usable cases and cannot be `Ready`.
+- `Ready` requires complete newest-graded coverage with no current error, failure, or regression.
+- Keep the implementation in the existing Rust modules; module extraction belongs to a later refactor.
+- Preserve unrelated worktree changes.
+
+---
+
+### Task 1: Emit the fidelity JSON v1 suite contract
+
+**Files:**
+
+- Modify: `tests/test_fidelity_exit.py`
+- Modify: `scripts/test-fidelity.py`
+
+**Interfaces:**
+
+- Produces: `suite_error(master_name: str, dry_run: bool, message: str) -> dict`
+- Produces: every new suite object with `schema_version`, `master`, `mode`, `outcome`, `total`, and `results`
+- Preserves: `results_failed(results: list[dict], dry_run: bool) -> bool`
+
+- [ ] **Step 1: Add a failing completed dry-run contract test**
+
+Add a unit test that runs one real local case without a model call:
+
+```python
+def test_dry_run_emits_versioned_completed_suite(runner):
+    suite = runner.run_tests(
+        "master-huineng",
+        dry_run=True,
+        max_tests=1,
+        quiet=True,
+    )
+
+    assert suite["schema_version"] == 1
+    assert suite["master"] == "master-huineng"
+    assert suite["mode"] == "dry_run"
+    assert suite["outcome"] == "completed"
+    assert suite["total"] == 1
+    assert len(suite["results"]) == 1
+    assert "passed" not in suite
+    assert "failed" not in suite
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python -m pytest tests/test_fidelity_exit.py::test_dry_run_emits_versioned_completed_suite -q
+```
+
+Expected: FAIL because the current dry-run object has no version, mode, or outcome.
+
+- [ ] **Step 3: Add the common v1 fields to completed suites**
+
+Define:
+
+```python
+SCHEMA_VERSION = 1
+
+
+def suite_common(master_name: str, dry_run: bool, outcome: str) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "master": master_name,
+        "mode": "dry_run" if dry_run else "graded",
+        "outcome": outcome,
+    }
+```
+
+Build the dry-run return from `suite_common(..., "completed")` and add
+`total` plus `results`. Build the graded completed return the same way while
+retaining `model`, `passed`, `failed`, `pass_rate`, and `results`.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing error-suite contract tests**
+
+Test `run_tests("master-does-not-exist", dry_run=False)` and the existing
+subprocess result. Assert the error suite equals:
+
+```python
+{
+    "schema_version": 1,
+    "master": "master-does-not-exist",
+    "mode": "graded",
+    "outcome": "error",
+    "total": 0,
+    "results": [],
+    "error": "Master 'master-does-not-exist' not found",
+}
+```
+
+Also extend the subprocess assertion to require all seven contract fields.
+
+- [ ] **Step 6: Run the error tests and verify RED**
+
+Run:
+
+```bash
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python -m pytest \
+  tests/test_fidelity_exit.py::test_missing_master_emits_versioned_error_suite \
+  tests/test_fidelity_exit.py::test_missing_master_exits_nonzero_with_clean_json_stdout \
+  -q
+```
+
+Expected: FAIL because precondition errors currently contain only `error`.
+
+- [ ] **Step 7: Centralize precondition errors**
+
+Implement:
+
+```python
+def suite_error(master_name: str, dry_run: bool, message: str) -> dict:
+    return {
+        **suite_common(master_name, dry_run, "error"),
+        "total": 0,
+        "results": [],
+        "error": message,
+    }
+```
+
+Use it for missing master, missing fidelity data, missing `anthropic`, and
+missing `ANTHROPIC_API_KEY`.
+
+- [ ] **Step 8: Verify the Python contract and exit behavior**
+
+Run:
+
+```bash
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python -m pytest tests/test_fidelity_exit.py -q
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python scripts/test-fidelity.py \
+  --master master-huineng --dry-run --json > /tmp/master-skill-pr1-fidelity.json
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python -m json.tool \
+  /tmp/master-skill-pr1-fidelity.json >/dev/null
+```
+
+Expected: all tests pass and both commands exit 0.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add scripts/test-fidelity.py tests/test_fidelity_exit.py
+git commit -m "feat(fidelity): emit versioned evaluation suites"
+```
+
+---
+
+### Task 2: Parse evaluation suites into typed Rust evidence
+
+**Files:**
+
+- Modify: `desktop/src/trace.rs`
+
+**Interfaces:**
+
+- Produces:
+
+```rust
+pub enum EvaluationMode {
+    DryRun,
+    Graded,
+}
+
+pub enum EvaluationCaseStatus {
+    Pass,
+    Fail,
+    DryRun,
+    ApiError,
+    Unknown(String),
+}
+
+pub enum EvaluationEvidenceErrorKind {
+    Execution,
+    MalformedPayload,
+    UnsupportedVersion,
+}
+
+pub struct EvaluationEvidenceError {
+    pub trace_id: u64,
+    pub slug: Option<String>,
+    pub kind: EvaluationEvidenceErrorKind,
+    pub message: String,
+}
+```
+
+- Changes `EvaluationRunResult` and `EvaluationRunHistoryItem` from
+  `dry_run: bool` to `mode: EvaluationMode`
+- Changes `EvaluationCaseResult.status` from `String` to
+  `EvaluationCaseStatus`
+- Produces `TraceRecord::evaluation_errors()`
+
+- [ ] **Step 1: Add failing v1 parsing tests**
+
+Add one test with a completed v1 dry-run suite and one with a completed v1
+graded suite. Assert explicit `EvaluationMode`, typed case statuses, counts,
+and slug normalization.
+
+Use this dry-run fixture:
+
+```json
+[{
+  "schema_version": 1,
+  "master": "master-huineng",
+  "mode": "dry_run",
+  "outcome": "completed",
+  "total": 1,
+  "results": [{"index": 0, "question": "Q", "status": "dry_run"}]
+}]
+```
+
+Use a graded fixture with `passed: 1`, `failed: 1`, one `PASS`, and one
+`FAIL`.
+
+- [ ] **Step 2: Run the v1 tests and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml \
+  parses_v1_evaluation -- --nocapture
+```
+
+Expected: compilation/test failure because the typed domain API does not exist.
+
+- [ ] **Step 3: Introduce typed domain enums and wire structs**
+
+Derive `Clone`, `Debug`, `PartialEq`, and `Eq` for the domain enums. Add
+`EvaluationMode::is_dry_run()` and a case-status parser that recognizes
+case-insensitive `PASS`, `FAIL`, `dry_run`, and `api_error`, retaining any
+other text in `Unknown`.
+
+Deserialize versioned suites through required wire fields:
+
+```rust
+#[derive(Deserialize)]
+struct EvaluationSuiteV1 {
+    schema_version: u64,
+    master: String,
+    mode: EvaluationModeWire,
+    outcome: EvaluationOutcomeWire,
+    total: usize,
+    results: Vec<EvaluationCaseWire>,
+    passed: Option<usize>,
+    failed: Option<usize>,
+    error: Option<String>,
+}
+```
+
+Use a small `schema_version` probe only to dispatch each JSON object. Do not
+default missing required v1 fields.
+
+- [ ] **Step 4: Convert valid v1 suites and verify GREEN**
+
+For `outcome = completed`, require:
+
+- dry-run cases to contain only `DryRun`, with no graded counts required;
+- graded suites to contain integer `passed` and `failed`;
+- no `Unknown` status.
+
+Convert each valid suite into run and case domain values, then run the tests
+from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing legacy compatibility tests**
+
+Retain or extend tests for:
+
+- old JSON with all `dry_run` statuses => `EvaluationMode::DryRun`;
+- old JSON with `passed` => `EvaluationMode::Graded`;
+- legacy plain-text `Testing:` / `Result:` output => graded result;
+- ambiguous legacy JSON without `passed` and without all-dry-run cases =>
+  malformed evidence.
+
+- [ ] **Step 6: Run legacy tests and verify RED where behavior changes**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml legacy_evaluation -- --nocapture
+```
+
+Expected: the new ambiguity test fails until legacy conversion is explicit.
+
+- [ ] **Step 7: Implement legacy conversion without field-absence mode inference**
+
+Deserialize legacy suites into a separate wire struct. Infer dry-run only when
+the suite has at least one case and every status is `DryRun`. Infer graded only
+when `passed` is present. Reject every other legacy JSON suite. Keep the
+existing plain-text parser as a graded fallback only when the detail is not a
+JSON document.
+
+- [ ] **Step 8: Add failing evidence-error tests**
+
+Test:
+
+- v1 `outcome = error` creates `Execution`;
+- malformed JSON creates `MalformedPayload`;
+- `schema_version = 2` creates `UnsupportedVersion`;
+- an unknown case status creates `MalformedPayload` and produces no completed
+  run;
+- a failed fidelity `TraceRecord` creates `Execution`.
+
+- [ ] **Step 9: Run evidence-error tests and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml evaluation_evidence_error -- --nocapture
+```
+
+Expected: FAIL because errors are currently dropped.
+
+- [ ] **Step 10: Return one parsed evaluation payload per trace**
+
+Add a private container:
+
+```rust
+#[derive(Default)]
+struct ParsedEvaluationEvidence {
+    runs: Vec<EvaluationRunResult>,
+    cases: Vec<EvaluationCaseResult>,
+    errors: Vec<EvaluationEvidenceError>,
+}
+```
+
+Make `TraceRecord::evaluation_results()`,
+`TraceRecord::evaluation_case_results()`, and
+`TraceRecord::evaluation_errors()` delegate to the same conversion rules.
+For a failed fidelity trace, preserve its scope and detail in an execution
+error. For JSON that begins as JSON but cannot satisfy a supported contract,
+return a parse/version error instead of falling through to the text parser.
+
+- [ ] **Step 11: Update enum call sites and verify the trace module**
+
+Replace string status comparisons with enum matches and replace direct
+`dry_run` field access with `mode`/`is_dry_run()`. Then run:
+
+```bash
+cargo fmt --manifest-path desktop/Cargo.toml
+cargo test --locked --manifest-path desktop/Cargo.toml trace::tests -- --nocapture
+```
+
+Expected: all trace tests pass.
+
+- [ ] **Step 12: Commit Task 2**
+
+```bash
+git add desktop/src/trace.rs
+git commit -m "refactor(desktop): type evaluation evidence"
+```
+
+---
+
+### Task 3: Enforce latest-run semantics for cases and graded analytics
+
+**Files:**
+
+- Modify: `desktop/src/trace.rs`
+- Modify: `desktop/src/app.rs`
+- Modify: `desktop/tests/baseline_cli.rs`
+
+**Interfaces:**
+
+- `latest_evaluation_case_results_for(slug)` returns cases from one newest
+  completed run
+- Structural coverage uses newest completed run of either mode
+- Graded coverage/failures/trends use newest graded run per skill
+- Current evidence errors remain until a successful attempt for the same scope
+
+- [ ] **Step 1: Add a failing no-history-merge regression test**
+
+Create an older graded trace with case index `0 = FAIL` and a newer graded
+trace with case index `0 = PASS`. Assert:
+
+```rust
+let cases = store.latest_evaluation_case_results_for("huineng");
+assert_eq!(cases.len(), 1);
+assert_eq!(cases[0].status, EvaluationCaseStatus::Pass);
+assert_eq!(cases[0].trace_id, newer_trace_id);
+```
+
+- [ ] **Step 2: Run the case test and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml \
+  latest_case_results_do_not_merge_history -- --nocapture
+```
+
+Expected: FAIL because the current method returns both records.
+
+- [ ] **Step 3: Stop after the newest completed record for a skill**
+
+Walk trace records newest-first. At the first completed record containing the
+normalized slug, return only that record's cases for the slug. Remove the UI's
+dependence on insertion order; collecting those cases by index is then safe.
+
+- [ ] **Step 4: Verify the latest-case test GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing graded-evidence retention tests**
+
+Create an older graded PASS followed by a newer dry-run for the same skill.
+Assert:
+
+- structural latest mode is dry-run;
+- newest graded result is still the older graded PASS;
+- failure insights use newest graded cases;
+- dry-run history is not compared as a graded regression.
+
+- [ ] **Step 6: Run the graded-retention tests and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml \
+  later_dry_run_preserves_graded_evidence -- --nocapture
+```
+
+Expected: FAIL because current analytics use the latest result of any mode.
+
+- [ ] **Step 7: Add newest-graded queries and graded trend comparison**
+
+Implement newest-first queries that filter `EvaluationMode::Graded` before
+deduplicating by slug. Use them for graded coverage, case-failure insights,
+failure queue, and regression comparison. Keep the case-detail and structural
+queries mode-agnostic. Give dry-run history entries `New` rather than comparing
+them against graded scores.
+
+- [ ] **Step 8: Add failing current-error replacement tests**
+
+Test:
+
+- newest failed/malformed attempt for a skill is returned;
+- an older error is suppressed by a later successful completed attempt for the
+  same skill;
+- errors for other skills remain visible;
+- an all-scope error is current until a later successful all-scope run.
+
+- [ ] **Step 9: Implement current evidence error selection**
+
+Walk records newest-first and track handled scopes. A successful suite handles
+its skill scope; an error handles its explicit skill scope; an all-scope action
+uses a distinct all-scope key. Return only the first outcome observed per
+scope.
+
+- [ ] **Step 10: Verify trace, app, and integration tests**
+
+Run:
+
+```bash
+cargo fmt --manifest-path desktop/Cargo.toml
+cargo test --locked --manifest-path desktop/Cargo.toml
+```
+
+Expected: all Rust tests pass.
+
+- [ ] **Step 11: Commit Task 3**
+
+```bash
+git add desktop/src/trace.rs desktop/src/app.rs desktop/tests/baseline_cli.rs
+git commit -m "fix(desktop): select current evaluation evidence"
+```
+
+---
+
+### Task 4: Fail closed on invalid fidelity JSONL
+
+**Files:**
+
+- Modify: `desktop/src/catalog.rs`
+- Modify: `desktop/src/app.rs`
+
+**Interfaces:**
+
+- Changes `parse_fidelity_cases(content)` to
+  `Result<Vec<FidelityCase>, String>`
+- Adds `fidelity_error: Option<String>` to `SkillDiagnostics` and `SkillRow`
+- Makes diagnostic gaps own strings so the line-numbered parse detail can be
+  surfaced
+
+- [ ] **Step 1: Add a failing invalid-line catalog test**
+
+Write a temporary `tests/fidelity.jsonl` with one valid case and a malformed
+second line. Assert:
+
+```rust
+assert_eq!(diagnostics.fidelity_case_count, 0);
+assert!(diagnostics.fidelity_cases.is_empty());
+assert!(diagnostics
+    .fidelity_error
+    .as_deref()
+    .is_some_and(|error| error.contains("line 2")));
+```
+
+Apply the diagnostics to a row and assert it is not `QualityLevel::Ready` and
+its summary contains `invalid fidelity suite`.
+
+- [ ] **Step 2: Run the catalog test and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml \
+  invalid_fidelity_jsonl_fails_closed -- --nocapture
+```
+
+Expected: FAIL because the current parser turns invalid lines into default
+values and still counts them.
+
+- [ ] **Step 3: Parse every nonblank line transactionally**
+
+For each nonblank line, deserialize `serde_json::Value`, require a non-empty
+string `q`, and convert it to `FidelityCase`. On the first error return:
+
+```rust
+Err(format!("line {}: {error}", line_index + 1))
+```
+
+Do not return partial cases. Distinguish missing file (`None`), unreadable file
+(`Some(read error)`), valid file, and invalid file.
+
+- [ ] **Step 4: Propagate the diagnostic through rows and quality**
+
+Copy `fidelity_error` in `apply_diagnostics`. Require
+`fidelity_error.is_none()` for `Ready`. Emit either:
+
+- `missing fidelity suite`, or
+- `invalid fidelity suite: {line-numbered detail}`
+
+but never both.
+
+- [ ] **Step 5: Update row fixtures and verify GREEN**
+
+Set `fidelity_error: None` in test helpers and app fixtures. Run:
+
+```bash
+cargo fmt --manifest-path desktop/Cargo.toml
+cargo test --locked --manifest-path desktop/Cargo.toml catalog::tests -- --nocapture
+```
+
+Expected: all catalog tests pass.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add desktop/src/catalog.rs desktop/src/app.rs
+git commit -m "fix(desktop): reject invalid fidelity suites"
+```
+
+---
+
+### Task 5: Make evaluation coverage and release posture truthful
+
+**Files:**
+
+- Modify: `desktop/src/trace.rs`
+- Modify: `desktop/src/app.rs`
+- Modify: `desktop/tests/baseline_cli.rs`
+
+**Interfaces:**
+
+- Expands `EvaluationRunCoverage` with structural, graded, dry-run, and current
+  error counts
+- Adds `is_structurally_complete()` and `is_graded_complete()`
+- Enforces decision precedence:
+  regression, error, graded failure, structural gap, graded gap, ready
+
+- [ ] **Step 1: Add a failing dry-run-only gate test**
+
+Build rows for every expected skill and add completed v1 dry-run traces for
+every skill. Assert:
+
+```rust
+assert!(snapshot.run_coverage.is_structurally_complete());
+assert!(!snapshot.run_coverage.is_graded_complete());
+assert_eq!(snapshot.decision.posture, EvaluationDecisionPosture::Unproven);
+assert_eq!(snapshot.decision.headline, "Graded evidence incomplete");
+```
+
+- [ ] **Step 2: Run the dry-run gate test and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml \
+  complete_dry_run_coverage_is_unproven -- --nocapture
+```
+
+Expected: FAIL because complete dry-run coverage currently becomes `Ready`.
+
+- [ ] **Step 3: Separate structural and graded coverage**
+
+Populate:
+
+```rust
+pub struct EvaluationRunCoverage {
+    pub total_skill_count: usize,
+    pub structural_run_skill_count: usize,
+    pub graded_run_skill_count: usize,
+    pub dry_run_skill_count: usize,
+    pub current_error_count: usize,
+}
+```
+
+Structural counts come from newest completed any-mode results. Graded counts
+come from newest graded results independently. Clamp counts to the discovered
+skill total only for presentation percentages, not for evidence selection.
+
+- [ ] **Step 4: Implement decision precedence through focused tests**
+
+Add one focused test for each state:
+
+1. graded regression => `Blocked`;
+2. current evidence error => `Blocked`;
+3. current graded case failure => existing failure-review posture;
+4. incomplete structural coverage => `Unproven`;
+5. complete structural but incomplete graded => `Unproven` with
+   `Graded evidence incomplete`;
+6. complete graded passing coverage => `Ready`.
+
+Run each new test immediately before implementing its branch, verify RED,
+implement the smallest branch, then verify GREEN.
+
+- [ ] **Step 5: Update UI labels and baseline assertions**
+
+Show structural and graded counts separately. Ensure dry-run copy says it
+establishes structure only. Update the baseline integration test to require
+structural completeness while explicitly expecting dry-run-only evidence not
+to be release-ready.
+
+- [ ] **Step 6: Verify the complete Rust suite**
+
+Run:
+
+```bash
+cargo fmt --manifest-path desktop/Cargo.toml
+cargo clippy --locked --manifest-path desktop/Cargo.toml --all-targets -- -D warnings
+cargo test --locked --manifest-path desktop/Cargo.toml
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add desktop/src/trace.rs desktop/src/app.rs desktop/tests/baseline_cli.rs
+git commit -m "fix(desktop): require graded release evidence"
+```
+
+---
+
+### Task 6: Review, document, and verify PR 1
+
+**Files:**
+
+- Modify only if evidence requires it: `README.md`, `desktop/README.md`
+- Review: every file changed since `origin/main`
+
+- [ ] **Step 1: Inspect the complete diff**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+Check for:
+
+- accidental schema breakage;
+- a path that still infers dry-run from missing `passed`;
+- stringly typed case status comparisons;
+- latest-any evidence feeding graded analytics;
+- malformed/error suites disappearing;
+- dry-run-only copy implying release readiness;
+- unrelated changes.
+
+- [ ] **Step 2: Run focused contract tests**
+
+Run:
+
+```bash
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python -m pytest tests/test_fidelity_exit.py -q
+cargo test --locked --manifest-path desktop/Cargo.toml
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run repository-wide verification**
+
+Run:
+
+```bash
+npm test
+/tmp/master-skill-pr1.nx5E4j/venv/bin/python -m pytest tests/ scripts/tests/ -q
+cargo fmt --manifest-path desktop/Cargo.toml -- --check
+cargo clippy --locked --manifest-path desktop/Cargo.toml --all-targets -- -D warnings
+cargo test --locked --manifest-path desktop/Cargo.toml
+cargo build --locked --manifest-path desktop/Cargo.toml
+```
+
+Expected: all commands exit 0, with no paid evaluation.
+
+- [ ] **Step 4: Perform final self-review**
+
+Re-read both design and implementation plan documents against the diff. Fix
+every correctness, compatibility, or clarity issue found through a new
+red-green cycle where behavior changes.
+
+- [ ] **Step 5: Commit documentation-only corrections if needed**
+
+```bash
+git add docs README.md desktop/README.md
+git commit -m "docs(desktop): explain evaluation evidence modes"
+```
+
+Skip this commit when no documentation correction is needed.
+
+- [ ] **Step 6: Prepare the PR handoff**
+
+Record:
+
+- commit list;
+- diff summary;
+- exact verification commands and outcomes;
+- backward-compatibility behavior;
+- intentionally deferred PR 2 runtime work.
+

--- a/docs/superpowers/plans/2026-07-30-desktop-evaluation-contract.md
+++ b/docs/superpowers/plans/2026-07-30-desktop-evaluation-contract.md
@@ -755,4 +755,3 @@ Record:
 - exact verification commands and outcomes;
 - backward-compatibility behavior;
 - intentionally deferred PR 2 runtime work.
-

--- a/docs/superpowers/specs/2026-07-30-desktop-evaluation-contract-design.md
+++ b/docs/superpowers/specs/2026-07-30-desktop-evaluation-contract-design.md
@@ -1,0 +1,220 @@
+# Desktop Evaluation Contract Design
+
+**Date:** 2026-07-30
+
+**Target branch:** `fix/desktop-evaluation-contract`
+
+**Goal:** Make desktop fidelity evidence deterministic, typed, backward
+compatible, and truthful about the difference between structural dry-runs and
+graded behavioral evidence.
+
+## Scope and selected approach
+
+This PR fixes the evaluation-specific findings from the desktop review:
+
+- historical case results can overwrite the newest result;
+- dry-run mode is inferred from a missing JSON field;
+- malformed and error suites disappear;
+- invalid JSONL can count as a fidelity case;
+- complete dry-run coverage is presented as release-ready.
+
+Three approaches were considered:
+
+1. **Patch the UI map and relabel the gate.** This is small, but the store API
+   would still return the wrong data and malformed/error evidence would remain
+   invisible.
+2. **Add a backward-compatible fidelity v1 contract and typed Rust domain
+   states.** This is the selected approach because it fixes the boundary that
+   creates all five symptoms while retaining old traces and external JSON
+   consumers.
+3. **Replace the fidelity runner and trace analytics together.** This would
+   permit a cleaner new API but would unnecessarily break the existing Python
+   runner, CI automation, and persisted history.
+
+The PR keeps evaluation code in the existing Rust files. Extracting
+`evaluation.rs` and a bulk desktop API remains later architecture work.
+
+## Root-cause evidence
+
+### Historical case results overwrite current results
+
+`TraceStore::latest_evaluation_case_results_for` walks every record
+newest-first and returns every matching historical case. The UI collects that
+sequence into a `BTreeMap<case_index, result>`. Older values are inserted after
+newer values, so an old result for the same case index replaces the current
+result.
+
+The store API promises "latest" while returning history. The fix belongs in the
+store query rather than changing UI insertion order.
+
+### Evaluation mode and errors are implicit
+
+The Python JSON output omits `passed` for a dry-run. Rust interprets that
+absence as `dry_run = true`, skips suites with missing fields, and drops
+`{"error": ...}` suites. The catalog parser separately converts an invalid
+JSONL line into an empty JSON value and still counts it as a case.
+
+The root cause is using field absence and `serde_json::Value` defaults as domain
+state.
+
+### Dry-run coverage is presented as release evidence
+
+The gate returns `Ready` whenever every skill has any latest run and there are
+no parsed failures or regressions. A complete dry-run therefore produces
+`Ready` even though it makes no model calls and cannot pass or fail behavioral
+assertions.
+
+One coverage count currently represents two claims: structural discoverability
+and graded behavioral evidence.
+
+## Backward-compatible fidelity JSON v1
+
+`scripts/test-fidelity.py --json` continues to emit a top-level JSON array so
+existing automation that iterates suites remains compatible. Every suite in new
+output uses this v1 contract:
+
+```json
+{
+  "schema_version": 1,
+  "master": "master-huineng",
+  "mode": "dry_run",
+  "outcome": "completed",
+  "total": 2,
+  "results": [
+    {
+      "index": 0,
+      "question": "什么是见性成佛？",
+      "difficulty": "basic",
+      "status": "dry_run"
+    }
+  ]
+}
+```
+
+Exact field rules:
+
+- `schema_version` is the integer `1`.
+- `master` is always present, including error suites.
+- `mode` is exactly `dry_run` or `graded`.
+- `outcome` is exactly `completed` or `error`.
+- `total` and `results` are present for every outcome; precondition errors use
+  `0` and `[]`.
+- A completed graded suite also has integer `passed` and `failed`.
+- An error suite has a non-empty string `error`.
+- A completed dry-run preserves the existing omission of `passed` and `failed`
+  for consumers that still use the legacy convention.
+
+The runner's existing exit contract remains unchanged: successful dry-runs exit
+zero; top-level errors, API errors, and graded failures exit non-zero.
+
+## Rust wire and domain types
+
+Rust parses v1 suites into required wire fields and converts them to domain
+types:
+
+```text
+EvaluationMode = DryRun | Graded
+EvaluationCaseStatus = Pass | Fail | DryRun | ApiError | Unknown(String)
+EvaluationSuiteOutcome = Completed | Error(String)
+EvaluationEvidenceError = Execution | MalformedPayload | UnsupportedVersion
+```
+
+`Unknown(String)` is retained for diagnostics and makes the suite invalid
+evidence; it is never treated as a pass or an ordinary graded failure.
+Malformed v1 fields produce an explicit evaluation evidence error.
+
+Legacy trace history remains readable:
+
+- the old JSON array is accepted;
+- legacy mode is inferred as dry-run only when every case status is `dry_run`;
+- a suite with `passed` is graded;
+- the old plain-text `Testing:` / `Result:` format remains readable;
+- ambiguous legacy JSON becomes invalid evidence instead of a dry-run.
+
+Raw command output remains stored for audit and migration diagnostics.
+
+## Latest-result and analytics semantics
+
+For the case-detail panel, a skill query returns results from the newest
+completed trace record that contains that skill and stops. It never combines
+case indexes from different runs.
+
+Behavioral analytics do not let a later dry-run erase valid graded evidence:
+
+- the case-detail panel uses the latest completed run of either mode;
+- structural coverage uses the latest completed run of either mode;
+- graded coverage, failure insights, and regression comparisons use the newest
+  graded run per skill;
+- the newest failed or malformed attempt remains visible as an evidence error
+  until a later successful attempt for the same scope replaces it.
+
+A regression test records an older FAIL and a newer PASS for the same skill and
+case index, then asserts that only the newer PASS is returned.
+
+Trace records do not contain repository revision hashes, so this PR does not
+claim that historical graded evidence is newer than the skill content. Adding
+content/revision fingerprints is a separate design.
+
+## Fail-closed local fidelity diagnostics
+
+Fidelity JSONL parsing returns a line-numbered error instead of a default case.
+The desktop distinguishes:
+
+- missing fidelity suite;
+- valid, non-empty fidelity suite;
+- invalid or unreadable fidelity suite.
+
+Invalid or unreadable suites have zero usable cases, cannot produce
+`QualityLevel::Ready`, and display an `invalid fidelity suite` diagnostic.
+Existing repository validators remain the authoritative CI gate; this desktop
+behavior protects locally modified or partially corrupted clones.
+
+## Truthful gate semantics
+
+Coverage tracks structural runs, newest graded runs, and current evaluation
+errors separately.
+
+Decision precedence is:
+
+1. a current graded regression is `Blocked`;
+2. a current evaluation execution or parse error is `Blocked`;
+3. a current graded case failure requires review under the existing failure
+   posture;
+4. incomplete structural coverage is `Unproven`;
+5. complete structural coverage without complete graded coverage is
+   `Unproven`, with the headline `Graded evidence incomplete`;
+6. `Ready` requires complete newest-graded coverage with no current errors,
+   failures, or regressions.
+
+The dry-run-only state explicitly says that structural baseline coverage is
+complete while graded evidence remains absent. It must not recommend proceeding
+with release approval.
+
+This PR does not add a paid local grading button or change the repository policy
+that paid grading may be advisory when credentials are absent.
+
+## Tests and acceptance
+
+Tests cover:
+
+- older case results cannot overwrite the newest run;
+- v1 dry-run and graded suites parse with explicit modes;
+- legacy JSON and legacy text traces remain readable;
+- error suites and malformed v1 payloads become visible evidence errors;
+- unknown case statuses are not counted as passes;
+- invalid JSONL is not counted as a fidelity case;
+- complete dry-run coverage remains `Unproven`;
+- complete passing graded coverage can become `Ready`;
+- the Python runner emits v1 fields for completed and error suites;
+- JSON stdout remains parseable and existing exit semantics remain intact.
+
+The PR must pass Rust formatting, strict Clippy, all Rust tests, `npm test`, and
+the complete Python test suite. No paid model evaluation is run.
+
+## Non-goals
+
+- No trace persistence or worker lifecycle changes; those are PR 2.
+- No new paid-evaluation workflow or credential handling.
+- No content/repository fingerprinting for evidence freshness.
+- No broad module split, SQLite, Tokio, or eframe upgrade.
+- No changes to doctrinal fixtures or evaluation assertions.

--- a/docs/superpowers/specs/2026-07-30-desktop-runtime-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-30-desktop-runtime-reliability-design.md
@@ -1,0 +1,196 @@
+# Desktop Runtime Reliability Design
+
+**Date:** 2026-07-30
+
+**Target branch:** `fix/desktop-runtime-reliability`
+
+**Base:** reviewed head of `fix/desktop-evaluation-contract`
+
+**Goal:** Make desktop trace persistence and background command execution safe
+under crashes, concurrent launches, worker disconnects, invalid CLI arguments,
+and stalled child processes.
+
+## Scope and selected approach
+
+This stacked PR addresses the runtime findings after the evaluation contract is
+correct:
+
+- trace saves truncate the destination directly;
+- GUI and `--baseline` can overwrite each other's in-memory snapshots;
+- persisted files have no schema version;
+- a disconnected worker leaves the UI permanently busy;
+- child processes have no deadline;
+- `--help` and unknown arguments launch the GUI.
+
+Three approaches were considered:
+
+1. **Temporary file plus rename only.** This prevents partial JSON but does not
+   prevent a stale process from replacing newer records.
+2. **Versioned JSON, a process-lifetime single-writer lease, and a bounded
+   synchronous command runner.** This is the selected approach because it
+   fixes corruption, lost updates, and hangs without changing the local
+   product architecture.
+3. **SQLite and Tokio.** This would support concurrent writers and asynchronous
+   process management, but it is unjustified for a 200-record store and one
+   active background task.
+
+The implementation remains in one Rust crate and retains `std::thread` plus
+channels.
+
+## Root-cause evidence
+
+### Atomic replacement alone does not solve lost updates
+
+The GUI and `--baseline` load the same trace file into separate in-memory
+stores. Even if each save uses a temporary file and atomic rename, a later save
+can replace newer records with a stale snapshot.
+
+The root cause is multiple independent read-modify-write owners. This design
+uses a process-lifetime single-writer lease rather than inventing merge
+semantics.
+
+### Worker disconnects and child processes are unbounded
+
+The GUI converts every `try_recv` error to `None`. If the worker panics and the
+sender disconnects, the receiver remains installed forever and the UI remains
+busy. Child commands use `Command::output()` without a deadline, so a stalled
+Node, Python, or npm process can produce the same visible symptom.
+
+The root cause is representing `Empty` and `Disconnected` as the same state and
+having no bounded command-execution abstraction.
+
+## Versioned trace file
+
+New saves use this envelope:
+
+```json
+{
+  "schema_version": 1,
+  "next_id": 42,
+  "records": []
+}
+```
+
+`capacity` is runtime configuration and is no longer persisted. Loading accepts
+the current unversioned object containing `capacity`, `next_id`, and `records`,
+then writes v1 on the next successful save. Unknown schema versions fail
+loudly. Existing `TraceAction` and record fields remain backward compatible.
+
+## Single-writer lease and atomic save
+
+A `TraceStoreLease` owns:
+
+- the trace path;
+- an open sibling lock file;
+- an exclusive cross-platform `fs4` lock.
+
+The GUI attempts to acquire the lease before loading writable trace state and
+retains it for the application lifetime. If another GUI or `--baseline` owns
+the lease, a second GUI opens in visibly read-only mode and disables install,
+uninstall, update, validation, and fidelity actions. Browsing remains
+available; refresh and inspect may update in-memory display data but do not
+create or persist trace records while read-only.
+
+`--baseline` fails immediately with a clear non-zero error when it cannot
+acquire the lease.
+
+Every save:
+
+1. serializes the complete v1 payload before touching the destination;
+2. creates a temporary file in the destination directory;
+3. writes, flushes, and `sync_all`s the temporary file;
+4. atomically persists it over the destination;
+5. leaves the previous valid file intact if serialization or temporary writing
+   fails.
+
+The implementation uses `fs4` version `1.1` with synchronous-only features and
+`tempfile` version `3`. It does not implement record merging. If concurrent
+writers become a product requirement, that requirement triggers a separate
+SQLite or append-journal design.
+
+## Explicit pending-task state
+
+The application replaces `task_rx` and `busy_label` with one `PendingTask`
+containing the trace id, label, start time, and receiver.
+
+Polling distinguishes:
+
+- `Empty`: keep waiting;
+- `Ok`: apply the existing success or error outcome;
+- `Disconnected`: clear busy state, mark the trace failed, persist it, and show
+  `Task worker disconnected before reporting a result`.
+
+No disconnected receiver remains installed for a later frame.
+
+Read-only mode rejects trace-producing actions before creating a trace or
+spawning a worker. Refresh and inspect use a non-traced read path.
+
+## Bounded command runner
+
+`CliClient` owns a synchronous `CommandRunner`. The production deadline is five
+minutes per direct child command; tests inject a shorter duration.
+
+The runner:
+
+- spawns the child with piped stdout and stderr;
+- drains both streams concurrently so a full pipe cannot deadlock the child;
+- waits with `wait-timeout` version `0.2`;
+- kills and reaps the direct child on deadline;
+- joins both reader threads;
+- preserves exit status, stdout, stderr, duration, and timeout state in the
+  error presented to the trace.
+
+Process-tree termination is a non-goal for this PR. The direct-child timeout
+still guarantees that the desktop worker returns instead of remaining busy
+forever.
+
+## Desktop CLI argument contract
+
+Argument parsing accepts:
+
+- no arguments: launch the GUI;
+- `--baseline`: run the headless baseline;
+- `--help` or `-h`: print usage and exit zero.
+
+Unknown arguments, extra arguments, or incompatible combinations print usage to
+stderr and exit `2`. Help never initializes eframe.
+
+## Tests and acceptance
+
+Tests cover:
+
+- legacy trace files load and save as schema v1;
+- unknown schema versions fail;
+- saved files round-trip and contain no persisted `capacity`;
+- two leases cannot own the same store simultaneously;
+- dropping the first lease permits a later acquisition;
+- a disconnected task receiver produces a terminal failure state;
+- command stdout and stderr are drained and retained;
+- a helper child that exceeds an injected deadline is killed and reported as a
+  timeout;
+- `--help` exits zero without launching a window;
+- unknown and extra arguments exit `2`;
+- `--baseline` lock contention fails clearly.
+
+The PR must pass Rust formatting, strict Clippy, all Rust tests, `npm test`, the
+complete Python test suite, and
+`cargo check --locked --all-targets --target x86_64-pc-windows-msvc`.
+
+## Stacking and rollout
+
+PR 1 is opened against `main`. This PR starts from the reviewed PR 1 head and is
+opened against the PR 1 branch. After PR 1 merges, this PR is rebased or
+retargeted to `main` without mixing unrelated changes.
+
+No paid model evaluation is run by this work.
+
+## Non-goals
+
+- No SQLite, append-only journal, or concurrent record merging.
+- No Tokio or other async runtime.
+- No process-tree termination.
+- No multi-crate workspace or broad mechanical module split.
+- No Node/Python runtime bundling or platform executable resolver.
+- No CJK font work.
+- No eframe, egui, Rust edition, or MSRV migration.
+- No new desktop screens beyond minimal read-only and error messaging.

--- a/scripts/test-fidelity.py
+++ b/scripts/test-fidelity.py
@@ -85,9 +85,17 @@ def load_tests(master_dir: Path) -> list[dict]:
     if not fidelity_path.exists():
         return []
     tests = []
-    for line in fidelity_path.read_text(encoding="utf-8").strip().splitlines():
+    for line_number, line in enumerate(
+        fidelity_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
         if line.strip():
-            tests.append(json.loads(line))
+            try:
+                tests.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"Invalid fidelity.jsonl line {line_number}: {error.msg}"
+                ) from error
     return tests
 
 
@@ -170,7 +178,14 @@ def run_tests(
             f"Master '{master_name}' not found",
         )
 
-    tests = load_tests(master_dir)
+    try:
+        tests = load_tests(master_dir)
+    except (OSError, ValueError) as error:
+        return suite_error(
+            master_name,
+            dry_run,
+            f"Unable to load fidelity suite: {error}",
+        )
     if not tests:
         return suite_error(
             master_name,

--- a/scripts/test-fidelity.py
+++ b/scripts/test-fidelity.py
@@ -91,11 +91,22 @@ def load_tests(master_dir: Path) -> list[dict]:
     ):
         if line.strip():
             try:
-                tests.append(json.loads(line))
+                test = json.loads(line)
             except json.JSONDecodeError as error:
                 raise ValueError(
                     f"Invalid fidelity.jsonl line {line_number}: {error.msg}"
                 ) from error
+            if not isinstance(test, dict):
+                raise ValueError(
+                    f"Invalid fidelity.jsonl line {line_number}: expected a JSON object"
+                )
+            question = test.get("q")
+            if not isinstance(question, str) or not question.strip():
+                raise ValueError(
+                    f"Invalid fidelity.jsonl line {line_number}: "
+                    "expected a non-empty string q"
+                )
+            tests.append(test)
     return tests
 
 

--- a/scripts/test-fidelity.py
+++ b/scripts/test-fidelity.py
@@ -31,6 +31,27 @@ from pathlib import Path
 from verify_citations import audit_answer, load_declared_ids
 
 PREBUILT_DIR = Path(__file__).resolve().parent.parent / "prebuilt"
+SCHEMA_VERSION = 1
+
+
+def suite_common(master_name: str, dry_run: bool, outcome: str) -> dict:
+    """Return fields shared by every fidelity JSON v1 suite."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "master": master_name,
+        "mode": "dry_run" if dry_run else "graded",
+        "outcome": outcome,
+    }
+
+
+def suite_error(master_name: str, dry_run: bool, message: str) -> dict:
+    """Return a fidelity JSON v1 suite for a precondition or execution error."""
+    return {
+        **suite_common(master_name, dry_run, "error"),
+        "total": 0,
+        "results": [],
+        "error": message,
+    }
 
 
 def load_skill_context(master_dir: Path) -> str:
@@ -143,11 +164,19 @@ def run_tests(
     """Run fidelity tests for a master. Returns summary."""
     master_dir = PREBUILT_DIR / master_name
     if not master_dir.exists():
-        return {"error": f"Master '{master_name}' not found"}
+        return suite_error(
+            master_name,
+            dry_run,
+            f"Master '{master_name}' not found",
+        )
 
     tests = load_tests(master_dir)
     if not tests:
-        return {"error": f"No fidelity.jsonl found for '{master_name}'"}
+        return suite_error(
+            master_name,
+            dry_run,
+            f"No fidelity.jsonl found for '{master_name}'",
+        )
 
     if max_tests is not None and max_tests > 0:
         # Prefer easier/basic tests when capping — smoke suite should hit
@@ -171,7 +200,11 @@ def run_tests(
                 "difficulty": test.get("difficulty", "unknown"),
                 "status": "dry_run",
             })
-        return {"master": master_name, "total": len(tests), "results": results}
+        return {
+            **suite_common(master_name, dry_run, "completed"),
+            "total": len(tests),
+            "results": results,
+        }
 
     # Load skill context
     system_prompt = load_skill_context(master_dir)
@@ -180,11 +213,19 @@ def run_tests(
     try:
         import anthropic
     except ImportError:
-        return {"error": "anthropic package not installed. Run: pip install anthropic"}
+        return suite_error(
+            master_name,
+            dry_run,
+            "anthropic package not installed. Run: pip install anthropic",
+        )
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        return {"error": "ANTHROPIC_API_KEY environment variable not set"}
+        return suite_error(
+            master_name,
+            dry_run,
+            "ANTHROPIC_API_KEY environment variable not set",
+        )
 
     client = anthropic.Anthropic(api_key=api_key)
 
@@ -253,7 +294,7 @@ def run_tests(
                 print(f"FAIL ({failures})")
 
     return {
-        "master": master_name,
+        **suite_common(master_name, dry_run, "completed"),
         "model": model,
         "total": len(tests),
         "passed": passed,

--- a/tests/test_fidelity_exit.py
+++ b/tests/test_fidelity_exit.py
@@ -97,6 +97,26 @@ def test_invalid_fidelity_file_emits_versioned_error_suite(runner, monkeypatch, 
     assert "line 2" in suite["error"]
 
 
+def test_fidelity_case_without_question_emits_versioned_error_suite(
+    runner, monkeypatch, tmp_path
+):
+    master_dir = tmp_path / "master-broken"
+    (master_dir / "tests").mkdir(parents=True)
+    (master_dir / "tests" / "fidelity.jsonl").write_text(
+        '{"difficulty":"basic"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runner, "PREBUILT_DIR", tmp_path)
+
+    suite = runner.run_tests("master-broken", dry_run=True, quiet=True)
+
+    assert suite["outcome"] == "error"
+    assert suite["total"] == 0
+    assert suite["results"] == []
+    assert "line 1" in suite["error"]
+    assert "non-empty string q" in suite["error"]
+
+
 def test_missing_master_exits_nonzero_with_clean_json_stdout():
     result = subprocess.run(
         [

--- a/tests/test_fidelity_exit.py
+++ b/tests/test_fidelity_exit.py
@@ -77,6 +77,26 @@ def test_missing_master_emits_versioned_error_suite(runner):
     }
 
 
+def test_invalid_fidelity_file_emits_versioned_error_suite(runner, monkeypatch, tmp_path):
+    master_dir = tmp_path / "master-broken"
+    (master_dir / "tests").mkdir(parents=True)
+    (master_dir / "tests" / "fidelity.jsonl").write_text(
+        '{"q":"valid"}\n{"q":\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runner, "PREBUILT_DIR", tmp_path)
+
+    suite = runner.run_tests("master-broken", dry_run=True, quiet=True)
+
+    assert suite["schema_version"] == 1
+    assert suite["master"] == "master-broken"
+    assert suite["mode"] == "dry_run"
+    assert suite["outcome"] == "error"
+    assert suite["total"] == 0
+    assert suite["results"] == []
+    assert "line 2" in suite["error"]
+
+
 def test_missing_master_exits_nonzero_with_clean_json_stdout():
     result = subprocess.run(
         [

--- a/tests/test_fidelity_exit.py
+++ b/tests/test_fidelity_exit.py
@@ -43,6 +43,40 @@ def test_top_level_error_fails(runner):
     assert runner.results_failed([{"error": "missing key"}], False) is True
 
 
+def test_dry_run_emits_versioned_completed_suite(runner):
+    suite = runner.run_tests(
+        "master-huineng",
+        dry_run=True,
+        max_tests=1,
+        quiet=True,
+    )
+
+    assert suite["schema_version"] == 1
+    assert suite["master"] == "master-huineng"
+    assert suite["mode"] == "dry_run"
+    assert suite["outcome"] == "completed"
+    assert suite["total"] == 1
+    assert len(suite["results"]) == 1
+    assert "passed" not in suite
+    assert "failed" not in suite
+
+
+def test_missing_master_emits_versioned_error_suite(runner):
+    assert runner.run_tests(
+        "master-does-not-exist",
+        dry_run=False,
+        quiet=True,
+    ) == {
+        "schema_version": 1,
+        "master": "master-does-not-exist",
+        "mode": "graded",
+        "outcome": "error",
+        "total": 0,
+        "results": [],
+        "error": "Master 'master-does-not-exist' not found",
+    }
+
+
 def test_missing_master_exits_nonzero_with_clean_json_stdout():
     result = subprocess.run(
         [
@@ -60,5 +94,14 @@ def test_missing_master_exits_nonzero_with_clean_json_stdout():
 
     assert result.returncode == 1
     payload = json.loads(result.stdout)
-    assert len(payload) == 1
-    assert "error" in payload[0]
+    assert payload == [
+        {
+            "schema_version": 1,
+            "master": "master-does-not-exist",
+            "mode": "graded",
+            "outcome": "error",
+            "total": 0,
+            "results": [],
+            "error": "Master 'master-does-not-exist' not found",
+        }
+    ]


### PR DESCRIPTION
## Summary

- emit a versioned fidelity-suite envelope with explicit `mode` and `outcome` fields
- parse evaluation evidence into typed Rust models while retaining conservative legacy compatibility
- keep structural dry-run evidence separate from graded evidence in coverage, filters, trends, and release gates
- surface malformed, unsupported, mismatched, and failed evaluation evidence instead of silently treating it as absent
- fail closed when fidelity JSONL is invalid and harden large/untrusted numeric inputs
- document the reviewed two-PR refactor design and the PR1 implementation plan

## Why

The desktop app inferred evaluation semantics from missing fields and string values. A dry run could therefore be mistaken for proof of quality, later dry runs could hide graded failures, and malformed evidence could disappear from the release decision. The new contract makes those states explicit and preserves the distinction end to end.

## Impact

Release readiness now requires current passing graded evidence for every skill. Dry runs remain useful as structural validation but cannot satisfy that gate. Existing legacy trace history is still read conservatively; ambiguous legacy JSON is rejected visibly.

## Validation

- `npm test` — 60 Node tests passed; repository validators passed
- `python -m pytest tests/ scripts/tests/ -q` — 373 passed
- full `--all --dry-run --json` output parsed successfully
- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` — 83 Rust unit tests plus all integration tests passed
- `cargo build --locked`

## Follow-up

PR2 will stack the runtime-reliability work on this branch: versioned/locked/atomic trace persistence, bounded subprocess execution, reliable worker completion, and explicit CLI argument handling.
