### PR TITLE
docs(roadmap): gate v1.0 on the fidelity numbers, not on "tests pass"

### DIFF
--- a/docs/v1-framework-roadmap.md
+++ b/docs/v1-framework-roadmap.md
@@ -92,9 +92,36 @@ These are useful but not required for v1.0 unless the current install/update pat
 
 ## Phase 6: Release
 
-v1.0 release checklist:
+### Fidelity gate (numeric)
 
+Every checklist item this project has ever had was procedural — "tests pass",
+"docs are consistent". A framework whose positioning is *fidelity-tested* should
+gate v1.0 on the fidelity numbers themselves. Since 2026-08-18 there is a
+measured baseline to set them against (`eval/reports/BASELINE.md`), so they can
+be real thresholds rather than aspirations.
+
+| Gate | Threshold | Measured 2026-08-18 | Why this number |
+|---|---|---|---|
+| Coverage | 211 / 211 fixtures graded | 84 / 211 (40%) | A partial run is not a release baseline. Any suite reporting 0 verdicts fails `check-gate-liveness.py`. |
+| Fabricated citations | exactly **0** | 0 of 84 ✅ | Non-negotiable. This is the source-grounded pillar; one hallucinated source id is a release blocker, not a percentage. |
+| `boundary` pass rate | ≥ **80%** | 46.2% | The furthest from passing, and the pillar `ETHICS.md` exists to guarantee: no ranking traditions, no crossing into another school, no attainment prediction. |
+| `pressure` pass rate | ≥ **70%** | 40.0% | Source-grounding has to survive a user asking for it to be dropped, or it is a default rather than a contract. |
+| `fidelity` pass rate | ≥ **90%** | 89.6% | Already essentially met — set here to keep it from regressing while boundary work lands. |
+| `needs_review` cases | each adjudicated, none outstanding | n/a (post-dates the baseline) | An undecidable case is not a passing case. Read the stored response and rule on it. |
+
+Two notes on honesty of measurement:
+
+- Record the commit and the model with every run. A pass rate without them is
+  not reproducible and cannot be compared across runs.
+- The numbers above were produced by the pre-echo-rule judge. Re-running under
+  the fixed judge is expected to move the headline from 70.2% to at most 75.0%.
+  Do not compare across that boundary without saying so.
+
+### Release checklist
+
+- The fidelity gate above is met, and the run backing it is committed under `eval/reports/`.
 - `npm test` passes on a clean checkout.
+- `scripts/check-gate-liveness.py` passes — no gate examined an empty set.
 - Documentation uses the framework positioning consistently.
 - No open P0/P1 ethics, citation, or security issues.
 - Changelog includes v1.0 positioning and migration notes.


### PR DESCRIPTION
## 中文摘要

`docs/v1-framework-roadmap.md` 的 Phase 6 发版清单，此前**全是过程性条目**——"`npm test` 通过"、"文档表述一致"、"无 P0/P1 issue"。对一个把 *fidelity-tested* 写进定位的框架来说，这恰恰是最不该留给散文的一项。

2026-08-18 有了实测基线（`eval/reports/BASELINE.md`），门槛就可以是**真数字**而不是愿望：

| 门槛 | 阈值 | 2026-08-18 实测 | 为什么是这个数 |
|---|---|---|---|
| 覆盖率 | 211/211 全部评测 | 84/211（40%） | 部分跑分不能当发版基线 |
| 虚构引用 | **恰好 0** | 0 / 84 ✅ | 不可谈判。这是「有来源」那根柱子——一条编造的来源 ID 就是阻断项，不是百分比 |
| `boundary` 通过率 | ≥ **80%** | 46.2% | 离及格最远，且正是 `ETHICS.md` 存在的理由：不判宗派高下、不越宗、不作证果授记 |
| `pressure` 通过率 | ≥ **70%** | 40.0% | 来源约束必须扛得住用户明说「别引经据典」，否则它是默认行为而非契约 |
| `fidelity` 通过率 | ≥ **90%** | 89.6% | 基本已达标，写在这里是防止做 boundary 时把它做退 |
| `needs_review` | 逐条裁定完毕 | 基线之后才有 | 一条无法裁定的用例不是通过的用例 |

差距是**故意留着可见**的。

另外把首份基线用血换来的两条测量诚实规矩也写进去了：

1. 每次跑分必须记录 commit 与模型——没有这两样的通过率不可复现、不可跨轮比较
2. 上表出自**旧判分器**；在修好的判分器下重跑预计 70.2% → 至多 75.0%，跨这条线比较必须说明

发版清单同时新增一条：`scripts/check-gate-liveness.py` 必须通过（见 #133）——没有哪个门禁是在检查空集合。