### PR TITLE
fix(desktop): harden runtime persistence and task execution

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -3132,6 +3133,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -1114,6 +1114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,8 +1740,10 @@ dependencies = [
  "anyhow",
  "eframe",
  "egui",
+ "fs4",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -20,3 +20,4 @@ fs4 = { version = "1.1", default-features = false, features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+wait-timeout = "0.2"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -16,5 +16,7 @@ path = "src/main.rs"
 anyhow = "1"
 eframe = "0.31"
 egui = "0.31"
+fs4 = { version = "1.1", default-features = false, features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::{channel, Receiver, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -26,7 +26,7 @@ use crate::trace::{
     EvaluationFailurePriority, EvaluationRegressionItem, EvaluationRemediationPlan,
     EvaluationRunCoverage, EvaluationRunHistoryFilter, EvaluationRunHistoryItem,
     EvaluationRunResult, EvaluationRunTrend, EvaluationTrendSummary, TraceAction, TraceFailureItem,
-    TraceListFilter, TraceStatus, TraceStore,
+    TraceListFilter, TraceStatus, TraceStore, TraceStoreLease,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -152,8 +152,7 @@ pub struct MasterSkillApp {
     tradition_filter: Option<String>,
     log: String,
     log_lines: Vec<String>,
-    task_rx: Option<Receiver<TaskEnvelope>>,
-    busy_label: Option<String>,
+    pending_task: Option<PendingTask>,
     console_section: ConsoleSection,
     log_expanded: bool,
     trace_filter: TraceListFilter,
@@ -163,7 +162,8 @@ pub struct MasterSkillApp {
     run_history_filter: EvaluationRunHistoryFilter,
     evaluation_window: EvaluationWindow,
     traces: TraceStore,
-    trace_path: PathBuf,
+    trace_lease: Option<TraceStoreLease>,
+    read_only_reason: Option<String>,
 }
 
 struct Snapshot {
@@ -182,10 +182,75 @@ struct TaskOutcome {
 
 type TaskResult = std::result::Result<TaskOutcome, String>;
 
-struct TaskEnvelope {
-    trace_id: u64,
+struct PendingTask {
+    trace_id: Option<u64>,
+    label: String,
+    started: Instant,
+    receiver: Receiver<TaskResult>,
+}
+
+enum PendingTaskEvent {
+    Pending,
+    Completed {
+        trace_id: Option<u64>,
+        elapsed: Duration,
+        result: Box<TaskResult>,
+    },
+    Disconnected {
+        trace_id: Option<u64>,
+        elapsed: Duration,
+    },
+}
+
+fn poll_pending_task(pending_task: &mut Option<PendingTask>) -> PendingTaskEvent {
+    let Some(pending) = pending_task.as_ref() else {
+        return PendingTaskEvent::Pending;
+    };
+    let receive_result = pending.receiver.try_recv();
+    if matches!(receive_result, Err(TryRecvError::Empty)) {
+        return PendingTaskEvent::Pending;
+    }
+
+    let pending = pending_task
+        .take()
+        .expect("pending task disappeared while polling");
+    match receive_result {
+        Ok(result) => PendingTaskEvent::Completed {
+            trace_id: pending.trace_id,
+            elapsed: pending.started.elapsed(),
+            result: Box::new(result),
+        },
+        Err(TryRecvError::Disconnected) => PendingTaskEvent::Disconnected {
+            trace_id: pending.trace_id,
+            elapsed: pending.started.elapsed(),
+        },
+        Err(TryRecvError::Empty) => unreachable!("empty receive returned after early check"),
+    }
+}
+
+const WORKER_DISCONNECTED_MESSAGE: &str = "Task worker disconnected before reporting a result";
+
+fn finish_disconnected_trace(
+    traces: &mut TraceStore,
+    trace_id: Option<u64>,
     elapsed: Duration,
-    result: TaskResult,
+) -> String {
+    if let Some(trace_id) = trace_id {
+        traces.finish_error_with_detail(
+            trace_id,
+            WORKER_DISCONNECTED_MESSAGE,
+            WORKER_DISCONNECTED_MESSAGE,
+            elapsed,
+        );
+    }
+    WORKER_DISCONNECTED_MESSAGE.to_string()
+}
+
+fn trace_action_requires_writer(action: &TraceAction) -> bool {
+    !matches!(
+        action,
+        TraceAction::Refresh | TraceAction::InspectSkill { .. }
+    )
 }
 
 struct MetricCard {
@@ -273,14 +338,33 @@ pub(crate) const TRACE_STORE_CAPACITY: usize = 200;
 impl MasterSkillApp {
     pub fn new() -> Self {
         let trace_path = desktop_trace_store_path();
-        let (traces, trace_load_message) =
-            match TraceStore::load_from_path(&trace_path, TRACE_STORE_CAPACITY) {
-                Ok(traces) => (traces, None),
-                Err(err) => (
-                    TraceStore::new(TRACE_STORE_CAPACITY),
-                    Some(format!("Trace history load failed: {err:#}")),
-                ),
-            };
+        let (trace_lease, read_only_reason) = match TraceStoreLease::try_acquire(&trace_path) {
+            Ok(Some(lease)) => (Some(lease), None),
+            Ok(None) => (
+                None,
+                Some(format!(
+                    "Trace store is in use by another process; this window is read-only: {}",
+                    trace_path.display()
+                )),
+            ),
+            Err(error) => (
+                None,
+                Some(format!(
+                    "Trace store writer lease failed; this window is read-only: {error:#}"
+                )),
+            ),
+        };
+        let trace_load_result = match &trace_lease {
+            Some(lease) => lease.load(TRACE_STORE_CAPACITY),
+            None => TraceStore::load_read_only_from_path(&trace_path, TRACE_STORE_CAPACITY),
+        };
+        let (traces, trace_load_message) = match trace_load_result {
+            Ok(traces) => (traces, None),
+            Err(err) => (
+                TraceStore::new(TRACE_STORE_CAPACITY),
+                Some(format!("Trace history load failed: {err:#}")),
+            ),
+        };
         let mut app = Self {
             client: CliClient::default(),
             inventory: None,
@@ -293,8 +377,7 @@ impl MasterSkillApp {
             tradition_filter: None,
             log: "Starting desktop manager...".to_string(),
             log_lines: vec!["Starting desktop manager...".to_string()],
-            task_rx: None,
-            busy_label: None,
+            pending_task: None,
             console_section: ConsoleSection::Overview,
             log_expanded: false,
             trace_filter: TraceListFilter::All,
@@ -304,9 +387,13 @@ impl MasterSkillApp {
             run_history_filter: EvaluationRunHistoryFilter::All,
             evaluation_window: EvaluationWindow::Recent8,
             traces,
-            trace_path,
+            trace_lease,
+            read_only_reason,
         };
         if let Some(message) = trace_load_message {
+            app.set_log(message);
+        }
+        if let Some(message) = app.read_only_reason.clone() {
             app.set_log(message);
         }
         app.refresh_all();
@@ -362,7 +449,10 @@ impl MasterSkillApp {
     }
 
     fn persist_traces(&mut self) {
-        if let Err(err) = self.traces.save_to_path(&self.trace_path) {
+        let Some(lease) = self.trace_lease.as_ref() else {
+            return;
+        };
+        if let Err(err) = lease.save(&self.traces) {
             self.set_log(format!("Trace history save failed: {err:#}"));
         }
     }
@@ -378,7 +468,19 @@ impl MasterSkillApp {
     }
 
     fn is_busy(&self) -> bool {
-        self.task_rx.is_some()
+        self.pending_task.is_some()
+    }
+
+    fn is_read_only(&self) -> bool {
+        self.trace_lease.is_none()
+    }
+
+    fn can_mutate(&self) -> bool {
+        !self.is_busy() && !self.is_read_only()
+    }
+
+    fn can_start_trace_action(&self, action: &TraceAction) -> bool {
+        !self.is_busy() && (!self.is_read_only() || !trace_action_requires_writer(action))
     }
 
     fn start_task_with_action<F>(
@@ -395,61 +497,97 @@ impl MasterSkillApp {
             return;
         }
 
+        if self.is_read_only()
+            && action
+                .as_ref()
+                .map(trace_action_requires_writer)
+                .unwrap_or(true)
+        {
+            let reason = self
+                .read_only_reason
+                .clone()
+                .unwrap_or_else(|| "the trace store writer lease is unavailable".to_string());
+            self.set_log(format!("Action unavailable in read-only mode: {reason}"));
+            return;
+        }
+
         let client = self.client.clone();
         let label = label.into();
-        let trace_id = if let Some(action) = action {
-            self.traces
-                .begin_with_action(label.clone(), action, command, "Queued.")
+        let command = command.map(Into::into);
+        let trace_id = if self.is_read_only() {
+            None
+        } else if let Some(action) = action {
+            Some(
+                self.traces
+                    .begin_with_action(label.clone(), action, command, "Queued."),
+            )
         } else {
-            self.traces
-                .begin_with_detail(label.clone(), command, "Queued.")
+            Some(
+                self.traces
+                    .begin_with_detail(label.clone(), command, "Queued."),
+            )
         };
-        self.persist_traces();
+        if trace_id.is_some() {
+            self.persist_traces();
+        }
         let (tx, rx) = channel();
-        self.task_rx = Some(rx);
-        self.busy_label = Some(label.clone());
+        self.pending_task = Some(PendingTask {
+            trace_id,
+            label: label.clone(),
+            started: Instant::now(),
+            receiver: rx,
+        });
         self.set_log(format!("{label}..."));
 
         thread::spawn(move || {
-            let started = Instant::now();
             let result = task(client).map_err(|err| format!("{err:#}"));
-            let _ = tx.send(TaskEnvelope {
-                trace_id,
-                elapsed: started.elapsed(),
-                result,
-            });
+            let _ = tx.send(result);
         });
     }
 
     fn poll_task(&mut self) {
-        let envelope = self.task_rx.as_ref().and_then(|rx| rx.try_recv().ok());
-        if let Some(envelope) = envelope {
-            self.task_rx = None;
-            self.busy_label = None;
-            match envelope.result {
+        match poll_pending_task(&mut self.pending_task) {
+            PendingTaskEvent::Pending => {}
+            PendingTaskEvent::Completed {
+                trace_id,
+                elapsed,
+                result,
+            } => match *result {
                 Ok(outcome) => {
                     if let Some(snapshot) = outcome.snapshot {
                         self.apply_snapshot(snapshot);
                     }
-                    self.traces.finish_success_with_detail(
-                        envelope.trace_id,
-                        outcome.message.clone(),
-                        outcome.detail.clone(),
-                        envelope.elapsed,
-                    );
-                    self.persist_traces();
+                    if let Some(trace_id) = trace_id {
+                        self.traces.finish_success_with_detail(
+                            trace_id,
+                            outcome.message.clone(),
+                            outcome.detail.clone(),
+                            elapsed,
+                        );
+                        self.persist_traces();
+                    }
                     self.set_log(outcome.message);
                 }
                 Err(message) => {
-                    self.traces.finish_error_with_detail(
-                        envelope.trace_id,
-                        first_line(&message),
-                        message.clone(),
-                        envelope.elapsed,
-                    );
-                    self.persist_traces();
+                    if let Some(trace_id) = trace_id {
+                        self.traces.finish_error_with_detail(
+                            trace_id,
+                            first_line(&message),
+                            message.clone(),
+                            elapsed,
+                        );
+                        self.persist_traces();
+                    }
                     self.set_log(message);
                 }
+            },
+            PendingTaskEvent::Disconnected { trace_id, elapsed } => {
+                let traced = trace_id.is_some();
+                let message = finish_disconnected_trace(&mut self.traces, trace_id, elapsed);
+                if traced {
+                    self.persist_traces();
+                }
+                self.set_log(message);
             }
         }
     }
@@ -620,23 +758,26 @@ impl MasterSkillApp {
                 self.start_refresh();
             }
             if ui
-                .add_enabled(!busy, egui::Button::new("Install all"))
+                .add_enabled(self.can_mutate(), egui::Button::new("Install all"))
                 .clicked()
             {
                 self.start_install_all();
             }
             if ui
-                .add_enabled(!busy, egui::Button::new("Update all"))
+                .add_enabled(self.can_mutate(), egui::Button::new("Update all"))
                 .clicked()
             {
                 self.start_update_all();
             }
-            if let Some(label) = &self.busy_label {
+            if let Some(pending) = &self.pending_task {
                 ui.separator();
                 ui.spinner();
-                ui.label(label);
+                ui.label(&pending.label);
             }
         });
+        if let Some(reason) = &self.read_only_reason {
+            ui.colored_label(egui::Color32::from_rgb(220, 170, 80), reason);
+        }
         ui.horizontal(|ui| {
             for section in [
                 ConsoleSection::Overview,
@@ -928,7 +1069,6 @@ impl MasterSkillApp {
     }
 
     fn show_evaluation_center(&mut self, ui: &mut egui::Ui) {
-        let busy = self.is_busy();
         let summary = evaluation_summary(&self.rows);
         let gate = evaluation_gate_snapshot(&self.rows, &self.traces, self.evaluation_window);
         let run_history: Vec<_> = gate
@@ -943,13 +1083,13 @@ impl MasterSkillApp {
             "Fidelity coverage, tradition distribution, and validation actions.",
             |ui| {
                 if ui
-                    .add_enabled(!busy, egui::Button::new("Run full validation"))
+                    .add_enabled(self.can_mutate(), egui::Button::new("Run full validation"))
                     .clicked()
                 {
                     self.start_full_validation();
                 }
                 if ui
-                    .add_enabled(!busy, egui::Button::new("Run fidelity dry-run"))
+                    .add_enabled(self.can_mutate(), egui::Button::new("Run fidelity dry-run"))
                     .clicked()
                 {
                     self.start_fidelity_dry_run();
@@ -1059,7 +1199,6 @@ impl MasterSkillApp {
         remediation_plan: &EvaluationRemediationPlan,
     ) {
         ui.heading("Decision Brief");
-        let busy = self.is_busy();
         let mut decision_action = None;
         let mut copy_report = false;
         let mut copy_plan = false;
@@ -1072,7 +1211,12 @@ impl MasterSkillApp {
             ui.strong(&brief.headline);
             ui.separator();
             if ui
-                .add_enabled(!busy, egui::Button::new(brief.action.label()))
+                .add_enabled(
+                    !self.is_busy()
+                        && (!self.is_read_only()
+                            || matches!(&brief.action, EvaluationDecisionAction::OpenSkill { .. })),
+                    egui::Button::new(brief.action.label()),
+                )
                 .clicked()
             {
                 decision_action = Some(brief.action.clone());
@@ -1178,7 +1322,6 @@ impl MasterSkillApp {
             return;
         }
 
-        let busy = self.is_busy();
         let mut action_to_rerun = None;
         let mut skill_to_open = None;
         egui::ScrollArea::horizontal()
@@ -1222,7 +1365,9 @@ impl MasterSkillApp {
                             ui.horizontal(|ui| {
                                 if ui
                                     .add_enabled(
-                                        !busy && item.action.is_some(),
+                                        item.action.as_ref().is_some_and(|action| {
+                                            self.can_start_trace_action(action)
+                                        }),
                                         egui::Button::new("Rerun"),
                                     )
                                     .clicked()
@@ -1330,7 +1475,6 @@ impl MasterSkillApp {
             return;
         }
 
-        let busy = self.is_busy();
         let mut skill_to_open = None;
         let mut skill_to_run = None;
         egui::ScrollArea::horizontal()
@@ -1367,7 +1511,12 @@ impl MasterSkillApp {
                                         if ui.button("Open").clicked() {
                                             skill_to_open = Some(item.slug.clone());
                                         }
-                                        if ui.add_enabled(!busy, egui::Button::new("Run")).clicked()
+                                        if ui
+                                            .add_enabled(
+                                                self.can_mutate(),
+                                                egui::Button::new("Run"),
+                                            )
+                                            .clicked()
                                         {
                                             skill_to_run = Some(item.slug.clone());
                                         }
@@ -1411,7 +1560,6 @@ impl MasterSkillApp {
             return;
         }
 
-        let busy = self.is_busy();
         let mut action_to_rerun = None;
         let mut skill_to_open = None;
         egui::ScrollArea::horizontal()
@@ -1458,7 +1606,9 @@ impl MasterSkillApp {
                                     ui.horizontal(|ui| {
                                         if ui
                                             .add_enabled(
-                                                !busy && item.action.is_some(),
+                                                item.action.as_ref().is_some_and(|action| {
+                                                    self.can_start_trace_action(action)
+                                                }),
                                                 egui::Button::new("Rerun"),
                                             )
                                             .clicked()
@@ -1608,7 +1758,7 @@ impl MasterSkillApp {
     fn show_trace_center(&mut self, ui: &mut egui::Ui) {
         let summary = self.traces.summary();
         let failure_queue = self.traces.trace_failure_queue(6);
-        let can_clear = summary.total > 0 && summary.running == 0;
+        let can_clear = summary.total > 0 && summary.running == 0 && self.can_mutate();
         Self::show_workspace_header(
             ui,
             "Run Trace Center",
@@ -1692,7 +1842,6 @@ impl MasterSkillApp {
             return;
         }
 
-        let busy = self.is_busy();
         let mut action_to_rerun = None;
         let mut skill_to_open = None;
 
@@ -1754,7 +1903,10 @@ impl MasterSkillApp {
                             ui.horizontal(|ui| {
                                 if ui
                                     .add_enabled(
-                                        !busy && record.can_rerun(),
+                                        record.can_rerun()
+                                            && record.action.as_ref().is_some_and(|action| {
+                                                self.can_start_trace_action(action)
+                                            }),
                                         egui::Button::new("Rerun"),
                                     )
                                     .clicked()
@@ -1799,7 +1951,6 @@ impl MasterSkillApp {
             return;
         }
 
-        let busy = self.is_busy();
         let mut action_to_rerun = None;
         let mut skill_to_open = None;
         egui::ScrollArea::horizontal()
@@ -1837,7 +1988,9 @@ impl MasterSkillApp {
                                     ui.horizontal(|ui| {
                                         if ui
                                             .add_enabled(
-                                                !busy && item.action.is_some(),
+                                                item.action.as_ref().is_some_and(|action| {
+                                                    self.can_start_trace_action(action)
+                                                }),
                                                 egui::Button::new("Rerun"),
                                             )
                                             .clicked()
@@ -2087,7 +2240,7 @@ impl MasterSkillApp {
             }
             if ui
                 .add_enabled(
-                    !self.is_busy() && !cases.is_empty(),
+                    self.can_mutate() && !cases.is_empty(),
                     egui::Button::new("Run skill dry-run"),
                 )
                 .clicked()
@@ -2157,7 +2310,6 @@ impl MasterSkillApp {
             return;
         }
 
-        let busy = self.is_busy();
         let mut operation_to_start = None;
         egui::Grid::new("recommended-actions-grid")
             .num_columns(4)
@@ -2182,7 +2334,10 @@ impl MasterSkillApp {
                             ui.label("manual");
                         }
                         operation => {
-                            if ui.add_enabled(!busy, egui::Button::new("Run")).clicked() {
+                            if ui
+                                .add_enabled(self.can_mutate(), egui::Button::new("Run"))
+                                .clicked()
+                            {
                                 operation_to_start = Some(operation.clone());
                             }
                         }
@@ -2269,13 +2424,13 @@ impl MasterSkillApp {
                 ui.separator();
                 if master.installed {
                     if ui
-                        .add_enabled(!self.is_busy(), egui::Button::new("Uninstall"))
+                        .add_enabled(self.can_mutate(), egui::Button::new("Uninstall"))
                         .clicked()
                     {
                         self.start_uninstall(master.slug.clone());
                     }
                 } else if ui
-                    .add_enabled(!self.is_busy(), egui::Button::new("Install"))
+                    .add_enabled(self.can_mutate(), egui::Button::new("Install"))
                     .clicked()
                 {
                     self.start_install(master.slug.clone());
@@ -2474,13 +2629,64 @@ fn desktop_trace_store_path_from_env(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::mpsc::channel;
+    use std::time::{Duration, Instant};
 
     use crate::catalog::{SkillKind, SkillRow};
     use crate::trace::{
         EvaluationDecisionAction, EvaluationDecisionBrief, EvaluationDecisionPosture,
         EvaluationMode, EvaluationRunResult, TraceAction, TraceStore,
     };
-    use std::time::Duration;
+
+    use super::{
+        finish_disconnected_trace, poll_pending_task, trace_action_requires_writer, PendingTask,
+        PendingTaskEvent, TaskResult,
+    };
+
+    #[test]
+    fn disconnected_pending_task_is_removed_and_marks_trace_failed() {
+        let mut traces = TraceStore::new(10);
+        let trace_id = traces.begin_with_action(
+            "Running full validation",
+            TraceAction::FullValidation,
+            Some("npm test"),
+            "Queued.",
+        );
+        let (sender, receiver) = channel::<TaskResult>();
+        drop(sender);
+        let mut pending = Some(PendingTask {
+            trace_id: Some(trace_id),
+            label: "Running full validation".to_string(),
+            started: Instant::now(),
+            receiver,
+        });
+
+        let event = poll_pending_task(&mut pending);
+        let PendingTaskEvent::Disconnected { trace_id, elapsed } = event else {
+            panic!("expected disconnected event");
+        };
+        let message = finish_disconnected_trace(&mut traces, trace_id, elapsed);
+
+        assert!(pending.is_none());
+        assert_eq!(traces.recent()[0].status, crate::trace::TraceStatus::Failed);
+        assert_eq!(
+            message,
+            "Task worker disconnected before reporting a result"
+        );
+    }
+
+    #[test]
+    fn read_only_policy_allows_browsing_but_rejects_trace_writes() {
+        assert!(!trace_action_requires_writer(&TraceAction::Refresh));
+        assert!(!trace_action_requires_writer(&TraceAction::InspectSkill {
+            slug: "huineng".to_string(),
+        }));
+        assert!(trace_action_requires_writer(&TraceAction::InstallAll));
+        assert!(trace_action_requires_writer(&TraceAction::FullValidation));
+        assert!(trace_action_requires_writer(
+            &TraceAction::FidelityDryRunAll
+        ));
+    }
 
     #[test]
     fn trace_store_path_prefers_xdg_data_home() {

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -253,6 +253,63 @@ fn trace_action_requires_writer(action: &TraceAction) -> bool {
     )
 }
 
+struct TraceStoreAccess {
+    traces: TraceStore,
+    lease: Option<TraceStoreLease>,
+    read_only_reason: Option<String>,
+    load_message: Option<String>,
+}
+
+fn open_trace_store(trace_path: &std::path::Path, capacity: usize) -> TraceStoreAccess {
+    let (mut lease, mut read_only_reason) = match TraceStoreLease::try_acquire(trace_path) {
+        Ok(Some(lease)) => (Some(lease), None),
+        Ok(None) => (
+            None,
+            Some(format!(
+                "Trace store is in use by another process; this window is read-only: {}",
+                trace_path.display()
+            )),
+        ),
+        Err(error) => (
+            None,
+            Some(format!(
+                "Trace store writer lease failed; this window is read-only: {error:#}"
+            )),
+        ),
+    };
+    let load_result = match &lease {
+        Some(lease) => lease.load(capacity),
+        None => TraceStore::load_read_only_from_path(trace_path, capacity),
+    };
+
+    match load_result {
+        Ok(traces) => TraceStoreAccess {
+            traces,
+            lease,
+            read_only_reason,
+            load_message: None,
+        },
+        Err(error) => {
+            lease = None;
+            let load_message = format!("Trace history load failed: {error:#}");
+            let preservation_reason = format!(
+                "Trace history could not be loaded; this window is read-only to preserve {}",
+                trace_path.display()
+            );
+            read_only_reason = Some(match read_only_reason {
+                Some(reason) => format!("{reason}; {preservation_reason}"),
+                None => preservation_reason,
+            });
+            TraceStoreAccess {
+                traces: TraceStore::new(capacity),
+                lease,
+                read_only_reason,
+                load_message: Some(load_message),
+            }
+        }
+    }
+}
+
 struct MetricCard {
     title: &'static str,
     value: String,
@@ -338,33 +395,12 @@ pub(crate) const TRACE_STORE_CAPACITY: usize = 200;
 impl MasterSkillApp {
     pub fn new() -> Self {
         let trace_path = desktop_trace_store_path();
-        let (trace_lease, read_only_reason) = match TraceStoreLease::try_acquire(&trace_path) {
-            Ok(Some(lease)) => (Some(lease), None),
-            Ok(None) => (
-                None,
-                Some(format!(
-                    "Trace store is in use by another process; this window is read-only: {}",
-                    trace_path.display()
-                )),
-            ),
-            Err(error) => (
-                None,
-                Some(format!(
-                    "Trace store writer lease failed; this window is read-only: {error:#}"
-                )),
-            ),
-        };
-        let trace_load_result = match &trace_lease {
-            Some(lease) => lease.load(TRACE_STORE_CAPACITY),
-            None => TraceStore::load_read_only_from_path(&trace_path, TRACE_STORE_CAPACITY),
-        };
-        let (traces, trace_load_message) = match trace_load_result {
-            Ok(traces) => (traces, None),
-            Err(err) => (
-                TraceStore::new(TRACE_STORE_CAPACITY),
-                Some(format!("Trace history load failed: {err:#}")),
-            ),
-        };
+        let TraceStoreAccess {
+            traces,
+            lease: trace_lease,
+            read_only_reason,
+            load_message: trace_load_message,
+        } = open_trace_store(&trace_path, TRACE_STORE_CAPACITY);
         let mut app = Self {
             client: CliClient::default(),
             inventory: None,
@@ -2628,9 +2664,10 @@ fn desktop_trace_store_path_from_env(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::PathBuf;
     use std::sync::mpsc::channel;
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use crate::catalog::{SkillKind, SkillRow};
     use crate::trace::{
@@ -2639,9 +2676,63 @@ mod tests {
     };
 
     use super::{
-        finish_disconnected_trace, poll_pending_task, trace_action_requires_writer, PendingTask,
-        PendingTaskEvent, TaskResult,
+        finish_disconnected_trace, open_trace_store, poll_pending_task,
+        trace_action_requires_writer, PendingTask, PendingTaskEvent, TaskResult,
     };
+
+    fn temp_trace_path(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("master-skill-desktop-app-{label}-{suffix}"))
+            .join("desktop-traces.json")
+    }
+
+    #[test]
+    fn contended_trace_access_opens_read_only() {
+        let path = temp_trace_path("contended");
+        let first = crate::trace::TraceStoreLease::try_acquire(&path)
+            .unwrap()
+            .unwrap();
+
+        let access = open_trace_store(&path, 10);
+
+        assert!(access.lease.is_none());
+        assert!(access
+            .read_only_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("read-only")));
+        drop(access);
+        drop(first);
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn invalid_trace_file_drops_writer_lease_and_preserves_source() {
+        let path = temp_trace_path("invalid");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let original = r#"{"schema_version":2,"next_id":1,"records":[]}"#;
+        fs::write(&path, original).unwrap();
+
+        let access = open_trace_store(&path, 10);
+
+        assert!(access.lease.is_none());
+        assert!(access
+            .read_only_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("preserve")));
+        assert!(access
+            .load_message
+            .as_deref()
+            .is_some_and(|message| message.contains("unsupported trace schema version 2")));
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        assert!(crate::trace::TraceStoreLease::try_acquire(&path)
+            .unwrap()
+            .is_some());
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
 
     #[test]
     fn disconnected_pending_task_is_removed_and_marks_trace_failed() {

--- a/desktop/src/baseline.rs
+++ b/desktop/src/baseline.rs
@@ -22,7 +22,7 @@ use crate::app::{
     desktop_trace_store_path, first_line, summarize_command_output, TRACE_STORE_CAPACITY,
 };
 use crate::cli::CliClient;
-use crate::trace::{TraceAction, TraceStore};
+use crate::trace::{TraceAction, TraceStoreLease};
 
 /// Returns the `(label, command)` pair for running a single master skill's
 /// fidelity dry-run: `master-{slug}`'s progress label and the
@@ -68,7 +68,10 @@ pub fn run_headless_baseline() -> Result<i32> {
     }
 
     let store_path = desktop_trace_store_path();
-    let mut traces = TraceStore::load_from_path(&store_path, TRACE_STORE_CAPACITY)?;
+    let lease = TraceStoreLease::try_acquire(&store_path)?.ok_or_else(|| {
+        anyhow!("trace store {store_path:?} is locked by another desktop or baseline process")
+    })?;
+    let mut traces = lease.load(TRACE_STORE_CAPACITY)?;
 
     let total = slugs.len();
     let mut ok_count = 0usize;
@@ -108,7 +111,7 @@ pub fn run_headless_baseline() -> Result<i32> {
         }
     }
 
-    traces.save_to_path(&store_path)?;
+    lease.save(&traces)?;
     println!("baseline: {ok_count}/{total} ok");
 
     Ok(if ok_count == total { 0 } else { 1 })

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -244,6 +244,28 @@ mod command_error_tests {
         assert!(message.contains("stdout:"));
         assert!(message.contains("stderr:"));
     }
+
+    #[test]
+    fn nonzero_error_retains_status_and_both_streams() {
+        let client = CliClient::new(std::env::current_dir().unwrap());
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "command::tests::command_runner_helper",
+                "--nocapture",
+            ])
+            .env("MASTER_SKILL_COMMAND_RUNNER_HELPER", "failure");
+
+        let error = client
+            .run_command(&mut command, "test command failed")
+            .unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("status"));
+        assert!(message.contains("failure stdout marker"));
+        assert!(message.contains("failure stderr marker"));
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 
+use crate::command::CommandRunner;
 use crate::model::{DoctorReport, MasterInspect, SkillInventory};
 
 #[derive(Clone, Debug)]
@@ -10,6 +12,7 @@ pub struct CliClient {
     repo_root: PathBuf,
     node_bin: String,
     home: Option<PathBuf>,
+    runner: CommandRunner,
 }
 
 impl CliClient {
@@ -18,11 +21,17 @@ impl CliClient {
             repo_root: repo_root.into(),
             node_bin: std::env::var("NODE").unwrap_or_else(|_| "node".to_string()),
             home: None,
+            runner: CommandRunner::default(),
         }
     }
 
     pub fn with_home(mut self, home: impl Into<PathBuf>) -> Self {
         self.home = Some(home.into());
+        self
+    }
+
+    pub fn with_command_timeout(mut self, timeout: Duration) -> Self {
+        self.runner = CommandRunner::new(timeout);
         self
     }
 
@@ -118,19 +127,31 @@ impl CliClient {
             command.env("HOME", home).env("USERPROFILE", home);
         }
 
-        let output = command.output().with_context(|| context.to_string())?;
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        if output.status.success() {
-            return Ok(stdout);
+        let output = self
+            .runner
+            .run(command)
+            .with_context(|| context.to_string())?;
+        if !output.timed_out && output.status.success() {
+            return Ok(output.stdout);
         }
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let reason = if output.timed_out {
+            format!(
+                "command timed out after {} ms; terminated with status {}",
+                output.elapsed.as_millis(),
+                output.status
+            )
+        } else {
+            format!(
+                "command failed after {} ms with status {}",
+                output.elapsed.as_millis(),
+                output.status
+            )
+        };
         Err(anyhow!(
-            "command failed with status {}: {}{}",
-            output.status,
-            stdout,
-            stderr
+            "{context}: {reason}\nstdout:\n{}\nstderr:\n{}",
+            output.stdout,
+            output.stderr
         ))
     }
 }
@@ -191,6 +212,38 @@ fn find_repo_root_from(start: &Path) -> Option<PathBuf> {
         candidate = dir.parent();
     }
     None
+}
+
+#[cfg(test)]
+mod command_error_tests {
+    use super::CliClient;
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[test]
+    fn timeout_error_retains_timing_status_and_both_streams() {
+        let client = CliClient::new(std::env::current_dir().unwrap())
+            .with_command_timeout(Duration::from_millis(100));
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "command::tests::command_runner_helper",
+                "--nocapture",
+            ])
+            .env("MASTER_SKILL_COMMAND_RUNNER_HELPER", "sleep");
+
+        let error = client
+            .run_command(&mut command, "test command failed")
+            .unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("test command failed"));
+        assert!(message.contains("timed out after"));
+        assert!(message.contains("status"));
+        assert!(message.contains("stdout:"));
+        assert!(message.contains("stderr:"));
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src/command.rs
+++ b/desktop/src/command.rs
@@ -112,6 +112,10 @@ mod tests {
             let stderr = vec![b'e'; 128 * 1024];
             io::stdout().write_all(&stdout).unwrap();
             io::stderr().write_all(&stderr).unwrap();
+        } else if mode == "failure" {
+            io::stdout().write_all(b"failure stdout marker").unwrap();
+            io::stderr().write_all(b"failure stderr marker").unwrap();
+            std::process::exit(7);
         } else if mode == "sleep" {
             std::thread::sleep(Duration::from_secs(5));
         }

--- a/desktop/src/command.rs
+++ b/desktop/src/command.rs
@@ -1,0 +1,155 @@
+use std::io::{self, Read};
+use std::process::{Command, ExitStatus, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use wait_timeout::ChildExt;
+
+pub const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Clone, Debug)]
+pub struct CommandRunner {
+    timeout: Duration,
+}
+
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub status: ExitStatus,
+    pub stdout: String,
+    pub stderr: String,
+    pub elapsed: Duration,
+    pub timed_out: bool,
+}
+
+impl CommandRunner {
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+
+    pub fn run(&self, command: &mut Command) -> Result<CommandOutput> {
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let started = Instant::now();
+        let mut child = command.spawn().context("failed to spawn child command")?;
+        let stdout = child.stdout.take().context("child stdout was not piped")?;
+        let stderr = child.stderr.take().context("child stderr was not piped")?;
+        let stdout_reader = spawn_reader(stdout);
+        let stderr_reader = spawn_reader(stderr);
+
+        let (status, timed_out) = match child.wait_timeout(self.timeout) {
+            Ok(Some(status)) => (status, false),
+            Ok(None) => {
+                let _ = child.kill();
+                (
+                    child.wait().context("failed to reap timed-out child")?,
+                    true,
+                )
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_reader(stdout_reader, "stdout");
+                let _ = join_reader(stderr_reader, "stderr");
+                return Err(error).context("failed while waiting for child command");
+            }
+        };
+        let stdout = join_reader(stdout_reader, "stdout")?;
+        let stderr = join_reader(stderr_reader, "stderr")?;
+
+        Ok(CommandOutput {
+            status,
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
+            elapsed: started.elapsed(),
+            timed_out,
+        })
+    }
+}
+
+impl Default for CommandRunner {
+    fn default() -> Self {
+        Self::new(DEFAULT_COMMAND_TIMEOUT)
+    }
+}
+
+fn spawn_reader<R>(mut reader: R) -> JoinHandle<io::Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+}
+
+fn join_reader(reader: JoinHandle<io::Result<Vec<u8>>>, stream: &str) -> Result<Vec<u8>> {
+    reader
+        .join()
+        .map_err(|_| anyhow!("{stream} reader thread panicked"))?
+        .with_context(|| format!("failed to read child {stream}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CommandRunner;
+    use std::io::{self, Write};
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    const HELPER_MODE: &str = "MASTER_SKILL_COMMAND_RUNNER_HELPER";
+
+    #[test]
+    fn command_runner_helper() {
+        let Ok(mode) = std::env::var(HELPER_MODE) else {
+            return;
+        };
+        if mode == "output" {
+            let stdout = vec![b'o'; 128 * 1024];
+            let stderr = vec![b'e'; 128 * 1024];
+            io::stdout().write_all(&stdout).unwrap();
+            io::stderr().write_all(&stderr).unwrap();
+        } else if mode == "sleep" {
+            std::thread::sleep(Duration::from_secs(5));
+        }
+    }
+
+    fn helper_command(mode: &str) -> Command {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "command::tests::command_runner_helper",
+                "--nocapture",
+            ])
+            .env(HELPER_MODE, mode);
+        command
+    }
+
+    #[test]
+    fn drains_and_retains_stdout_and_stderr() {
+        let output = CommandRunner::new(Duration::from_secs(5))
+            .run(&mut helper_command("output"))
+            .unwrap();
+
+        assert!(output.status.success());
+        assert!(!output.timed_out);
+        assert!(output.stdout.matches('o').count() >= 128 * 1024);
+        assert!(output.stderr.matches('e').count() >= 128 * 1024);
+    }
+
+    #[test]
+    fn kills_and_reaps_a_child_after_the_deadline() {
+        let started = Instant::now();
+        let output = CommandRunner::new(Duration::from_millis(100))
+            .run(&mut helper_command("sleep"))
+            .unwrap();
+
+        assert!(output.timed_out);
+        assert!(!output.status.success());
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}

--- a/desktop/src/desktop_args.rs
+++ b/desktop/src/desktop_args.rs
@@ -1,0 +1,64 @@
+use std::ffi::OsString;
+use std::fmt;
+
+pub const DESKTOP_USAGE: &str = "Usage: master-skill-desktop [--baseline | --help]\n\n\
+Options:\n  --baseline  Run the headless fidelity dry-run baseline\n  \
+-h, --help  Print this help";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchMode {
+    Gui,
+    Baseline,
+    Help,
+}
+
+#[derive(Debug)]
+pub struct LaunchArgsError {
+    args: Vec<OsString>,
+}
+
+impl fmt::Display for LaunchArgsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid arguments: {:?}", self.args)
+    }
+}
+
+impl std::error::Error for LaunchArgsError {}
+
+pub fn parse_launch_mode(
+    args: impl IntoIterator<Item = OsString>,
+) -> Result<LaunchMode, LaunchArgsError> {
+    let args: Vec<OsString> = args.into_iter().collect();
+    match args.as_slice() {
+        [] => Ok(LaunchMode::Gui),
+        [argument] if argument == "--baseline" => Ok(LaunchMode::Baseline),
+        [argument] if argument == "--help" || argument == "-h" => Ok(LaunchMode::Help),
+        _ => Err(LaunchArgsError { args }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_launch_mode, LaunchMode};
+    use std::ffi::OsString;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn parses_only_the_supported_launch_modes() {
+        assert_eq!(parse_launch_mode(args(&[])).unwrap(), LaunchMode::Gui);
+        assert_eq!(
+            parse_launch_mode(args(&["--baseline"])).unwrap(),
+            LaunchMode::Baseline
+        );
+        assert_eq!(
+            parse_launch_mode(args(&["--help"])).unwrap(),
+            LaunchMode::Help
+        );
+        assert_eq!(parse_launch_mode(args(&["-h"])).unwrap(), LaunchMode::Help);
+        assert!(parse_launch_mode(args(&["--unknown"])).is_err());
+        assert!(parse_launch_mode(args(&["--baseline", "extra"])).is_err());
+    }
+}

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -3,6 +3,7 @@ pub mod baseline;
 pub mod catalog;
 pub mod cli;
 pub mod command;
+pub mod desktop_args;
 pub mod fonts;
 pub mod layout;
 pub mod model;

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod baseline;
 pub mod catalog;
 pub mod cli;
+pub mod command;
 pub mod fonts;
 pub mod layout;
 pub mod model;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,20 +1,34 @@
 use eframe::egui;
 use master_skill_desktop::app::MasterSkillApp;
 use master_skill_desktop::baseline::run_headless_baseline;
+use master_skill_desktop::desktop_args::{parse_launch_mode, LaunchMode, DESKTOP_USAGE};
 use master_skill_desktop::fonts::install_cjk_fonts;
 
 fn main() -> eframe::Result {
-    if std::env::args().any(|arg| arg == "--baseline") {
-        let exit_code = match run_headless_baseline() {
-            Ok(code) => code,
-            Err(err) => {
-                eprintln!("baseline failed: {err:#}");
-                1
-            }
-        };
-        std::process::exit(exit_code);
+    match parse_launch_mode(std::env::args_os().skip(1)) {
+        Ok(LaunchMode::Gui) => run_gui(),
+        Ok(LaunchMode::Baseline) => {
+            let exit_code = match run_headless_baseline() {
+                Ok(code) => code,
+                Err(err) => {
+                    eprintln!("baseline failed: {err:#}");
+                    1
+                }
+            };
+            std::process::exit(exit_code);
+        }
+        Ok(LaunchMode::Help) => {
+            println!("{DESKTOP_USAGE}");
+            Ok(())
+        }
+        Err(error) => {
+            eprintln!("{error}\n\n{DESKTOP_USAGE}");
+            std::process::exit(2);
+        }
     }
+}
 
+fn run_gui() -> eframe::Result {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([1120.0, 720.0]),
         ..Default::default()

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -1916,6 +1916,18 @@ impl TraceStore {
     }
 
     pub fn load_from_path(path: &Path, capacity: usize) -> Result<Self> {
+        Self::load_from_path_with_interruption_policy(path, capacity, true)
+    }
+
+    pub fn load_read_only_from_path(path: &Path, capacity: usize) -> Result<Self> {
+        Self::load_from_path_with_interruption_policy(path, capacity, false)
+    }
+
+    fn load_from_path_with_interruption_policy(
+        path: &Path,
+        capacity: usize,
+        mark_running_interrupted: bool,
+    ) -> Result<Self> {
         if !path.is_file() {
             return Ok(Self::new(capacity));
         }
@@ -1968,7 +1980,9 @@ impl TraceStore {
             .unwrap_or(0)
             .saturating_add(1)
             .max(store.next_id);
-        store.mark_running_records_interrupted();
+        if mark_running_interrupted {
+            store.mark_running_records_interrupted();
+        }
         store.enforce_capacity();
         Ok(store)
     }
@@ -5201,6 +5215,24 @@ mod tests {
         assert_eq!(record.summary, "Interrupted before completion.");
         assert!(record.detail.contains("Desktop manager closed"));
 
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn read_only_load_preserves_running_records_owned_by_writer() {
+        let path = temp_path("trace-read-only");
+        let mut store = TraceStore::new(10);
+        store.begin_with_action(
+            "Running full validation",
+            TraceAction::FullValidation,
+            Some("npm test"),
+            "Queued.",
+        );
+        store.save_to_path(&path).unwrap();
+
+        let restored = TraceStore::load_read_only_from_path(&path, 10).unwrap();
+
+        assert_eq!(restored.recent()[0].status, TraceStatus::Running);
         fs::remove_file(path).unwrap();
     }
 

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -1818,7 +1819,87 @@ fn decision_action_for_regressed_scope(scope: &str) -> EvaluationDecisionAction 
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+const TRACE_STORE_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Deserialize)]
+struct TraceStoreFileV1 {
+    schema_version: u64,
+    next_id: u64,
+    records: VecDeque<TraceRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyTraceStoreFile {
+    capacity: usize,
+    next_id: u64,
+    records: VecDeque<TraceRecord>,
+}
+
+#[derive(Serialize)]
+struct TraceStoreFileV1Ref<'a> {
+    schema_version: u64,
+    next_id: u64,
+    records: &'a VecDeque<TraceRecord>,
+}
+
+#[derive(Debug)]
+pub struct TraceStoreLease {
+    trace_path: PathBuf,
+    _lock_file: fs::File,
+}
+
+impl TraceStoreLease {
+    pub fn try_acquire(trace_path: &Path) -> Result<Option<Self>> {
+        let parent = trace_store_parent(trace_path);
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create trace store directory {}",
+                parent.display()
+            )
+        })?;
+
+        let mut lock_name = trace_path.as_os_str().to_os_string();
+        lock_name.push(".lock");
+        let lock_path = PathBuf::from(lock_name);
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .with_context(|| format!("failed to open trace lock {}", lock_path.display()))?;
+
+        match fs4::FileExt::try_lock(&lock_file) {
+            Ok(()) => Ok(Some(Self {
+                trace_path: trace_path.to_path_buf(),
+                _lock_file: lock_file,
+            })),
+            Err(fs4::TryLockError::WouldBlock) => Ok(None),
+            Err(fs4::TryLockError::Error(error)) => Err(error)
+                .with_context(|| format!("failed to lock trace store {}", trace_path.display())),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.trace_path
+    }
+
+    pub fn load(&self, capacity: usize) -> Result<TraceStore> {
+        TraceStore::load_from_path(&self.trace_path, capacity)
+    }
+
+    pub fn save(&self, store: &TraceStore) -> Result<()> {
+        store.save_to_path(&self.trace_path)
+    }
+}
+
+fn trace_store_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+#[derive(Clone, Debug)]
 pub struct TraceStore {
     capacity: usize,
     next_id: u64,
@@ -1839,9 +1920,46 @@ impl TraceStore {
             return Ok(Self::new(capacity));
         }
 
-        let content = fs::read_to_string(path)?;
-        let mut store: Self = serde_json::from_str(&content)?;
-        store.capacity = capacity;
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read trace store {}", path.display()))?;
+        let value: serde_json::Value = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse trace store {}", path.display()))?;
+        let (next_id, records) = if let Some(raw_version) = value.get("schema_version") {
+            let version = raw_version.as_u64().ok_or_else(|| {
+                anyhow!(
+                    "invalid trace schema_version in {}: expected a positive integer",
+                    path.display()
+                )
+            })?;
+            if version != TRACE_STORE_SCHEMA_VERSION {
+                return Err(anyhow!("unsupported trace schema version {version}"));
+            }
+            let payload: TraceStoreFileV1 = serde_json::from_value(value).with_context(|| {
+                format!(
+                    "invalid trace schema version 1 payload in {}",
+                    path.display()
+                )
+            })?;
+            if payload.schema_version != TRACE_STORE_SCHEMA_VERSION {
+                return Err(anyhow!(
+                    "unsupported trace schema version {}",
+                    payload.schema_version
+                ));
+            }
+            (payload.next_id, payload.records)
+        } else {
+            let payload: LegacyTraceStoreFile =
+                serde_json::from_value(value).with_context(|| {
+                    format!("invalid legacy trace store payload in {}", path.display())
+                })?;
+            let _legacy_capacity = payload.capacity;
+            (payload.next_id, payload.records)
+        };
+        let mut store = Self {
+            capacity,
+            next_id,
+            records,
+        };
         store.next_id = store
             .records
             .iter()
@@ -1856,11 +1974,40 @@ impl TraceStore {
     }
 
     pub fn save_to_path(&self, path: &Path) -> Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let content = serde_json::to_string_pretty(self)?;
-        fs::write(path, content)?;
+        let content = serde_json::to_vec_pretty(&TraceStoreFileV1Ref {
+            schema_version: TRACE_STORE_SCHEMA_VERSION,
+            next_id: self.next_id,
+            records: &self.records,
+        })
+        .context("failed to serialize trace store")?;
+        let parent = trace_store_parent(path);
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create trace store directory {}",
+                parent.display()
+            )
+        })?;
+
+        let mut temporary = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+            format!(
+                "failed to create temporary trace file in {}",
+                parent.display()
+            )
+        })?;
+        temporary
+            .write_all(&content)
+            .context("failed to write temporary trace file")?;
+        temporary
+            .flush()
+            .context("failed to flush temporary trace file")?;
+        temporary
+            .as_file()
+            .sync_all()
+            .context("failed to sync temporary trace file")?;
+        temporary
+            .persist(path)
+            .map_err(|error| error.error)
+            .with_context(|| format!("failed to replace trace store {}", path.display()))?;
         Ok(())
     }
 
@@ -2416,6 +2563,7 @@ mod tests {
         EvaluationMode, EvaluationRegressionItem, EvaluationRemediationPlan, EvaluationRunCoverage,
         EvaluationRunHistoryFilter, EvaluationRunHistoryItem, EvaluationRunTrend,
         EvaluationTrendSummary, FailureKind, TraceAction, TraceListFilter, TraceStatus, TraceStore,
+        TraceStoreLease,
     };
 
     fn temp_path(name: &str) -> PathBuf {
@@ -2424,6 +2572,14 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("master-skill-desktop-{name}-{suffix}.json"))
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("master-skill-desktop-{name}-{suffix}"))
     }
 
     #[test]
@@ -4961,6 +5117,68 @@ mod tests {
         );
 
         fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn loads_legacy_trace_file_and_rewrites_schema_v1() {
+        let directory = temp_dir("trace-legacy");
+        let path = directory.join("desktop-traces.json");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(&path, r#"{"capacity":99,"next_id":7,"records":[]}"#).unwrap();
+
+        let store = TraceStore::load_from_path(&path, 10).unwrap();
+        store.save_to_path(&path).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["next_id"], 7);
+        assert!(value.get("capacity").is_none());
+        assert!(value["records"].is_array());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejects_unknown_trace_schema_version() {
+        let directory = temp_dir("trace-version");
+        let path = directory.join("desktop-traces.json");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(&path, r#"{"schema_version":2,"next_id":1,"records":[]}"#).unwrap();
+
+        let error = TraceStore::load_from_path(&path, 10).unwrap_err();
+
+        assert!(format!("{error:#}").contains("unsupported trace schema version 2"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn versioned_trace_file_round_trips_without_capacity() {
+        let directory = temp_dir("trace-v1");
+        let path = directory.join("desktop-traces.json");
+        let mut store = TraceStore::new(10);
+        store.begin("one");
+
+        store.save_to_path(&path).unwrap();
+        let restored = TraceStore::load_from_path(&path, 3).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+
+        assert_eq!(restored.summary().total, 1);
+        assert_eq!(value["schema_version"], 1);
+        assert!(value.get("capacity").is_none());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn only_one_trace_store_lease_can_hold_a_path() {
+        let directory = temp_dir("trace-lease");
+        let path = directory.join("desktop-traces.json");
+        let first = TraceStoreLease::try_acquire(&path).unwrap().unwrap();
+
+        assert!(TraceStoreLease::try_acquire(&path).unwrap().is_none());
+        drop(first);
+        assert!(TraceStoreLease::try_acquire(&path).unwrap().is_some());
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/desktop/src/trace.rs
+++ b/desktop/src/trace.rs
@@ -1980,6 +1980,9 @@ impl TraceStore {
             .unwrap_or(0)
             .saturating_add(1)
             .max(store.next_id);
+        if store.next_id == u64::MAX {
+            return Err(anyhow!("trace record ID space is exhausted"));
+        }
         if mark_running_interrupted {
             store.mark_running_records_interrupted();
         }
@@ -5162,6 +5165,26 @@ mod tests {
         let error = TraceStore::load_from_path(&path, 10).unwrap_err();
 
         assert!(format!("{error:#}").contains("unsupported trace schema version 2"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejects_trace_store_with_exhausted_record_ids() {
+        let directory = temp_dir("trace-id-exhausted");
+        let path = directory.join("desktop-traces.json");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(
+            &path,
+            format!(
+                r#"{{"schema_version":1,"next_id":{},"records":[]}}"#,
+                u64::MAX
+            ),
+        )
+        .unwrap();
+
+        let error = TraceStore::load_from_path(&path, 10).unwrap_err();
+
+        assert!(format!("{error:#}").contains("record ID space is exhausted"));
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/desktop/tests/baseline_cli.rs
+++ b/desktop/tests/baseline_cli.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use master_skill_desktop::trace::{EvaluationDecisionBrief, EvaluationDecisionPosture, TraceStore};
+use master_skill_desktop::trace::{
+    EvaluationDecisionBrief, EvaluationDecisionPosture, TraceStore, TraceStoreLease,
+};
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -159,6 +161,30 @@ fn baseline_flag_runs_headless_and_records_traces_for_all_master_skills() {
     assert_eq!(brief.headline, "Graded evidence incomplete");
 
     fs::remove_dir_all(&xdg_data_home).ok();
+}
+
+#[test]
+fn baseline_lock_contention_fails_clearly() {
+    let xdg_data_home = temp_xdg_data_home();
+    let store_path = xdg_data_home
+        .join("master-skill")
+        .join("desktop-traces.json");
+    let _lease = TraceStoreLease::try_acquire(&store_path)
+        .unwrap()
+        .expect("test must acquire the first lease");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_master-skill-desktop"));
+    command
+        .arg("--baseline")
+        .current_dir(repo_root())
+        .env("XDG_DATA_HOME", &xdg_data_home);
+
+    let output = run_with_timeout(command, Duration::from_secs(10));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr.contains("trace store"));
+    assert!(stderr.contains("another"));
+    fs::remove_dir_all(xdg_data_home).ok();
 }
 
 /// Builds a directory that *looks* like a Master-skill repo root to the

--- a/desktop/tests/desktop_args_cli.rs
+++ b/desktop/tests/desktop_args_cli.rs
@@ -1,0 +1,85 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn run_desktop(args: &[&str]) -> std::process::Output {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let xdg_data_home =
+        std::env::temp_dir().join(format!("master-skill-desktop-args-test-{suffix}"));
+    fs::create_dir_all(&xdg_data_home).unwrap();
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_master-skill-desktop"));
+    command
+        .args(args)
+        .current_dir(repo_root())
+        .env("XDG_DATA_HOME", &xdg_data_home)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .expect("failed to spawn master-skill-desktop");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let output = loop {
+        if child
+            .try_wait()
+            .expect("failed to poll desktop child")
+            .is_some()
+        {
+            break child
+                .wait_with_output()
+                .expect("failed to collect desktop child output");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("desktop did not exit for arguments {args:?}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    fs::remove_dir_all(xdg_data_home).ok();
+    output
+}
+
+#[test]
+fn help_exits_zero_without_launching_a_window() {
+    for flag in ["--help", "-h"] {
+        let output = run_desktop(&[flag]);
+        assert!(output.status.success(), "{flag} failed: {output:?}");
+        assert!(String::from_utf8_lossy(&output.stdout).contains("Usage:"));
+    }
+}
+
+#[test]
+fn unknown_argument_exits_two_and_prints_usage_to_stderr() {
+    let output = run_desktop(&["--unknown"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr.contains("invalid arguments"));
+    assert!(stderr.contains("Usage:"));
+}
+
+#[test]
+fn extra_or_incompatible_arguments_exit_two() {
+    for args in [
+        vec!["--baseline", "extra"],
+        vec!["--baseline", "--help"],
+        vec!["--help", "extra"],
+    ] {
+        let output = run_desktop(&args);
+        assert_eq!(output.status.code(), Some(2), "args {args:?}: {output:?}");
+    }
+}

--- a/docs/superpowers/plans/2026-07-30-desktop-runtime-reliability.md
+++ b/docs/superpowers/plans/2026-07-30-desktop-runtime-reliability.md
@@ -1,0 +1,1067 @@
+# Desktop Runtime Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make desktop trace persistence and background command execution safe under crashes, concurrent launches, worker disconnects, invalid CLI arguments, and stalled child processes.
+
+**Architecture:** Keep the existing single-crate, thread-and-channel architecture, but establish explicit ownership boundaries. A process-lifetime `TraceStoreLease` becomes the only application path that saves a versioned trace snapshot atomically; a synchronous `CommandRunner` bounds every child command; and one `PendingTask` state machine represents all worker terminal states. CLI argument parsing remains separate from eframe initialization so headless modes cannot accidentally launch a window.
+
+**Tech Stack:** Rust 2021, `serde`/`serde_json`, `fs4` 1.1 sync-only locking, `tempfile` 3 atomic replacement, `wait-timeout` 0.2 bounded process waits, standard threads and MPSC channels, eframe/egui.
+
+## Global Constraints
+
+- Stack this branch on the reviewed head of `fix/desktop-evaluation-contract`; open PR 2 against that branch.
+- Use `fs4` version `1.1` with `default-features = false, features = ["sync"]`.
+- Use `tempfile` version `3`.
+- Use `wait-timeout` version `0.2`.
+- Retain one Rust crate and the existing `std::thread` plus channel execution model.
+- Use a five-minute production deadline for each direct child command.
+- Kill and reap the direct child on timeout; process-tree termination is explicitly out of scope.
+- Accept the current unversioned trace object as legacy input, save only schema version 1, and reject unknown versions.
+- Do not persist runtime `capacity`.
+- A contended GUI is visibly read-only; a contended `--baseline` exits non-zero.
+- `--help` and `-h` exit zero without initializing eframe; invalid or extra arguments exit `2`.
+- Do not run paid model evaluation.
+
+---
+
+### Task 1: Versioned, Atomic Trace Persistence
+
+**Files:**
+- Modify: `desktop/Cargo.toml`
+- Modify: `desktop/Cargo.lock`
+- Modify: `desktop/src/trace.rs:1-20`
+- Modify: `desktop/src/trace.rs:1822-1870`
+- Test: `desktop/src/trace.rs:4930-end`
+
+**Interfaces:**
+- Consumes: existing `TraceRecord`, `TraceStatus`, and `TraceStore` record-management behavior.
+- Produces: `TraceStore::load_from_path(path: &Path, capacity: usize) -> anyhow::Result<TraceStore>`, `TraceStore::save_to_path(path: &Path) -> anyhow::Result<()>`, and `TraceStoreLease::{try_acquire, load, save, path}`.
+
+- [ ] **Step 1: Add failing schema and lease tests**
+
+Add these tests to `trace.rs`:
+
+```rust
+#[test]
+fn loads_legacy_trace_file_and_rewrites_schema_v1() {
+    let directory = temp_dir("trace-legacy");
+    let path = directory.join("desktop-traces.json");
+    fs::create_dir_all(&directory).unwrap();
+    fs::write(
+        &path,
+        r#"{"capacity":99,"next_id":7,"records":[]}"#,
+    )
+    .unwrap();
+
+    let store = TraceStore::load_from_path(&path, 10).unwrap();
+    store.save_to_path(&path).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["next_id"], 7);
+    assert!(value.get("capacity").is_none());
+    assert!(value["records"].is_array());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn rejects_unknown_trace_schema_version() {
+    let directory = temp_dir("trace-version");
+    let path = directory.join("desktop-traces.json");
+    fs::create_dir_all(&directory).unwrap();
+    fs::write(
+        &path,
+        r#"{"schema_version":2,"next_id":1,"records":[]}"#,
+    )
+    .unwrap();
+
+    let error = TraceStore::load_from_path(&path, 10).unwrap_err();
+
+    assert!(format!("{error:#}").contains("unsupported trace schema version 2"));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn versioned_trace_file_round_trips_without_capacity() {
+    let directory = temp_dir("trace-v1");
+    let path = directory.join("desktop-traces.json");
+    let mut store = TraceStore::new(10);
+    store.begin("one");
+
+    store.save_to_path(&path).unwrap();
+    let restored = TraceStore::load_from_path(&path, 3).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+
+    assert_eq!(restored.summary().total, 1);
+    assert_eq!(value["schema_version"], 1);
+    assert!(value.get("capacity").is_none());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn only_one_trace_store_lease_can_hold_a_path() {
+    let directory = temp_dir("trace-lease");
+    let path = directory.join("desktop-traces.json");
+    let first = TraceStoreLease::try_acquire(&path).unwrap().unwrap();
+
+    assert!(TraceStoreLease::try_acquire(&path).unwrap().is_none());
+    drop(first);
+    assert!(TraceStoreLease::try_acquire(&path).unwrap().is_some());
+    fs::remove_dir_all(directory).unwrap();
+}
+```
+
+Add a `temp_dir` helper beside the existing `temp_path` helper:
+
+```rust
+fn temp_dir(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("master-skill-desktop-{label}-{suffix}"))
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml loads_legacy_trace_file_and_rewrites_schema_v1 -- --nocapture
+cargo test --locked --manifest-path desktop/Cargo.toml only_one_trace_store_lease_can_hold_a_path -- --nocapture
+```
+
+Expected: compilation fails because `TraceStoreLease` and the v1 persistence contract do not exist; after filtering tests individually, the current serializer also persists `capacity`.
+
+- [ ] **Step 3: Add the persistence dependencies**
+
+Add:
+
+```toml
+fs4 = { version = "1.1", default-features = false, features = ["sync"] }
+tempfile = "3"
+```
+
+Run `cargo check --manifest-path desktop/Cargo.toml` once to update `desktop/Cargo.lock`.
+
+- [ ] **Step 4: Implement schema-aware loading and atomic saving**
+
+Replace direct `TraceStore` serialization with explicit persisted payloads:
+
+```rust
+const TRACE_STORE_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Deserialize)]
+struct TraceStoreFileV1 {
+    schema_version: u64,
+    next_id: u64,
+    records: VecDeque<TraceRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyTraceStoreFile {
+    capacity: usize,
+    next_id: u64,
+    records: VecDeque<TraceRecord>,
+}
+
+#[derive(Serialize)]
+struct TraceStoreFileV1Ref<'a> {
+    schema_version: u64,
+    next_id: u64,
+    records: &'a VecDeque<TraceRecord>,
+}
+```
+
+Remove `Serialize` and `Deserialize` from `TraceStore` itself. In `load_from_path`, parse to `serde_json::Value`, inspect `schema_version` before deserializing, reject any non-v1 version, and otherwise parse the legacy object. Build the runtime `TraceStore` with the caller-provided capacity, recompute a safe lower bound for `next_id`, mark running records interrupted, and enforce capacity.
+
+Implement saving as:
+
+```rust
+pub fn save_to_path(&self, path: &Path) -> Result<()> {
+    let content = serde_json::to_vec_pretty(&TraceStoreFileV1Ref {
+        schema_version: TRACE_STORE_SCHEMA_VERSION,
+        next_id: self.next_id,
+        records: &self.records,
+    })?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(&content)?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+    temporary.persist(path).map_err(|error| error.error)?;
+    Ok(())
+}
+```
+
+Import `std::io::Write`. Serialization must occur before directory creation or destination replacement.
+
+- [ ] **Step 5: Implement the process-lifetime writer lease**
+
+Add:
+
+```rust
+#[derive(Debug)]
+pub struct TraceStoreLease {
+    trace_path: PathBuf,
+    _lock_file: fs::File,
+}
+
+impl TraceStoreLease {
+    pub fn try_acquire(trace_path: &Path) -> Result<Option<Self>> {
+        let parent = trace_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent)?;
+        let mut lock_name = trace_path.as_os_str().to_os_string();
+        lock_name.push(".lock");
+        let lock_path = PathBuf::from(lock_name);
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+
+        match fs4::FileExt::try_lock(&lock_file) {
+            Ok(()) => Ok(Some(Self {
+                trace_path: trace_path.to_path_buf(),
+                _lock_file: lock_file,
+            })),
+            Err(fs4::TryLockError::WouldBlock) => Ok(None),
+            Err(fs4::TryLockError::Error(error)) => Err(error.into()),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.trace_path
+    }
+
+    pub fn load(&self, capacity: usize) -> Result<TraceStore> {
+        TraceStore::load_from_path(&self.trace_path, capacity)
+    }
+
+    pub fn save(&self, store: &TraceStore) -> Result<()> {
+        store.save_to_path(&self.trace_path)
+    }
+}
+```
+
+The open file handle holds the advisory lock until `TraceStoreLease` is dropped.
+
+- [ ] **Step 6: Run focused and complete trace tests**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml trace::tests -- --nocapture
+```
+
+Expected: all trace tests pass, including legacy migration, v1 round-trip, unknown-version rejection, contention, and reacquisition after drop.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add desktop/Cargo.toml desktop/Cargo.lock desktop/src/trace.rs
+git commit -m "fix(desktop): make trace persistence atomic"
+```
+
+---
+
+### Task 2: Exclusive Baseline Writer
+
+**Files:**
+- Modify: `desktop/src/baseline.rs:20-115`
+- Modify: `desktop/tests/baseline_cli.rs`
+
+**Interfaces:**
+- Consumes: `TraceStoreLease::try_acquire`, `TraceStoreLease::load`, and `TraceStoreLease::save` from Task 1.
+- Produces: `run_headless_baseline() -> anyhow::Result<i32>` that refuses to run while another process owns the store.
+
+- [ ] **Step 1: Write the lock-contention integration test**
+
+Add:
+
+```rust
+#[test]
+fn baseline_lock_contention_fails_clearly() {
+    let xdg_data_home = temp_xdg_data_home();
+    let store_path = xdg_data_home
+        .join("master-skill")
+        .join("desktop-traces.json");
+    let _lease = TraceStoreLease::try_acquire(&store_path)
+        .unwrap()
+        .expect("test must acquire the first lease");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_master-skill-desktop"));
+    command
+        .arg("--baseline")
+        .current_dir(repo_root())
+        .env("XDG_DATA_HOME", &xdg_data_home);
+
+    let output = run_with_timeout(command, Duration::from_secs(10));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr.contains("trace store"));
+    assert!(stderr.contains("another"));
+    fs::remove_dir_all(xdg_data_home).ok();
+}
+```
+
+Import `TraceStoreLease` with `TraceStore`.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml --test baseline_cli baseline_lock_contention_fails_clearly -- --nocapture
+```
+
+Expected: FAIL because the child baseline currently loads, runs, and saves despite the held lease.
+
+- [ ] **Step 3: Acquire and retain the lease in the baseline**
+
+Before loading the store:
+
+```rust
+let store_path = desktop_trace_store_path();
+let lease = TraceStoreLease::try_acquire(&store_path)?.ok_or_else(|| {
+    anyhow!(
+        "trace store {:?} is locked by another desktop or baseline process",
+        store_path
+    )
+})?;
+let mut traces = lease.load(TRACE_STORE_CAPACITY)?;
+```
+
+Replace the final `traces.save_to_path(&store_path)?` with `lease.save(&traces)?`. Keep `lease` in scope for the complete run.
+
+- [ ] **Step 4: Run all baseline integration tests**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml --test baseline_cli -- --nocapture
+```
+
+Expected: all baseline tests pass; the normal baseline still writes v1 and the contended run exits quickly with status `1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop/src/baseline.rs desktop/tests/baseline_cli.rs
+git commit -m "fix(desktop): serialize baseline trace writers"
+```
+
+---
+
+### Task 3: Bounded Command Runner
+
+**Files:**
+- Modify: `desktop/Cargo.toml`
+- Modify: `desktop/Cargo.lock`
+- Create: `desktop/src/command.rs`
+- Modify: `desktop/src/lib.rs`
+- Modify: `desktop/src/cli.rs:1-130`
+- Test: `desktop/src/command.rs`
+
+**Interfaces:**
+- Consumes: `std::process::Command`.
+- Produces: `CommandRunner::new(timeout: Duration)`, `CommandRunner::run(command: &mut Command) -> anyhow::Result<CommandOutput>`, and a clonable five-minute default runner used by `CliClient`.
+
+- [ ] **Step 1: Add the dependency and failing runner tests**
+
+Add `wait-timeout = "0.2"` to `desktop/Cargo.toml`, declare `pub mod command;` in `desktop/src/lib.rs`, and create `desktop/src/command.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::CommandRunner;
+    use std::io::{self, Write};
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    const HELPER_MODE: &str = "MASTER_SKILL_COMMAND_RUNNER_HELPER";
+
+    #[test]
+    fn command_runner_helper() {
+        let Ok(mode) = std::env::var(HELPER_MODE) else {
+            return;
+        };
+        if mode == "output" {
+            let stdout = vec![b'o'; 128 * 1024];
+            let stderr = vec![b'e'; 128 * 1024];
+            io::stdout().write_all(&stdout).unwrap();
+            io::stderr().write_all(&stderr).unwrap();
+        } else if mode == "sleep" {
+            std::thread::sleep(Duration::from_secs(5));
+        }
+    }
+
+    fn helper_command(mode: &str) -> Command {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "command::tests::command_runner_helper",
+                "--nocapture",
+            ])
+            .env(HELPER_MODE, mode);
+        command
+    }
+
+    #[test]
+    fn drains_and_retains_stdout_and_stderr() {
+        let output = CommandRunner::new(Duration::from_secs(5))
+            .run(&mut helper_command("output"))
+            .unwrap();
+
+        assert!(output.status.success());
+        assert!(!output.timed_out);
+        assert!(output.stdout.matches('o').count() >= 128 * 1024);
+        assert!(output.stderr.matches('e').count() >= 128 * 1024);
+    }
+
+    #[test]
+    fn kills_and_reaps_a_child_after_the_deadline() {
+        let started = Instant::now();
+        let output = CommandRunner::new(Duration::from_millis(100))
+            .run(&mut helper_command("sleep"))
+            .unwrap();
+
+        assert!(output.timed_out);
+        assert!(!output.status.success());
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml command::tests -- --nocapture
+```
+
+Expected: compilation fails because `CommandRunner` does not exist.
+
+- [ ] **Step 3: Implement concurrent pipe draining and bounded waiting**
+
+Implement:
+
+```rust
+use std::io::{self, Read};
+use std::process::{Command, ExitStatus, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use wait_timeout::ChildExt;
+
+pub const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Clone, Debug)]
+pub struct CommandRunner {
+    timeout: Duration,
+}
+
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub status: ExitStatus,
+    pub stdout: String,
+    pub stderr: String,
+    pub elapsed: Duration,
+    pub timed_out: bool,
+}
+
+impl CommandRunner {
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+
+    pub fn run(&self, command: &mut Command) -> Result<CommandOutput> {
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let started = Instant::now();
+        let mut child = command.spawn().context("failed to spawn child command")?;
+        let stdout = child.stdout.take().context("child stdout was not piped")?;
+        let stderr = child.stderr.take().context("child stderr was not piped")?;
+        let stdout_reader = spawn_reader(stdout);
+        let stderr_reader = spawn_reader(stderr);
+
+        let wait_result = child.wait_timeout(self.timeout);
+        let (status, timed_out) = match wait_result {
+            Ok(Some(status)) => (status, false),
+            Ok(None) => {
+                let _ = child.kill();
+                (
+                    child.wait().context("failed to reap timed-out child")?,
+                    true,
+                )
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_reader(stdout_reader, "stdout");
+                let _ = join_reader(stderr_reader, "stderr");
+                return Err(error).context("failed while waiting for child command");
+            }
+        };
+        let stdout = join_reader(stdout_reader, "stdout")?;
+        let stderr = join_reader(stderr_reader, "stderr")?;
+
+        Ok(CommandOutput {
+            status,
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
+            elapsed: started.elapsed(),
+            timed_out,
+        })
+    }
+}
+
+impl Default for CommandRunner {
+    fn default() -> Self {
+        Self::new(DEFAULT_COMMAND_TIMEOUT)
+    }
+}
+
+fn spawn_reader<R>(mut reader: R) -> JoinHandle<io::Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+}
+
+fn join_reader(
+    reader: JoinHandle<io::Result<Vec<u8>>>,
+    stream: &str,
+) -> Result<Vec<u8>> {
+    reader
+        .join()
+        .map_err(|_| anyhow!("{stream} reader thread panicked"))?
+        .with_context(|| format!("failed to read child {stream}"))
+}
+```
+
+- [ ] **Step 4: Route every `CliClient` child through the runner**
+
+Add `runner: CommandRunner` to `CliClient`, initialize it with `CommandRunner::default()`, and add:
+
+```rust
+pub fn with_command_timeout(mut self, timeout: Duration) -> Self {
+    self.runner = CommandRunner::new(timeout);
+    self
+}
+```
+
+Replace `Command::output()` in `run_command`:
+
+```rust
+let output = self
+    .runner
+    .run(command)
+    .with_context(|| context.to_string())?;
+if !output.timed_out && output.status.success() {
+    return Ok(output.stdout);
+}
+
+let reason = if output.timed_out {
+    format!("command timed out after {} ms", output.elapsed.as_millis())
+} else {
+    format!(
+        "command failed after {} ms with status {}",
+        output.elapsed.as_millis(),
+        output.status
+    )
+};
+Err(anyhow!(
+    "{context}: {reason}\nstdout:\n{}\nstderr:\n{}",
+    output.stdout,
+    output.stderr
+))
+```
+
+This formatted error is what the existing task layer stores in trace detail.
+
+- [ ] **Step 5: Run command and CLI tests**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml command::tests -- --nocapture
+cargo test --manifest-path desktop/Cargo.toml cli:: -- --nocapture
+cargo test --manifest-path desktop/Cargo.toml --test cli_client -- --nocapture
+```
+
+Expected: the large-output helper cannot deadlock, the sleeping helper returns in under two seconds with `timed_out = true`, and all real CLI integration tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add desktop/Cargo.toml desktop/Cargo.lock desktop/src/lib.rs desktop/src/command.rs desktop/src/cli.rs
+git commit -m "fix(desktop): bound child command execution"
+```
+
+---
+
+### Task 4: Explicit Pending State and Read-Only GUI
+
+**Files:**
+- Modify: `desktop/src/app.rs:1-780`
+- Modify: `desktop/src/app.rs:930-2290`
+- Test: `desktop/src/app.rs:2480-end`
+
+**Interfaces:**
+- Consumes: `TraceStoreLease` from Task 1 and bounded `CliClient` from Task 3.
+- Produces: one `PendingTask` slot that distinguishes `Empty`, completion, and disconnection; a retained optional writer lease; and centralized read-only action enforcement.
+
+- [ ] **Step 1: Write failing pending-state and action-policy tests**
+
+Add:
+
+```rust
+#[test]
+fn disconnected_pending_task_is_removed_and_marks_trace_failed() {
+    let mut traces = TraceStore::new(10);
+    let trace_id = traces.begin_with_action(
+        "Running full validation",
+        TraceAction::FullValidation,
+        Some("npm test"),
+        "Queued.",
+    );
+    let (sender, receiver) = channel::<TaskResult>();
+    drop(sender);
+    let mut pending = Some(PendingTask {
+        trace_id: Some(trace_id),
+        label: "Running full validation".to_string(),
+        started: Instant::now(),
+        receiver,
+    });
+
+    let event = poll_pending_task(&mut pending);
+    let PendingTaskEvent::Disconnected {
+        trace_id,
+        elapsed,
+    } = event
+    else {
+        panic!("expected disconnected event");
+    };
+    let message = finish_disconnected_trace(&mut traces, trace_id, elapsed);
+
+    assert!(pending.is_none());
+    assert_eq!(traces.recent()[0].status, TraceStatus::Failed);
+    assert_eq!(
+        message,
+        "Task worker disconnected before reporting a result"
+    );
+}
+
+#[test]
+fn read_only_policy_allows_browsing_but_rejects_trace_writes() {
+    assert!(!trace_action_requires_writer(&TraceAction::Refresh));
+    assert!(!trace_action_requires_writer(&TraceAction::InspectSkill {
+        slug: "huineng".to_string(),
+    }));
+    assert!(trace_action_requires_writer(&TraceAction::InstallAll));
+    assert!(trace_action_requires_writer(&TraceAction::FullValidation));
+    assert!(trace_action_requires_writer(
+        &TraceAction::FidelityDryRunAll
+    ));
+}
+```
+
+Import `channel` and `Instant` in the test module.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml disconnected_pending_task_is_removed_and_marks_trace_failed -- --nocapture
+cargo test --manifest-path desktop/Cargo.toml read_only_policy_allows_browsing_but_rejects_trace_writes -- --nocapture
+```
+
+Expected: compilation fails because the pending-task state machine and read-only policy do not exist.
+
+- [ ] **Step 3: Replace the split receiver/label fields with `PendingTask`**
+
+Define:
+
+```rust
+struct PendingTask {
+    trace_id: Option<u64>,
+    label: String,
+    started: Instant,
+    receiver: Receiver<TaskResult>,
+}
+
+enum PendingTaskEvent {
+    Pending,
+    Completed {
+        trace_id: Option<u64>,
+        elapsed: Duration,
+        result: TaskResult,
+    },
+    Disconnected {
+        trace_id: Option<u64>,
+        elapsed: Duration,
+    },
+}
+```
+
+Replace `task_rx` and `busy_label` with `pending_task: Option<PendingTask>`. Implement `poll_pending_task` with an exact `TryRecvError` match: `Empty` retains the slot, while both completion and `Disconnected` take the slot. Make workers send only `TaskResult`; compute elapsed from `PendingTask::started`.
+
+Implement:
+
+```rust
+const WORKER_DISCONNECTED_MESSAGE: &str =
+    "Task worker disconnected before reporting a result";
+
+fn finish_disconnected_trace(
+    traces: &mut TraceStore,
+    trace_id: Option<u64>,
+    elapsed: Duration,
+) -> String {
+    if let Some(trace_id) = trace_id {
+        traces.finish_error_with_detail(
+            trace_id,
+            WORKER_DISCONNECTED_MESSAGE,
+            WORKER_DISCONNECTED_MESSAGE,
+            elapsed,
+        );
+    }
+    WORKER_DISCONNECTED_MESSAGE.to_string()
+}
+```
+
+Update `MasterSkillApp::poll_task` to apply success/error outcomes as before, persist traced terminal results, and use this helper for disconnection.
+
+- [ ] **Step 4: Acquire the GUI lease and represent read-only mode**
+
+Replace `trace_path` with:
+
+```rust
+trace_lease: Option<TraceStoreLease>,
+read_only_reason: Option<String>,
+```
+
+In `MasterSkillApp::new`, call `TraceStoreLease::try_acquire(&trace_path)` before loading. Retain `Some(lease)` for the application lifetime. For `Ok(None)`, load the store for browsing and set:
+
+```rust
+Some(format!(
+    "Trace store is in use by another process; this window is read-only: {}",
+    trace_path.display()
+))
+```
+
+For lock I/O errors, also open read-only and include the error in the reason. Change `persist_traces` to save only through `self.trace_lease.as_ref().map(|lease| lease.save(&self.traces))`.
+
+- [ ] **Step 5: Enforce read-only behavior centrally**
+
+Add:
+
+```rust
+fn trace_action_requires_writer(action: &TraceAction) -> bool {
+    !matches!(action, TraceAction::Refresh | TraceAction::InspectSkill { .. })
+}
+
+fn is_read_only(&self) -> bool {
+    self.trace_lease.is_none()
+}
+
+fn can_mutate(&self) -> bool {
+    !self.is_busy() && !self.is_read_only()
+}
+```
+
+At the start of `start_task_with_action`, if the app is read-only and its action requires a writer, log the read-only reason and return before creating a trace or spawning a worker. For `Refresh` and `InspectSkill` in read-only mode, create `PendingTask { trace_id: None, ... }`; do not mutate or persist the trace store.
+
+- [ ] **Step 6: Make read-only mode visible and disable writer controls**
+
+Show the read-only reason in the toolbar. Keep Refresh and Open/Inspect enabled while idle. Gate Install, Uninstall, Install all, Update all, fidelity runs, full validation, rerun actions, and Clear traces on `can_mutate()` or an action-specific helper:
+
+```rust
+fn can_start_trace_action(&self, action: &TraceAction) -> bool {
+    !self.is_busy()
+        && (!self.is_read_only() || !trace_action_requires_writer(action))
+}
+```
+
+Retain centralized enforcement even where UI controls are disabled.
+
+- [ ] **Step 7: Run app and full Rust tests**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml app::tests -- --nocapture
+cargo test --manifest-path desktop/Cargo.toml
+```
+
+Expected: the disconnected receiver is removed in one poll and its traced operation ends `Failed`; browsing policy tests pass; all existing UI and evaluation tests remain green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add desktop/src/app.rs
+git commit -m "fix(desktop): make task termination explicit"
+```
+
+---
+
+### Task 5: Explicit Desktop CLI Argument Contract
+
+**Files:**
+- Create: `desktop/src/desktop_args.rs`
+- Modify: `desktop/src/lib.rs`
+- Modify: `desktop/src/main.rs`
+- Create: `desktop/tests/desktop_args_cli.rs`
+
+**Interfaces:**
+- Consumes: `run_headless_baseline()` and the existing eframe startup closure.
+- Produces: `parse_launch_mode(args: impl IntoIterator<Item = OsString>) -> Result<LaunchMode, LaunchArgsError>`, `DESKTOP_USAGE`, and binary exit behavior `0` for help, `2` for invalid arguments.
+
+- [ ] **Step 1: Write failing binary integration tests**
+
+Create:
+
+```rust
+use std::process::Command;
+
+fn desktop() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_master-skill-desktop"))
+}
+
+#[test]
+fn help_exits_zero_without_launching_a_window() {
+    for flag in ["--help", "-h"] {
+        let output = desktop().arg(flag).output().unwrap();
+        assert!(output.status.success(), "{flag} failed: {output:?}");
+        assert!(String::from_utf8_lossy(&output.stdout).contains("Usage:"));
+    }
+}
+
+#[test]
+fn unknown_argument_exits_two_and_prints_usage_to_stderr() {
+    let output = desktop().arg("--unknown").output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr.contains("invalid arguments"));
+    assert!(stderr.contains("Usage:"));
+}
+
+#[test]
+fn extra_or_incompatible_arguments_exit_two() {
+    for args in [
+        vec!["--baseline", "extra"],
+        vec!["--baseline", "--help"],
+        vec!["--help", "extra"],
+    ] {
+        let output = desktop().args(&args).output().unwrap();
+        assert_eq!(output.status.code(), Some(2), "args {args:?}: {output:?}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml --test desktop_args_cli -- --nocapture
+```
+
+Expected: `--help` and unknown arguments fall into GUI initialization or are incorrectly accepted.
+
+- [ ] **Step 3: Implement the pure parser**
+
+Create `desktop_args.rs`:
+
+```rust
+use std::ffi::OsString;
+use std::fmt;
+
+pub const DESKTOP_USAGE: &str =
+    "Usage: master-skill-desktop [--baseline | --help]\n\n\
+     Options:\n  --baseline  Run the headless fidelity dry-run baseline\n  \
+     -h, --help  Print this help";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchMode {
+    Gui,
+    Baseline,
+    Help,
+}
+
+#[derive(Debug)]
+pub struct LaunchArgsError {
+    args: Vec<OsString>,
+}
+
+impl fmt::Display for LaunchArgsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid arguments: {:?}", self.args)
+    }
+}
+
+impl std::error::Error for LaunchArgsError {}
+
+pub fn parse_launch_mode(
+    args: impl IntoIterator<Item = OsString>,
+) -> Result<LaunchMode, LaunchArgsError> {
+    let args: Vec<OsString> = args.into_iter().collect();
+    match args.as_slice() {
+        [] => Ok(LaunchMode::Gui),
+        [argument] if argument == "--baseline" => Ok(LaunchMode::Baseline),
+        [argument] if argument == "--help" || argument == "-h" => Ok(LaunchMode::Help),
+        _ => Err(LaunchArgsError { args }),
+    }
+}
+```
+
+Declare `pub mod desktop_args;` in `lib.rs`.
+
+- [ ] **Step 4: Parse before any eframe initialization**
+
+In `main`, match `parse_launch_mode(std::env::args_os().skip(1))`:
+
+```rust
+match parse_launch_mode(std::env::args_os().skip(1)) {
+    Ok(LaunchMode::Gui) => run_gui(),
+    Ok(LaunchMode::Baseline) => {
+        let exit_code = match run_headless_baseline() {
+            Ok(code) => code,
+            Err(error) => {
+                eprintln!("baseline failed: {error:#}");
+                1
+            }
+        };
+        std::process::exit(exit_code);
+    }
+    Ok(LaunchMode::Help) => {
+        println!("{DESKTOP_USAGE}");
+        Ok(())
+    }
+    Err(error) => {
+        eprintln!("{error}\n\n{DESKTOP_USAGE}");
+        std::process::exit(2);
+    }
+}
+```
+
+Move the current eframe setup into `fn run_gui() -> eframe::Result`.
+
+- [ ] **Step 5: Run CLI and baseline tests**
+
+Run:
+
+```bash
+cargo test --manifest-path desktop/Cargo.toml --test desktop_args_cli -- --nocapture
+cargo test --manifest-path desktop/Cargo.toml --test baseline_cli -- --nocapture
+```
+
+Expected: help exits `0`, every invalid combination exits `2`, normal baseline behavior and lock contention remain correct.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add desktop/src/desktop_args.rs desktop/src/lib.rs desktop/src/main.rs desktop/tests/desktop_args_cli.rs
+git commit -m "fix(desktop): reject invalid launch arguments"
+```
+
+---
+
+### Task 6: Self-Review and Cross-Platform Verification
+
+**Files:**
+- Modify only files implicated by review findings.
+
+**Interfaces:**
+- Consumes: all Tasks 1-5.
+- Produces: a clean, reviewed stacked PR with recorded verification evidence.
+
+- [ ] **Step 1: Review the complete stacked diff**
+
+Run:
+
+```bash
+git diff --check fix/desktop-evaluation-contract...HEAD
+git diff --stat fix/desktop-evaluation-contract...HEAD
+git diff fix/desktop-evaluation-contract...HEAD -- desktop/Cargo.toml desktop/src desktop/tests
+```
+
+Inspect specifically for:
+
+- any application save that bypasses `TraceStoreLease`;
+- any write action still enabled or executable in read-only mode;
+- any `try_recv().ok()` that collapses `Disconnected` into `Empty`;
+- any direct `Command::output`, `Command::status`, or unbounded `wait`;
+- any CLI argument path that can reach eframe for non-empty invalid input;
+- any timeout path that fails to kill, reap, or join both output readers;
+- any persisted `capacity` field or version fallback that accepts an unknown version.
+
+- [ ] **Step 2: Run format and strict lint**
+
+Run:
+
+```bash
+cargo fmt --manifest-path desktop/Cargo.toml -- --check
+cargo clippy --locked --manifest-path desktop/Cargo.toml --all-targets -- -D warnings
+```
+
+Expected: both exit zero with no warnings.
+
+- [ ] **Step 3: Run all repository test suites**
+
+Run:
+
+```bash
+cargo test --locked --manifest-path desktop/Cargo.toml
+cargo build --locked --manifest-path desktop/Cargo.toml
+npm test
+python3 -m pytest tests/ scripts/tests/ -q
+```
+
+Expected: every Rust, Node, validator, and Python test passes.
+
+- [ ] **Step 4: Check the Windows target**
+
+Run:
+
+```bash
+rustup target add x86_64-pc-windows-msvc
+cargo check --locked --manifest-path desktop/Cargo.toml --all-targets --target x86_64-pc-windows-msvc
+```
+
+Expected: cross-target checking exits zero, proving the fs4 lock, tempfile replacement, command wait, argument parser, and tests compile for Windows.
+
+- [ ] **Step 5: Commit any review corrections**
+
+If review produced changes, stage only the implicated files and commit:
+
+```bash
+git add desktop/Cargo.toml desktop/Cargo.lock desktop/src desktop/tests
+git commit -m "fix(desktop): harden runtime reliability edges"
+```
+
+If the tree is already clean, do not create an empty commit.
+
+- [ ] **Step 6: Push and open the stacked draft PR**
+
+Push `fix/desktop-runtime-reliability` and open a draft PR against `fix/desktop-evaluation-contract`. The body must summarize the lease/atomic-persistence contract, bounded command execution, disconnected-worker terminal state, read-only GUI behavior, CLI parsing, exact test results, and the Windows target check.


### PR DESCRIPTION
## Summary

- persist trace history as a versioned schema-v1 envelope without runtime `capacity`
- serialize writers with a process-lifetime `fs4` lease and replace snapshots atomically through a synced temporary file
- keep contended GUI instances visibly read-only and make contended headless baselines fail immediately
- preserve active writer records in read-only views and protect unknown/corrupt trace files from downgrade overwrites
- replace implicit receiver polling with an explicit pending-task state machine that turns worker disconnects into terminal failures
- route every Node, Python, and npm child through a five-minute bounded runner that drains both pipes, kills/reaps on timeout, and retains diagnostics
- parse desktop launch arguments before eframe initialization, with explicit help and invalid-argument exit behavior

## Why

The previous runtime directly truncated the trace file, allowed independent GUI and baseline snapshots to overwrite each other, treated an empty channel and a disconnected worker identically, and waited forever for child commands. It also launched the GUI for help and invalid command lines. These were independent paths to corrupted history, stale lost updates, or a permanently busy desktop.

## Impact

- Existing unversioned trace files load normally and migrate to schema v1 on the next successful write.
- Unknown or malformed trace files remain untouched and put the GUI in read-only mode.
- A second GUI can browse and inspect, but cannot install, uninstall, update, validate, run fidelity, or clear traces.
- `--baseline` refuses to run while another writer owns the trace store.
- A stalled direct child returns a detailed timeout instead of leaving the UI busy indefinitely.
- `--help`/`-h` exit `0`; unknown, extra, or incompatible arguments exit `2`.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` — 99 Rust unit tests and 12 integration tests passed
- `cargo build --locked`
- `cargo check --locked --all-targets --target x86_64-pc-windows-msvc`
- `npm test` — repository validators and 60 Node tests passed
- `python -m pytest tests/ scripts/tests/ -q` — 373 passed

## Stack

This is PR2 of the reviewed refactor and intentionally targets `fix/desktop-evaluation-contract` (draft PR #123). After PR1 merges, this PR can be retargeted to `main` without mixing the evaluation-contract and runtime-reliability review units.
