### PR TITLE
ci: wire ClawHub publishing (one manual step left: the token)

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,59 @@
+name: Publish skills to ClawHub
+
+# ClawHub (https://clawhub.ai) is OpenClaw's public skill registry — the other
+# shelf these skills belong on, alongside npm and the Claude Code marketplace.
+#
+# Publishing needs a ClawHub account token. It cannot be minted from CI: the
+# reusable workflow itself says "GitHub OIDC trusted publishing for skills is
+# not supported yet". So the one manual step is:
+#
+#   1. npx clawhub login          (creates/authorises the account, prints a token)
+#   2. add that token as the repository secret CLAWHUB_TOKEN
+#   3. run this workflow with dry_run = false
+#
+# Until step 2 is done, only dry runs are possible — which is why dry_run
+# defaults to true rather than to the more useful value.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only. Leave true until CLAWHUB_TOKEN exists."
+        type: boolean
+        default: true
+      owner:
+        description: "ClawHub owner/publisher handle. Blank = the token's own account."
+        type: string
+        default: ""
+
+jobs:
+  publish:
+    # Pinned to a commit rather than @main on purpose: this call hands a
+    # publish token to someone else's workflow, and that workflow checks out
+    # its own source at whatever ref it was invoked with. A moving ref would
+    # mean trusting every future commit in that repository in advance.
+    # Refreshing the pin is a deliberate, reviewable change.
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@8aa76c1a7268749cc9eeabff570badf428ef4aaa
+    # Reusable workflows cannot escalate beyond what the caller grants, and the
+    # callee needs id-token: write for the OIDC handshake it uses to locate its
+    # own source. Granting less makes the job fail at that step.
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      # Each prebuilt/<skill>/ carries its own SKILL.md and supporting files.
+      # NOTE: ClawHub derives the published slug from the *folder name* —
+      # verified with `clawhub skill publish … --dry-run`, which reported
+      # "master-zhiyi" even though that skill's meta.json declares
+      # slug: zhiyi. Every folder here matches its slash command except
+      # prebuilt/compare, which would publish as the generic "compare"
+      # instead of "compare-masters". Rename the folder before the first real
+      # publish if that name matters — a slug is hard to take back.
+      root: prebuilt
+      dry_run: ${{ inputs.dry_run }}
+      owner: ${{ inputs.owner }}
+    secrets:
+      # Absent secret resolves to an empty string, which the callee accepts for
+      # dry runs and rejects for real publishes — the failure mode is a clear
+      # error, not a silent no-op.
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
Second of the three acceptance follow-ups. ClawHub is OpenClaw's public skill registry — the shelf these skills are missing from, alongside npm and the Claude Code marketplace.

## What is blocked and why

Publishing needs a **ClawHub account token**, and it cannot be minted from CI — the reusable workflow says so itself: *"GitHub OIDC trusted publishing for skills is not supported yet."* Creating accounts is outside what I do, so this PR wires everything up to that one step:

1. `npx clawhub login` — authorise, get a token
2. add it as the repository secret **`CLAWHUB_TOKEN`**
3. run the workflow with **dry_run = false**

Until step 2, only dry runs are possible, which is why `dry_run` defaults to `true` rather than the more useful value.

## Checked against the real CLI, not assumed

- **The published slug comes from the folder name, not `meta.json`.** `clawhub skill publish <folder> --dry-run` printed `Would publish master-zhiyi@1.0.0` for a skill whose `meta.json` declares `slug: zhiyi`. So all nineteen folders publish under their slash-command names — **except `prebuilt/compare`, which would land as the generic `compare` instead of `compare-masters`**. Flagged in a comment in the workflow. Worth renaming before the first real publish: a taken slug is hard to take back, and `compare` is the kind of name someone else will want. I did not rename it here because the folder path appears in the README's git-clone install instructions, so it is your call whether to break those symlinks.
- Dry runs are accepted with **no token at all** (the callee's validation step exits 0 when `dry_run == true`), so the wiring can be exercised before any account exists.
- The callee's `inputs`/`secrets` were diffed against its `workflow_call` contract; all three passed values are accepted names.

## Supply chain

Pinned to commit `8aa76c1` rather than `@main`. This call hands a publish token to someone else's workflow, and that workflow checks out **its own source** at whatever ref it was invoked with — a moving ref would mean trusting every future commit in that repository in advance. Refreshing the pin should be a deliberate, reviewable change.

`permissions` are granted on the calling job because a reusable workflow cannot escalate beyond its caller, and the callee needs `id-token: write` for the OIDC handshake it uses to locate its own source.