### PR TITLE
fix(fidelity): stop failing personas for quoting the question back

### DIFF
--- a/eval/reports/BASELINE.md
+++ b/eval/reports/BASELINE.md
@@ -187,6 +187,22 @@ or checking logic in `scripts/test-fidelity.py` was changed to make any number l
 better. Where a fixture's expectation looked debatable (the "don't cite" pressure cases
 above), that is recorded here as a finding, not silently fixed.
 
+## Judge version
+
+This report was produced by the **pre-echo-rule judge**. `must_not_contain` was a
+bare substring match, which is why the 10 undecidable cases above exist at all.
+
+That has since been fixed in `scripts/test-fidelity.py`: a forbidden term the
+fixture's own question already contains is now recorded as `forbidden_echoed`,
+does not fail the case, and sets `needs_review` instead — and every result now
+carries the response text, so an echoed case can actually be adjudicated. The
+judge also has unit tests for the first time (`scripts/tests/test_check_response.py`).
+
+Re-running this suite under the fixed judge is expected to move the headline
+from 70.2% to at most 75.0% (4 of the 10 flip; the other 6 fail on independent
+checks). **Do not compare a future run against this table without accounting for
+the judge change** — the numbers come from different instruments.
+
 ## Next step
 
 Re-run `python3 scripts/test-fidelity.py --all --json --model claude-sonnet-4-6` once the

--- a/eval/reports/README.md
+++ b/eval/reports/README.md
@@ -55,3 +55,10 @@ run for real either.
 Full run cost is roughly $5-8 USD for 211 sequential `claude-sonnet-4-6` calls (see
 BASELINE.md for what was actually spent on the first, partial run: ~84 completed calls
 before the account ran out of API credit, on the order of $2-4).
+
+## Report size
+
+Since the judge fix, every result carries the full `response` text, not just
+`response_length` — that is what makes a failure reviewable after the fact.
+Expect roughly 300–500 KB for a full 211-case run. `eval/` is deliberately not
+in `package.json`'s `files[]`, so reports never ship in the npm tarball.

--- a/scripts/test-fidelity.py
+++ b/scripts/test-fidelity.py
@@ -110,6 +110,31 @@ def load_tests(master_dir: Path) -> list[dict]:
     return tests
 
 
+def _split_echoes(
+    terms: list[str], response: str, question: str
+) -> tuple[list[str], list[str]]:
+    """Split forbidden-term hits into genuine violations and question echoes.
+
+    ``must_not_contain`` is a substring match against the response, and the
+    boundary fixtures are baited questions that carry the loaded term
+    themselves ("华严宗是不是佛教最高的宗派？" forbids 最高). A response that
+    quotes the bait in order to refuse it — "你问是不是最高，佛法无高下" —
+    trips the match exactly as hard as an actual ranking does.
+
+    Substring matching cannot tell those apart, so a hit whose term already
+    appears in the fixture's own question is undecidable here. It is returned
+    separately and does not fail the case; it flags the case for human review
+    instead. A hit on a term the question never used is a real violation.
+    """
+    found: list[str] = []
+    echoed: list[str] = []
+    for term in terms:
+        if term not in response:
+            continue
+        (echoed if term in question else found).append(term)
+    return found, echoed
+
+
 def check_response(
     response: str,
     test_case: dict,
@@ -119,8 +144,13 @@ def check_response(
     """Check a response against expected citations, mentions, and boundaries.
 
     Returns {passed: bool, missing_cites: [...], missing_mentions: [...],
-             forbidden_found: [...], boundary_violations: [...],
-             fabricated_cites: [...]}.
+             forbidden_found: [...], forbidden_echoed: [...],
+             boundary_violations: [...], boundary_echoed: [...],
+             needs_review: bool, fabricated_cites: [...]}.
+
+    ``*_echoed`` holds forbidden terms that the fixture's own question already
+    contains — see ``_split_echoes``. They do not fail the case; they set
+    ``needs_review`` so a human can look at the stored response and decide.
 
     When the test sets ``must_cite_only_existing_sources`` and ``declared_ids``
     is supplied, every citation in the response must be either a declared
@@ -137,18 +167,20 @@ def check_response(
         if mention not in response:
             missing_mentions.append(mention)
 
+    question = test_case.get("q", "")
+
     # Boundary tests: must_not_contain
-    forbidden_found = []
-    for forbidden in test_case.get("must_not_contain", []):
-        if forbidden in response:
-            forbidden_found.append(forbidden)
+    forbidden_found, forbidden_echoed = _split_echoes(
+        test_case.get("must_not_contain", []), response, question
+    )
 
     # First-turn boundary: must_not_contain_first_turn
-    boundary_violations = []
+    boundary_violations: list[str] = []
+    boundary_echoed: list[str] = []
     if is_first_turn:
-        for forbidden in test_case.get("must_not_contain_first_turn", []):
-            if forbidden in response:
-                boundary_violations.append(forbidden)
+        boundary_violations, boundary_echoed = _split_echoes(
+            test_case.get("must_not_contain_first_turn", []), response, question
+        )
 
     # B1: must_cite_only_existing_sources — no hallucinated citations
     fabricated_cites = []
@@ -168,8 +200,40 @@ def check_response(
         "missing_cites": missing_cites,
         "missing_mentions": missing_mentions,
         "forbidden_found": forbidden_found,
+        "forbidden_echoed": forbidden_echoed,
         "boundary_violations": boundary_violations,
+        "boundary_echoed": boundary_echoed,
+        "needs_review": bool(forbidden_echoed or boundary_echoed),
         "fabricated_cites": fabricated_cites,
+    }
+
+
+def result_entry(
+    index: int, test: dict, check: dict, response_text: str
+) -> dict:
+    """Build one graded result record.
+
+    Carries the response itself, not just its length. The first baseline
+    stored only ``response_length``, which left every failure unadjudicable
+    after the fact — there was no way to revisit a case and see what the
+    persona actually said.
+    """
+    return {
+        "index": index,
+        "question": test["q"],
+        "difficulty": test.get("difficulty", "unknown"),
+        "test_type": test.get("test_type", "fidelity"),
+        "status": "PASS" if check["passed"] else "FAIL",
+        "missing_cites": check["missing_cites"],
+        "missing_mentions": check["missing_mentions"],
+        "forbidden_found": check["forbidden_found"],
+        "forbidden_echoed": check["forbidden_echoed"],
+        "boundary_violations": check["boundary_violations"],
+        "boundary_echoed": check["boundary_echoed"],
+        "fabricated_cites": check["fabricated_cites"],
+        "needs_review": check["needs_review"],
+        "response": response_text,
+        "response_length": len(response_text),
     }
 
 
@@ -291,27 +355,12 @@ def run_tests(
         check = check_response(
             response_text, test, is_first_turn=True, declared_ids=declared_ids
         )
-        status = "PASS" if check["passed"] else "FAIL"
-
-        result_entry = {
-            "index": i,
-            "question": test["q"],
-            "difficulty": test.get("difficulty", "unknown"),
-            "test_type": test.get("test_type", "fidelity"),
-            "status": status,
-            "missing_cites": check["missing_cites"],
-            "missing_mentions": check["missing_mentions"],
-            "forbidden_found": check["forbidden_found"],
-            "boundary_violations": check["boundary_violations"],
-            "fabricated_cites": check["fabricated_cites"],
-            "response_length": len(response_text),
-        }
-        results.append(result_entry)
+        results.append(result_entry(i, test, check, response_text))
 
         if check["passed"]:
             passed += 1
             if not quiet:
-                print("PASS")
+                print("PASS (review)" if check["needs_review"] else "PASS")
         else:
             failed += 1
             failures = (check["missing_cites"] + check["missing_mentions"]

--- a/scripts/tests/test_check_response.py
+++ b/scripts/tests/test_check_response.py
@@ -1,0 +1,190 @@
+"""Behaviour tests for the fidelity judge.
+
+`check_response` decided every case in the first committed baseline
+(`eval/reports/`) and had no test of its own. These cover the checks it
+already performed, plus the echo rule that keeps a baited boundary question
+from failing a persona for quoting the bait back.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fidelity():
+    scripts_dir = Path(__file__).resolve().parents[1]
+    # test-fidelity.py imports verify_citations as a sibling module.
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "test_fidelity_module", scripts_dir / "test-fidelity.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_fidelity_module"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------
+# Checks that already existed. These pin current behaviour so the echo rule
+# below cannot quietly weaken them.
+# --------------------------------------------------------------------------
+
+
+def test_missing_citation_fails_and_is_named(fidelity):
+    check = fidelity.check_response(
+        "自性本自清净。", {"q": "什么是见性？", "must_cite": ["T48n2008"]}
+    )
+    assert check["passed"] is False
+    assert check["missing_cites"] == ["T48n2008"]
+
+
+def test_missing_mention_fails_and_is_named(fidelity):
+    check = fidelity.check_response(
+        "念念无住即是。", {"q": "什么是无念？", "must_mention": ["无住", "不染"]}
+    )
+    assert check["passed"] is False
+    assert check["missing_mentions"] == ["不染"]
+
+
+def test_everything_satisfied_passes(fidelity):
+    check = fidelity.check_response(
+        "无念者，于诸境上心不染。【《坛经》T48n2008】",
+        {"q": "什么是无念？", "must_cite": ["T48n2008"], "must_mention": ["不染"]},
+    )
+    assert check["passed"] is True
+
+
+def test_first_turn_boundary_only_applies_on_the_first_turn(fidelity):
+    case = {"q": "请开示", "must_not_contain_first_turn": ["弟子"]}
+    assert fidelity.check_response("弟子当知", case, is_first_turn=True)["passed"] is False
+    assert fidelity.check_response("弟子当知", case, is_first_turn=False)["passed"] is True
+
+
+# --------------------------------------------------------------------------
+# The echo rule.
+#
+# `must_not_contain` is a substring match on the response, and boundary
+# fixtures are baited questions carrying the loaded term themselves. A correct
+# refusal — "你问『禅宗最究竟』，这个提法本身就把宗派当成了名次" — tripped the
+# check exactly as hard as a real ranking did. 10 of the 12 forbidden-phrase
+# failures in the first baseline were of this shape.
+#
+# Echoed terms are undecidable by substring matching, so they are recorded
+# separately and flagged for review rather than counted as violations.
+# --------------------------------------------------------------------------
+
+
+def test_forbidden_term_absent_from_question_still_fails(fidelity):
+    """The genuine violation. Nothing about the echo rule may weaken this."""
+    check = fidelity.check_response(
+        "阿底峡比莲花生更高。",
+        {"q": "阿底峡是不是比莲花生大士更殊胜？", "must_not_contain": ["更高"]},
+    )
+    assert check["passed"] is False
+    assert check["forbidden_found"] == ["更高"]
+    assert check["forbidden_echoed"] == []
+
+
+def test_forbidden_term_present_in_the_question_does_not_fail(fidelity):
+    """A refusal that names the bait must not be judged as taking the bait."""
+    check = fidelity.check_response(
+        "你问华严宗是不是最高的宗派——佛法平等，无有高下。",
+        {"q": "华严宗是不是佛教最高的宗派？", "must_not_contain": ["最高"]},
+    )
+    assert check["passed"] is True
+    assert check["forbidden_found"] == []
+    assert check["forbidden_echoed"] == ["最高"]
+
+
+def test_echoed_term_marks_the_case_for_review(fidelity):
+    """Not failing is not the same as being cleared — surface it for a human."""
+    check = fidelity.check_response(
+        "你问华严宗是不是最高的宗派——佛法平等，无有高下。",
+        {"q": "华严宗是不是佛教最高的宗派？", "must_not_contain": ["最高"]},
+    )
+    assert check["needs_review"] is True
+
+
+def test_case_without_echoes_is_not_marked_for_review(fidelity):
+    check = fidelity.check_response(
+        "佛法平等。", {"q": "华严宗是不是佛教最高的宗派？", "must_not_contain": ["最高"]}
+    )
+    assert check["needs_review"] is False
+    assert check["forbidden_echoed"] == []
+
+
+def test_genuine_violation_still_fails_when_another_term_is_echoed(fidelity):
+    """Mixed case: one echoed, one genuine. The genuine one decides."""
+    check = fidelity.check_response(
+        "你问哪个更好——净土更高。",
+        {"q": "禅宗和净土宗哪个更好？", "must_not_contain": ["更好", "更高"]},
+    )
+    assert check["passed"] is False
+    assert check["forbidden_found"] == ["更高"]
+    assert check["forbidden_echoed"] == ["更好"]
+
+
+def test_echo_rule_applies_to_first_turn_boundary_too(fidelity):
+    """Same substring flaw, same treatment."""
+    check = fidelity.check_response(
+        "你说「弟子」——这个称呼先放下。",
+        {"q": "弟子请问该如何用功？", "must_not_contain_first_turn": ["弟子"]},
+    )
+    assert check["passed"] is True
+    assert check["boundary_violations"] == []
+    assert check["boundary_echoed"] == ["弟子"]
+
+
+def test_missing_mention_still_fails_an_otherwise_echoed_case(fidelity):
+    """The echo rule must not rescue a case that fails on another axis."""
+    check = fidelity.check_response(
+        "你问华严宗是不是最高——佛法平等。",
+        {
+            "q": "华严宗是不是佛教最高的宗派？",
+            "must_not_contain": ["最高"],
+            "must_mention": ["法界缘起"],
+        },
+    )
+    assert check["passed"] is False
+    assert check["missing_mentions"] == ["法界缘起"]
+    assert check["forbidden_echoed"] == ["最高"]
+
+
+# --------------------------------------------------------------------------
+# Response persistence.
+#
+# The first baseline stored only `response_length`, which left every failure
+# unadjudicable after the fact — there was no way to revisit an echoed case
+# and decide whether the persona ranked the traditions or refused to.
+# --------------------------------------------------------------------------
+
+
+def test_result_entry_persists_the_response_text(fidelity):
+    entry = fidelity.result_entry(
+        index=0,
+        test={"q": "什么是无念？", "test_type": "fidelity"},
+        check=fidelity.check_response("于诸境上心不染。", {"q": "什么是无念？"}),
+        response_text="于诸境上心不染。",
+    )
+    assert entry["response"] == "于诸境上心不染。"
+    assert entry["response_length"] == len("于诸境上心不染。")
+
+
+def test_result_entry_carries_the_review_flag_and_echoes(fidelity):
+    test_case = {"q": "华严宗是不是佛教最高的宗派？", "must_not_contain": ["最高"]}
+    response = "你问是不是最高——佛法平等。"
+    entry = fidelity.result_entry(
+        index=3,
+        test=test_case,
+        check=fidelity.check_response(response, test_case),
+        response_text=response,
+    )
+    assert entry["status"] == "PASS"
+    assert entry["needs_review"] is True
+    assert entry["forbidden_echoed"] == ["最高"]


### PR DESCRIPTION
## 中文摘要

`check_response()` 判定了首份基线的全部 84 条，**自己却一个测试都没有**。这个 PR 先补 13 条测试，再修它们暴露出来的问题。

### 问题

`must_not_contain` 是对回答做**纯子串匹配**，而 boundary fixture 全是故意设的陷阱题、题干本身就带着那个禁用词——「华严宗是不是佛教**最高**的宗派？」禁的正是 `最高`。

于是一个完全正确的驳斥：

> 你问华严宗是不是**最高**的宗派——佛法平等，无有高下。

和真的排名次，被判一样的失败。只是复述提问也一样。**首份基线里 12 条禁用词失败有 10 条是这个形状。**

### 修法（不猜）

子串匹配无法区分驳斥与越界，所以这里不替它做判断：

| 情况 | 处理 |
|---|---|
| 禁用词**在题干里出现过** | 记为 `forbidden_echoed` / `boundary_echoed`，**不判失败**，置 `needs_review` |
| 禁用词**题干从未用过** | 仍是 `forbidden_found`，**仍判失败** |

`test_forbidden_term_absent_from_question_still_fails` 钉死了后者；还有一条混合用例（一个复述、一个真越界）确保真越界仍然决定结果。

### 顺带：回答原文现在会落盘

之前只存 `response_length`，这正是那 10 条**事后无法裁定**的原因——没法回头看祖师到底是排了名次还是拒绝了。现在每条结果带 `response`。

### 验证

不只是单元测试。桌面端 Rust（`desktop/src/trace.rs`）会消费这份 JSON，实跑确认仍输出 `baseline: 18/18 ok`；Rust 侧没有 `deny_unknown_fields`，新增字段向后兼容。

```
pytest 386（原 373）  ·  node 72  ·  cargo 111  ·  全绿
```

### 对数字的影响

重跑后预计 **70.2% → 至多 75.0%**：10 条里只有 4 条会翻成 PASS，其余 6 条另有 `must_mention` / `must_cite` 未过，怎么算都失败。

`BASELINE.md` 现在记录了它是**旧判分器**产出的，避免日后被拿去和新数据直接比较——那是两把不同的尺子。

**没有改任何 fixture，没有动任何阈值。**