### PR TITLE
fix(ci): stop reporting a successful ClawHub publish as 19 failures

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -3,22 +3,46 @@ name: Publish skills to ClawHub
 # ClawHub (https://clawhub.ai) is OpenClaw's public skill registry — the other
 # shelf these skills belong on, alongside npm and the Claude Code marketplace.
 #
-# Publishing needs a ClawHub account token. It cannot be minted from CI: the
-# reusable workflow itself says "GitHub OIDC trusted publishing for skills is
-# not supported yet". So the one manual step is:
+# Publishing needs a ClawHub account token in the repository secret
+# CLAWHUB_TOKEN. It cannot be minted from CI (ClawHub does not support GitHub
+# OIDC trusted publishing for skills), so that secret is set by hand, once.
 #
-#   1. npx clawhub login          (creates/authorises the account, prints a token)
-#   2. add that token as the repository secret CLAWHUB_TOKEN
-#   3. run this workflow with dry_run = false
+# WHY THIS CALLS THE CLI DIRECTLY instead of openclaw/clawhub's reusable
+# skill-publish.yml, which it used before 2026-08-12:
 #
-# Until step 2 is done, only dry runs are possible — which is why dry_run
-# defaults to true rather than to the more useful value.
+#   The reusable workflow buckets each publish by its status, through a lookup
+#   that knows exactly three:
+#
+#       {"would-publish": ..., "published": ..., "unchanged": ...}
+#
+#   But clawhub CLI 0.23.3 emits five. When the registry answers
+#   publicationStatus="pending" — which is what it does for a first-time
+#   publish that still has to clear the SkillSpector scan — the CLI reports
+#   "pending-publication", the lookup raises KeyError, and the run is recorded
+#   as "Invalid publish output: 'pending-publication'".
+#
+#   On 2026-08-12 that turned a completely successful first publish of all 19
+#   skills into 19 red failures. The upload had already happened; only the
+#   report was wrong. Nothing upstream to bump to, either — the pin below was
+#   already the newest commit of that file.
+#
+#   A false red is worse than no check. So the loop lives here, where the
+#   status map can be complete and can be fixed the same day it breaks.
+#
+# Two rules this job keeps, both learned from that incident:
+#
+#   1. The CLI version is PINNED. A registry client that changes its output
+#      vocabulary underneath a parser is exactly what went wrong; letting
+#      @latest float would just reschedule it.
+#   2. An unrecognised status FAILS LOUDLY and names itself. It is never
+#      quietly counted as success — that would trade a false red for a false
+#      green, which is the worse of the two.
 
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Preview only. Leave true until CLAWHUB_TOKEN exists."
+        description: "Preview only. No publish mutation is performed."
         type: boolean
         default: true
       owner:
@@ -26,39 +50,122 @@ on:
         type: string
         default: ""
 
+# Pinned: see rule 1 above.
+env:
+  CLAWHUB_CLI_VERSION: "0.23.3"
+
 jobs:
   publish:
-    # Pinned to a commit rather than @main on purpose: this call hands a
-    # publish token to someone else's workflow, and that workflow checks out
-    # its own source at whatever ref it was invoked with. A moving ref would
-    # mean trusting every future commit in that repository in advance.
-    # Refreshing the pin is a deliberate, reviewable change.
-    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@8aa76c1a7268749cc9eeabff570badf428ef4aaa
-    # Reusable workflows cannot escalate beyond what the caller grants, and the
-    # callee needs id-token: write for the OIDC handshake it uses to locate its
-    # own source. Granting less makes the job fail at that step.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
-      id-token: write
-    with:
-      # Each prebuilt/<skill>/ carries its own SKILL.md and supporting files.
-      #
-      # ClawHub derives the published slug from the *folder name*, not from
-      # SKILL.md. Re-verified on clawhub CLI 0.23.3: publishing the folder
-      # formerly named prebuilt/compare reported "Would publish compare@1.0.0"
-      # even though its SKILL.md declares `name: compare-masters`. The CLI has
-      # a --slug flag, but the reusable workflow called below exposes no such
-      # input (skill_path, root, dry_run, owner, tags, registry, site, ref) —
-      # so via CI the folder name IS the slug, with no override.
-      #
-      # That folder is now prebuilt/compare-masters, so every folder here
-      # equals the name it publishes under. Keep that invariant: a slug is
-      # hard to take back once it is public.
-      root: prebuilt
-      dry_run: ${{ inputs.dry_run }}
-      owner: ${{ inputs.owner }}
-    secrets:
-      # Absent secret resolves to an empty string, which the callee accepts for
-      # dry runs and rejects for real publishes — the failure mode is a clear
-      # error, not a silent no-op.
-      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@v6.0.0
+        with:
+          node-version: "24"
+
+      - name: Install ClawHub CLI
+        run: npm install -g "clawhub@${CLAWHUB_CLI_VERSION}"
+
+      - name: Authenticate
+        # Dry runs need no account: the CLI resolves the slug and validates the
+        # folder locally. Keeping auth out of them means the preview can be run
+        # by anyone, including from a fork, without a token in reach.
+        if: ${{ !inputs.dry_run }}
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "::error::CLAWHUB_TOKEN is not set. Add it as a repository secret," \
+                 "then re-run. Mint one at https://clawhub.ai/settings?view=tokens"
+            exit 1
+          fi
+          clawhub login --token "$CLAWHUB_TOKEN" --label "github-actions" >/dev/null
+          echo "Authenticated as: $(clawhub whoami)"
+
+      - name: Publish every skill in prebuilt/
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          OWNER: ${{ inputs.owner }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import subprocess
+          import sys
+
+          # Every status clawhub 0.23.3 can return, and whether it means the
+          # skill is where we want it. "pending-publication" and "submitted"
+          # are successes that are simply not visible yet: the upload landed
+          # and the registry is scanning it.
+          OK_STATUSES = {
+              "would-publish": "would publish",
+              "published": "published",
+              "unchanged": "already current",
+              "pending-publication": "uploaded — awaiting review",
+              "submitted": "uploaded — submitted",
+          }
+
+          dry_run = os.environ["DRY_RUN"] == "true"
+          owner = os.environ.get("OWNER", "").strip()
+          root = pathlib.Path("prebuilt")
+
+          folders = sorted(p for p in root.iterdir() if p.is_dir())
+          if not folders:
+              sys.exit(f"::error::No skill folders under {root}/")
+
+          results, failures = [], []
+          for folder in folders:
+              command = ["clawhub", "skill", "publish", str(folder.resolve()), "--json"]
+              if dry_run:
+                  command.append("--dry-run")
+              if owner:
+                  command += ["--owner", owner]
+
+              done = subprocess.run(command, capture_output=True, text=True)
+              if done.returncode != 0:
+                  message = done.stderr.strip() or done.stdout.strip() or f"exit {done.returncode}"
+                  failures.append((folder.name, message))
+                  continue
+
+              try:
+                  payload = json.loads(done.stdout)
+                  status = payload["status"]
+              except (KeyError, ValueError) as exc:
+                  failures.append((folder.name, f"unreadable CLI output: {exc}"))
+                  continue
+
+              if status not in OK_STATUSES:
+                  # Rule 2: name the unknown status so the fix is obvious.
+                  failures.append((
+                      folder.name,
+                      f"unknown status {status!r} from clawhub "
+                      f"{os.environ.get('CLAWHUB_CLI_VERSION', '?')} — add it to "
+                      f"OK_STATUSES in this workflow (or fix it if it is a real error)",
+                  ))
+                  continue
+
+              results.append((payload.get("slug", folder.name), status))
+
+          summary = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a") as out:
+              out.write(f"## ClawHub {'dry run' if dry_run else 'publish'}\n\n")
+              out.write("| slug | outcome |\n|---|---|\n")
+              for slug, status in results:
+                  out.write(f"| `{slug}` | {OK_STATUSES[status]} |\n")
+              for name, message in failures:
+                  out.write(f"| `{name}` | ❌ {message} |\n")
+              out.write(f"\n{len(results)} ok, {len(failures)} failed.\n")
+
+          for slug, status in results:
+              print(f"  {slug}: {OK_STATUSES[status]}")
+          for name, message in failures:
+              print(f"::error::{name}: {message}")
+
+          print(f"\n{len(results)} ok, {len(failures)} failed.")
+          sys.exit(1 if failures else 0)
+          PY


### PR DESCRIPTION
首次实发当场撞上：**19 个 skill 全部上传成功，工作流却报了 19 条红。**

## 成因

上游 `openclaw/clawhub` 的复用工作流按状态分桶，查找表只认三个：

```python
status_keys = {"would-publish": ..., "published": ..., "unchanged": ...}
results[status_keys[result["status"]]].append(result)   # ← KeyError
```

而 clawhub CLI 0.23.3 会吐**五个**。首次发布要过 SkillSpector 扫描，注册表返回 `publicationStatus="pending"`，CLI 报 `pending-publication` → KeyError → 记成 `Invalid publish output: 'pending-publication'`。

**上传其实已经发生了**（CLI `returncode == 0`），错的只是那份报告。事后核实：18/19 已匿名可解析，剩下 `compare-masters` 仍在扫描队列。

上游也没有更新的版本可以升 —— 钉着的 `8aa76c1a` 已经是该文件最新的 commit（2026-07-20）。

## 改法

把循环搬回自己家，状态表补全：

| 状态 | 含义 |
|---|---|
| `would-publish` | dry run 预览 |
| `published` | 已发布 |
| `unchanged` | 已是最新 |
| `pending-publication` | **已上传，等审核** |
| `submitted` | **已上传，已提交** |

后两个是「成功但还不可见」，不是失败。

## 两条固化下来的规矩

1. **CLI 版本钉死**（`CLAWHUB_CLI_VERSION: 0.23.3`）。一个注册表客户端在解析器脚下改自己的输出词汇表，正是这次的成因；放任 `@latest` 浮动只是把它重新安排到以后发生。
2. **不认识的状态要响亮地失败，并且报出自己的名字** —— 提示去哪补这张表。绝不悄悄算成功：那是把假红换成假绿，**而假绿更坏**。

## 顺带

- dry run 不再需要 token：CLI 在本地就能解析 slug 并校验目录，让预览不必碰密钥，fork 也能跑
- 结果写进 `GITHUB_STEP_SUMMARY`，一张表看完 19 个的去向
- 副作用：不再把 publish token 交给别人仓库的工作流去 checkout 自己的源码 —— 这正是原注释里那段「钉 commit 而不用 @main」所担心的事