### PR TITLE
ci: SHA-pin the actions in clawhub-publish.yml

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -61,9 +61,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: "24"
 


### PR DESCRIPTION
## Summary

`.github/workflows/clawhub-publish.yml` (added 2026-08-12) pinned `actions/checkout` and `actions/setup-node` to floating tags (`@v7.0.1`, `@v6.0.0`) instead of commit SHAs, unlike every other workflow in this repo. This PR SHA-pins both, matching house style.

- `actions/checkout@v7.0.1` → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-node@v6.0.0` → `2028fbc5c25fe9cf00d9f06a71cc4710d4507903`

Both tag refs resolved directly to commit objects via the GitHub API (`object.type == "commit"`), so no tag-object dereference was needed.

**中文说明**：`SECURITY.md` 第109行宣称"所有 `uses:` 引用都锁定到完整 commit SHA"，README 首屏也有同样的英文表述（"SHA-pinned GitHub Actions"）。这条声明自 2026-08-12 起就是假的——当天新增的 `clawhub-publish.yml` 用的是浮动 tag（`@v7.0.1`、`@v6.0.0`），不是 commit SHA。这个工作流尤其不该松懈：它是**全仓库唯一持有 `CLAWHUB_TOKEN`（唯一的仓库密钥）的工作流**，而 `checkout`/`setup-node` 这两步恰好在鉴权步骤*之前*于同一个 job 里执行——这正是 SHA pin 要防的"tag 被重打"（mutable tag attack）场景：一旦这两个 action 的 tag 被恶意重指向，就能在 token 还没派上用场之前抢先执行任意代码。本 PR 把这两处补上 SHA pin，让 SECURITY.md 的声明重新为真。

## Version skew (intentionally not touched)

The other workflows in this repo currently pin `actions/checkout` at v7.0.0 and `actions/setup-node` at v6.4.0, while `clawhub-publish.yml` names v7.0.1 / v6.0.0 — a pre-existing mismatch, not something this PR introduces or fixes. There are already open Dependabot PRs that will converge these:

- #121 bumps `actions/checkout` 7.0.0 → 7.0.1
- #118 bumps `actions/setup-node` 6.0.0 → 7.0.0

This PR is scoped to the single security fix — same versions as before, now pinned to their commit SHAs. Version unification is left to those Dependabot PRs so the reviewer can decide how to land them.

## Audit

Grepped every `uses:` line under `.github/workflows/` and confirmed each now matches `owner/repo@<40-char-commit-sha>  # vX.Y.Z`. `clawhub-publish.yml` was the only offender; no other file needed changes.

## Test plan

- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/clawhub-publish.yml'))"` — YAML still parses
- [x] `npm test` — 60/60 passing
- [x] `grep -rn "uses:" .github/workflows/` — every action reference across all 6 workflow files is now a 40-char commit SHA with a version comment
