### PR TITLE
ci: make a gate that examined nothing fail instead of passing

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -95,6 +95,15 @@ jobs:
       - name: Validate routing table (v0.11 — hard gate)
         run: python scripts/validate-routing.py
 
+      # Three shipped defects were the same shape: a gate examined an empty set
+      # and reported success (pytest.ini testpaths overridden so neither suite
+      # ran the other's cases; test_voice_rules.py parametrized over an empty
+      # glob; the fidelity smoke exiting 0 after grading nothing). A passing
+      # check is indistinguishable from one that did nothing unless something
+      # asserts otherwise — that is what this step is.
+      - name: Check gate liveness (every gate examined a non-empty set)
+        run: python scripts/check-gate-liveness.py
+
       - name: Test session-start hook lineage sanitization
         run: bash hooks/tests/test_session_start.sh
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "validate:versions": "python3 scripts/check-manifest-versions.py",
     "test:hook": "bash hooks/tests/test_session_start.sh && bash hooks/tests/test_run_hook.sh && bash hooks/tests/test_run_hook_cmd.sh",
     "test:cli": "node --test tests/cli.test.mjs",
-    "test": "python3 scripts/validate.py --strict && python3 scripts/validate-fidelity.py && python3 scripts/validate-persona-fidelity.py && python3 scripts/check-manifest-versions.py && python3 scripts/validate-routing.py && python3 scripts/test-fidelity.py --all --dry-run && node --test tests/cli.test.mjs",
+    "test": "python3 scripts/check-gate-liveness.py && python3 scripts/validate.py --strict && python3 scripts/validate-fidelity.py && python3 scripts/validate-persona-fidelity.py && python3 scripts/check-manifest-versions.py && python3 scripts/validate-routing.py && python3 scripts/test-fidelity.py --all --dry-run && node --test tests/cli.test.mjs",
     "test:smoke": "python3 scripts/test-fidelity.py --master yinguang --max-tests 1",
     "prepack": "node bin/cli.mjs list"
   },

--- a/scripts/check-gate-liveness.py
+++ b/scripts/check-gate-liveness.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Assert that this repo's gates actually examined something.
+
+Three shipped defects were the same shape — a gate examined an empty set and
+reported success:
+
+  - `pytest.ini` listed `testpaths = tests` while CI passed `scripts/tests/`
+    explicitly, so neither suite ever ran the other's cases.
+  - `tests/test_voice_rules.py` globbed `prebuilt/<slug>/voice.md` when
+    voice.md lives under `references/`. The empty glob parametrized every case
+    over an empty set: nothing asserted, reported green.
+  - The fidelity smoke — a branch-protection-required check — writes
+    `{"skipped": true, "reason": "no_api_key"}` and exits 0 when the secret is
+    missing, which it always has been.
+
+None of those was a wrong assertion. Each was an assertion that never ran, and
+a passing check is indistinguishable from a check that did nothing unless
+something asserts otherwise. That is this script's whole job.
+
+Usage:
+    python3 scripts/check-gate-liveness.py            # check this repo
+    python3 scripts/check-gate-liveness.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# A verdict — as opposed to a skip, an error, or a dry run.
+GRADED_STATUSES = {"PASS", "FAIL"}
+
+
+def check_every_test_file_collects(
+    test_files: list[str], collected_counts: dict[str, int]
+) -> list[str]:
+    """Every test file must contribute at least one collected test.
+
+    A file that imports cleanly and yields nothing is the voice_rules failure:
+    pytest reports success because there was nothing to fail.
+    """
+    problems = []
+    for path in sorted(test_files):
+        if collected_counts.get(path, 0) < 1:
+            problems.append(
+                f"{path} collected 0 tests — it asserts nothing but reports green "
+                "(empty glob or empty parametrize?)"
+            )
+    return problems
+
+
+def check_testpaths_cover_suites(
+    testpaths: list[str], test_dirs: list[str]
+) -> list[str]:
+    """Every directory holding tests must be reachable from a bare `pytest`."""
+    covered = set(testpaths)
+    return [
+        f"{d} holds tests but is not in pytest.ini testpaths — a bare `pytest` skips it"
+        for d in sorted(test_dirs)
+        if d not in covered
+    ]
+
+
+def check_graded_suites_graded_something(suites: list[dict]) -> list[str]:
+    """A graded fidelity suite that produced no verdict must not read as a pass.
+
+    Dry runs are exempt: grading nothing is what a dry run is for.
+    """
+    problems = []
+    for suite in suites:
+        if suite.get("mode") == "dry_run":
+            continue
+        verdicts = [
+            r for r in suite.get("results", [])
+            if str(r.get("status", "")).upper() in GRADED_STATUSES
+        ]
+        if not verdicts:
+            problems.append(
+                f"{suite.get('master', '?')}: graded suite produced 0 verdicts "
+                "— it graded nothing (missing API key, or every call errored)"
+            )
+    return problems
+
+
+def check_catalog_matches_filesystem(
+    catalog: dict, prebuilt_dir: Path, root: Path
+) -> list[str]:
+    """The catalog and `prebuilt/` must name the same set of skills."""
+    entries = catalog.get("skills", [])
+    if not entries:
+        problems = ["skill-catalog.json lists no skills — an empty catalog validates vacuously"]
+        return problems
+
+    problems = []
+    catalog_sources = set()
+    for entry in entries:
+        source = entry.get("source", "")
+        catalog_sources.add(source)
+        if source.startswith("prebuilt/") and not (root / source).is_dir():
+            problems.append(
+                f"{entry.get('name', '?')}: catalog points at {source}, which does not exist"
+            )
+
+    if prebuilt_dir.is_dir():
+        for d in sorted(p for p in prebuilt_dir.iterdir() if p.is_dir()):
+            rel = f"prebuilt/{d.name}"
+            if rel not in catalog_sources:
+                problems.append(
+                    f"{d.name}: directory exists under prebuilt/ but no catalog entry "
+                    "claims it — it ships to nobody and no gate examines it"
+                )
+    return problems
+
+
+def check_every_skill_has_fixtures(prebuilt_dir: Path) -> list[str]:
+    """Every prebuilt skill must carry at least one fidelity fixture."""
+    if not prebuilt_dir.is_dir():
+        return [f"{prebuilt_dir} does not exist — nothing to examine"]
+
+    problems = []
+    for d in sorted(p for p in prebuilt_dir.iterdir() if p.is_dir()):
+        fixtures = d / "tests" / "fidelity.jsonl"
+        if not fixtures.exists():
+            problems.append(f"{d.name}: no tests/fidelity.jsonl — nothing grades this skill")
+            continue
+        lines = [ln for ln in fixtures.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        if not lines:
+            problems.append(f"{d.name}: tests/fidelity.jsonl is empty — it grades 0 cases")
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Repo-level wiring
+# ---------------------------------------------------------------------------
+
+
+def discover_test_files(root: Path) -> list[str]:
+    return sorted(
+        str(p.relative_to(root))
+        for d in ("tests", "scripts/tests")
+        for p in (root / d).glob("test_*.py")
+        if (root / d).is_dir()
+    )
+
+
+def discover_test_dirs(root: Path) -> list[str]:
+    return sorted(
+        d for d in ("tests", "scripts/tests")
+        if (root / d).is_dir() and any((root / d).glob("test_*.py"))
+    )
+
+
+def read_testpaths(root: Path) -> list[str]:
+    ini = root / "pytest.ini"
+    if not ini.exists():
+        return []
+    for line in ini.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("testpaths"):
+            return line.split("=", 1)[1].split()
+    return []
+
+
+def collect_counts(root: Path) -> dict[str, int]:
+    """Ask pytest what it actually collects, per file."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q"],
+        cwd=root, capture_output=True, text=True,
+    )
+    counts: dict[str, int] = {}
+    for line in proc.stdout.splitlines():
+        match = re.match(r"^([\w./-]+\.py)::", line.strip())
+        if match:
+            counts[match.group(1)] = counts.get(match.group(1), 0) + 1
+    return counts
+
+
+def run_all(root: Path) -> list[str]:
+    problems: list[str] = []
+
+    test_files = discover_test_files(root)
+    if not test_files:
+        return ["no test files found at all — this check would pass vacuously"]
+
+    problems += check_every_test_file_collects(test_files, collect_counts(root))
+    problems += check_testpaths_cover_suites(read_testpaths(root), discover_test_dirs(root))
+
+    catalog_path = root / "skill-catalog.json"
+    if catalog_path.exists():
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        problems += check_catalog_matches_filesystem(catalog, root / "prebuilt", root)
+
+    problems += check_every_skill_has_fixtures(root / "prebuilt")
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    problems = run_all(args.root)
+
+    if args.json:
+        print(json.dumps({"problems": problems, "ok": not problems}, ensure_ascii=False, indent=2))
+    elif problems:
+        print(f"✗ {len(problems)} gate-liveness problem(s):\n")
+        for p in problems:
+            print(f"  - {p}")
+        print("\nA gate that examines nothing reports the same green as one that passes.")
+    else:
+        print("✓ gate liveness ok — every gate examined a non-empty set")
+
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_gate_liveness.py
+++ b/scripts/tests/test_check_gate_liveness.py
@@ -1,0 +1,232 @@
+"""Behaviour tests for the gate-liveness meta-check.
+
+Three of this repo's shipped defects were the same shape: a gate examined an
+empty set and reported success.
+
+  - `pytest.ini` listed `testpaths = tests` while CI passed `scripts/tests/`,
+    so neither suite ever ran the other's cases (v0.10.1).
+  - `tests/test_voice_rules.py` globbed `prebuilt/<slug>/voice.md` when
+    voice.md lives under `references/`. The empty glob left every case
+    parametrized over an empty set: nothing asserted, green (v0.10.1).
+  - The fidelity smoke — a branch-protection-required check — writes
+    `{"skipped": true, "reason": "no_api_key"}` and exits 0 when the secret is
+    absent, which it always has been.
+
+None of those is a wrong assertion. Each is an assertion that never ran. This
+check exists to make "I examined nothing" fail loudly instead of passing
+quietly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def liveness():
+    scripts_dir = Path(__file__).resolve().parents[1]
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "check_gate_liveness", scripts_dir / "check-gate-liveness.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_gate_liveness"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------
+# Every test file must contribute at least one collected test.
+# This is the voice_rules bug: the file exists, pytest imports it fine, and it
+# yields nothing because the set it parametrizes over came back empty.
+# --------------------------------------------------------------------------
+
+
+def test_file_collecting_zero_tests_is_a_problem(liveness):
+    problems = liveness.check_every_test_file_collects(
+        test_files=["tests/test_voice_rules.py", "tests/test_cli.py"],
+        collected_counts={"tests/test_voice_rules.py": 0, "tests/test_cli.py": 7},
+    )
+    assert len(problems) == 1
+    assert "test_voice_rules.py" in problems[0]
+
+
+def test_all_files_collecting_is_clean(liveness):
+    problems = liveness.check_every_test_file_collects(
+        test_files=["tests/a.py", "tests/b.py"],
+        collected_counts={"tests/a.py": 3, "tests/b.py": 1},
+    )
+    assert problems == []
+
+
+def test_file_absent_from_collection_entirely_is_a_problem(liveness):
+    """Never collected at all is the same failure as collected-zero."""
+    problems = liveness.check_every_test_file_collects(
+        test_files=["scripts/tests/a.py"], collected_counts={}
+    )
+    assert len(problems) == 1
+    assert "scripts/tests/a.py" in problems[0]
+
+
+# --------------------------------------------------------------------------
+# testpaths must cover every directory that holds tests.
+# This is the pytest.ini bug verbatim.
+# --------------------------------------------------------------------------
+
+
+def test_uncovered_test_directory_is_a_problem(liveness):
+    problems = liveness.check_testpaths_cover_suites(
+        testpaths=["tests"], test_dirs=["tests", "scripts/tests"]
+    )
+    assert len(problems) == 1
+    assert "scripts/tests" in problems[0]
+
+
+def test_testpaths_covering_everything_is_clean(liveness):
+    problems = liveness.check_testpaths_cover_suites(
+        testpaths=["tests", "scripts/tests"], test_dirs=["tests", "scripts/tests"]
+    )
+    assert problems == []
+
+
+# --------------------------------------------------------------------------
+# A graded fidelity suite that graded nothing must not read as a pass.
+# --------------------------------------------------------------------------
+
+
+def test_graded_suite_with_no_graded_cases_is_a_problem(liveness):
+    problems = liveness.check_graded_suites_graded_something(
+        [{"master": "master-zhiyi", "mode": "graded", "results": []}]
+    )
+    assert len(problems) == 1
+    assert "master-zhiyi" in problems[0]
+
+
+def test_graded_suite_of_only_api_errors_is_a_problem(liveness):
+    """The credit-exhaustion shape: 10 results, none of them a verdict."""
+    problems = liveness.check_graded_suites_graded_something(
+        [
+            {
+                "master": "master-xuyun",
+                "mode": "graded",
+                "results": [{"status": "api_error"}] * 10,
+            }
+        ]
+    )
+    assert len(problems) == 1
+    assert "master-xuyun" in problems[0]
+
+
+def test_graded_suite_with_real_verdicts_is_clean(liveness):
+    problems = liveness.check_graded_suites_graded_something(
+        [
+            {
+                "master": "master-xuyun",
+                "mode": "graded",
+                "results": [{"status": "PASS"}, {"status": "FAIL"}],
+            }
+        ]
+    )
+    assert problems == []
+
+
+def test_dry_run_suite_is_exempt(liveness):
+    """A dry run grades nothing by design — that is not the failure mode."""
+    problems = liveness.check_graded_suites_graded_something(
+        [{"master": "master-ouyi", "mode": "dry_run", "results": []}]
+    )
+    assert problems == []
+
+
+# --------------------------------------------------------------------------
+# Discovery drift: the catalog and the filesystem must agree.
+# --------------------------------------------------------------------------
+
+
+def test_catalog_entry_without_a_directory_is_a_problem(liveness, tmp_path):
+    prebuilt = tmp_path / "prebuilt"
+    (prebuilt / "master-huineng").mkdir(parents=True)
+    catalog = {
+        "skills": [
+            {"name": "master-huineng", "source": "prebuilt/master-huineng"},
+            {"name": "master-ghost", "source": "prebuilt/master-ghost"},
+        ]
+    }
+    problems = liveness.check_catalog_matches_filesystem(catalog, prebuilt, tmp_path)
+    assert any("master-ghost" in p for p in problems)
+
+
+def test_directory_missing_from_catalog_is_a_problem(liveness, tmp_path):
+    prebuilt = tmp_path / "prebuilt"
+    (prebuilt / "master-huineng").mkdir(parents=True)
+    (prebuilt / "master-orphan").mkdir(parents=True)
+    catalog = {"skills": [{"name": "master-huineng", "source": "prebuilt/master-huineng"}]}
+    problems = liveness.check_catalog_matches_filesystem(catalog, prebuilt, tmp_path)
+    assert any("master-orphan" in p for p in problems)
+
+
+def test_catalog_agreeing_with_filesystem_is_clean(liveness, tmp_path):
+    prebuilt = tmp_path / "prebuilt"
+    for slug in ("master-huineng", "compare-masters"):
+        (prebuilt / slug).mkdir(parents=True)
+    catalog = {
+        "skills": [
+            {"name": "master-huineng", "source": "prebuilt/master-huineng"},
+            {"name": "compare-masters", "source": "prebuilt/compare-masters"},
+        ]
+    }
+    problems = liveness.check_catalog_matches_filesystem(catalog, prebuilt, tmp_path)
+    assert problems == []
+
+
+def test_empty_catalog_is_a_problem_not_a_vacuous_pass(liveness, tmp_path):
+    """The whole point: examining nothing must never read as success."""
+    prebuilt = tmp_path / "prebuilt"
+    prebuilt.mkdir(parents=True)
+    problems = liveness.check_catalog_matches_filesystem({"skills": []}, prebuilt, tmp_path)
+    assert len(problems) >= 1
+    assert any("empty" in p.lower() or "no skills" in p.lower() for p in problems)
+
+
+# --------------------------------------------------------------------------
+# Fixtures must exist and be non-empty, per skill.
+# --------------------------------------------------------------------------
+
+
+def test_empty_fixture_file_is_a_problem(liveness, tmp_path):
+    prebuilt = tmp_path / "prebuilt"
+    good = prebuilt / "master-a" / "tests"
+    good.mkdir(parents=True)
+    (good / "fidelity.jsonl").write_text(json.dumps({"q": "x"}) + "\n", encoding="utf-8")
+    empty = prebuilt / "master-b" / "tests"
+    empty.mkdir(parents=True)
+    (empty / "fidelity.jsonl").write_text("", encoding="utf-8")
+
+    problems = liveness.check_every_skill_has_fixtures(prebuilt)
+    assert len(problems) == 1
+    assert "master-b" in problems[0]
+
+
+def test_missing_fixture_file_is_a_problem(liveness, tmp_path):
+    prebuilt = tmp_path / "prebuilt"
+    (prebuilt / "master-c").mkdir(parents=True)
+    problems = liveness.check_every_skill_has_fixtures(prebuilt)
+    assert len(problems) == 1
+    assert "master-c" in problems[0]
+
+
+# --------------------------------------------------------------------------
+# The real repo must pass its own check.
+# --------------------------------------------------------------------------
+
+
+def test_this_repo_passes_the_liveness_check(liveness):
+    root = Path(__file__).resolve().parents[2]
+    problems = liveness.run_all(root)
+    assert problems == [], "gate liveness problems: " + "; ".join(problems)


### PR DESCRIPTION
## 中文摘要

这个仓库有三次事故是**同一个形状**——门禁检查了一个空集合，然后报绿。都不是"断言写错了"，而是"断言根本没跑"：

| 事故 | 形态 |
|---|---|
| `pytest.ini` 写 `testpaths = tests`，而 CI 显式传 `scripts/tests/` | 两套测试互相都没跑过 |
| `test_voice_rules.py` 去 `prebuilt/<slug>/voice.md` 找文件，实际在 `references/` | glob 打空 → parametrize over 空集 → 零断言、报绿 |
| fidelity smoke（**分支保护必需检查**）缺 `ANTHROPIC_API_KEY` | 写下 `{"skipped": true}` 然后 `exit 0`，而 secret 从来就没配过 |

**一个通过的检查，和一个什么都没做的检查，看起来完全一样——除非有东西专门去断言这件事。** 这个 PR 就是那个断言。

### `scripts/check-gate-liveness.py` 验证什么

- 每个测试文件至少贡献 1 个被收集的用例 ← voice_rules 形状
- `pytest.ini` 的 testpaths 覆盖所有放测试的目录 ← testpaths 形状
- graded 的 fidelity suite 至少产出 1 条真实判定（dry-run 豁免）← no_api_key 形状，以及余额耗尽形状
- `skill-catalog.json` 与 `prebuilt/` 双向一致 ← `compare` → `compare-masters` 改名形状
- 每个 prebuilt skill 都有非空的 `fidelity.jsonl`

### 不是靠"测试绿了"就交差

三个历史 bug **在真实工作区里逐个复现过**，确认它真的会响：

```
复现 testpaths 事故  → 报出 16 个文件收集到 0 个测试
清空一份 fidelity.jsonl → master-ouyi: fidelity.jsonl is empty — it grades 0 cases
删掉一条 catalog 条目   → master-ouyi: directory exists under prebuilt/ but no catalog entry claims it
恢复后                  → ✓ gate liveness ok，exit 0
```

### 接线

进了 validate job，也进了 `npm test` 的**第一位**——存活性失败应该在它不信任的那些门禁开口之前就叫停。

16 条测试，**先于脚本写**。pytest 402（原 386）· node 72。