### PR TITLE
feat(fidelity): grade against the other hosts this repo ships to

### DIFF
--- a/eval/reports/BASELINE.md
+++ b/eval/reports/BASELINE.md
@@ -5,7 +5,7 @@ fixtures under `prebuilt/*/tests/fidelity.jsonl` had never actually been scored 
 recorded — CI only ran `--dry-run` (structural check, no API calls).
 
 - **Measured commit:** `c697d5d3be78ce6738cf1f969ca057c7e4c16bb5` (`c697d5d`)
-- **Model:** `claude-sonnet-4-6`
+- **Provider / model:** `anthropic` / `claude-sonnet-4-6` — this is one column of the matrix, not the project score. `--provider deepseek|gemini` grade the other shipped hosts; numbers from different models are never pooled.
 - **Run window:** 2026-08-18 04:06–04:50 UTC
 - **Invocation:** `python3 scripts/test-fidelity.py --all --json --model claude-sonnet-4-6`
 - **Raw data:** [`0.10.1-c697d5d.json`](./0.10.1-c697d5d.json)

--- a/eval/reports/README.md
+++ b/eval/reports/README.md
@@ -62,3 +62,33 @@ Since the judge fix, every result carries the full `response` text, not just
 `response_length` — that is what makes a failure reviewable after the fact.
 Expect roughly 300–500 KB for a full 211-case run. `eval/` is deliberately not
 in `package.json`'s `files[]`, so reports never ship in the npm tarball.
+
+## Provider is an axis, not a shortcut
+
+This project ships one `prebuilt/` to five hosts — Claude Code, Cursor, Codex
+CLI, OpenCode, Gemini CLI — and the README calls that a unified plugin. Every
+fidelity number it has produced so far came from one Anthropic model. A fixture
+measures whether the *prompt* induces the right behaviour, and that is a
+property of the prompt-and-model pair, not of the prompt alone. The Gemini CLI
+path in particular ships `gemini-extension.json` and `GEMINI.md` and has no
+evidence behind it at all.
+
+So `--provider` exists to fill in a missing column, not to spend less:
+
+```bash
+python3 scripts/test-fidelity.py --all --json                                  # anthropic, default model
+python3 scripts/test-fidelity.py --all --json --provider deepseek --model <id> # DeepSeek
+python3 scripts/test-fidelity.py --all --json --provider gemini   --model <id> # Gemini
+```
+
+Non-Anthropic providers require `--model`. There is deliberately no default: a
+model id committed to this repo would rot silently, and a run that cannot name
+its model is not a reproducible measurement. Both non-Anthropic providers go
+through their OpenAI-compatible endpoints, so one adapter covers them.
+
+**Never pool across models.** Two models are two instruments; averaging a Sonnet
+run with a DeepSeek run — or a Sonnet run with an Opus run — produces a figure
+that describes neither. `--all` prints a warning and `aggregation_conflicts()`
+names the offending pair. Report one row per provider/model, and say which
+instrument produced each number.
+\n

--- a/scripts/test-fidelity.py
+++ b/scripts/test-fidelity.py
@@ -33,21 +33,155 @@ from verify_citations import audit_answer, load_declared_ids
 PREBUILT_DIR = Path(__file__).resolve().parent.parent / "prebuilt"
 SCHEMA_VERSION = 1
 
+# This project ships one prebuilt/ to five hosts (Claude Code, Cursor, Codex
+# CLI, OpenCode, Gemini CLI), but every fidelity number it has produced came
+# from one Anthropic model. A fixture measures whether the prompt induces the
+# right behaviour, and that is a property of the prompt-and-model pair — so
+# provider is an axis of the eval matrix, not a way to spend less.
+#
+# `api` selects the request/response shape. DeepSeek and Gemini both expose
+# OpenAI-compatible endpoints, so one adapter covers them.
+PROVIDERS: dict[str, dict] = {
+    "anthropic": {
+        "env": "ANTHROPIC_API_KEY",
+        "api": "anthropic",
+        "base_url": None,
+        "default_model": "claude-sonnet-4-6",
+        "models_url": "https://docs.claude.com/en/docs/about-claude/models",
+    },
+    "deepseek": {
+        "env": "DEEPSEEK_API_KEY",
+        "api": "openai",
+        "base_url": "https://api.deepseek.com/v1",
+        "default_model": None,
+        "models_url": "https://api-docs.deepseek.com/quick_start/pricing",
+    },
+    "gemini": {
+        "env": "GEMINI_API_KEY",
+        "api": "openai",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "default_model": None,
+        "models_url": "https://ai.google.dev/gemini-api/docs/models",
+    },
+}
 
-def suite_common(master_name: str, dry_run: bool, outcome: str) -> dict:
+DEFAULT_PROVIDER = "anthropic"
+
+
+def resolve_provider(name: str) -> dict:
+    """Look up a provider spec, failing with the list of what is available."""
+    try:
+        return PROVIDERS[name]
+    except KeyError:
+        known = ", ".join(sorted(PROVIDERS))
+        raise ValueError(f"unknown provider {name!r} — known providers: {known}") from None
+
+
+def resolve_model(provider: str, explicit: str | None) -> str:
+    """Pick the model id for a run.
+
+    Anthropic keeps a default so existing invocations are unchanged. Every other
+    provider must be named explicitly: a guessed model id committed to this repo
+    would rot silently, and a run that cannot say which model produced it is not
+    a reproducible measurement.
+    """
+    if explicit:
+        return explicit
+    spec = resolve_provider(provider)
+    if spec["default_model"]:
+        return spec["default_model"]
+    raise ValueError(
+        f"provider {provider!r} has no default model — pass --model explicitly. "
+        f"Current model ids: {spec['models_url']}"
+    )
+
+
+def build_request(
+    provider: str, model: str, system_prompt: str, question: str, max_tokens: int
+) -> dict:
+    """Build the request body for this provider's API shape."""
+    spec = resolve_provider(provider)
+    if spec["api"] == "anthropic":
+        return {
+            "model": model,
+            "max_tokens": max_tokens,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": question}],
+        }
+    return {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question},
+        ],
+    }
+
+
+def extract_text(provider: str, response: object) -> str:
+    """Pull the answer text out of this provider's response object.
+
+    Raises rather than returning "" on an empty response: a blank answer scored
+    as a normal case fails every must_mention and would be recorded as a persona
+    defect when it is really a transport problem.
+    """
+    spec = resolve_provider(provider)
+    if spec["api"] == "anthropic":
+        blocks = getattr(response, "content", None) or []
+        for block in blocks:
+            if getattr(block, "type", None) == "text":
+                return block.text
+        raise ValueError(f"{provider}: response carried no text block")
+
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        raise ValueError(f"{provider}: response carried no choices")
+    content = getattr(choices[0].message, "content", None)
+    if content is None:
+        raise ValueError(f"{provider}: response message had no content")
+    return content
+
+
+def aggregation_conflicts(suites: list[dict]) -> list[str]:
+    """Report why a set of suites must not be pooled into one number.
+
+    Two models are two instruments. Averaging a Sonnet run with a DeepSeek run
+    — or a Sonnet run with an Opus run — produces a figure that describes
+    neither. Report per model instead.
+    """
+    seen = {
+        (s.get("provider", DEFAULT_PROVIDER), s.get("model"))
+        for s in suites
+        if s.get("model")
+    }
+    if len(seen) <= 1:
+        return []
+    listed = ", ".join(f"{p}/{m}" for p, m in sorted(seen))
+    return [
+        "refusing to aggregate across instruments — these suites came from "
+        f"different models ({listed}). Report a row per model."
+    ]
+
+
+def suite_common(
+    master_name: str, dry_run: bool, outcome: str, provider: str = DEFAULT_PROVIDER
+) -> dict:
     """Return fields shared by every fidelity JSON v1 suite."""
     return {
         "schema_version": SCHEMA_VERSION,
         "master": master_name,
+        "provider": provider,
         "mode": "dry_run" if dry_run else "graded",
         "outcome": outcome,
     }
 
 
-def suite_error(master_name: str, dry_run: bool, message: str) -> dict:
+def suite_error(
+    master_name: str, dry_run: bool, message: str, provider: str = DEFAULT_PROVIDER
+) -> dict:
     """Return a fidelity JSON v1 suite for a precondition or execution error."""
     return {
-        **suite_common(master_name, dry_run, "error"),
+        **suite_common(master_name, dry_run, "error", provider),
         "total": 0,
         "results": [],
         "error": message,
@@ -240,32 +374,27 @@ def result_entry(
 def run_tests(
     master_name: str,
     dry_run: bool = False,
-    model: str = "claude-sonnet-4-6",
+    model: str | None = None,
     max_tests: int | None = None,
     quiet: bool = False,
+    provider: str = DEFAULT_PROVIDER,
 ) -> dict:
     """Run fidelity tests for a master. Returns summary."""
     master_dir = PREBUILT_DIR / master_name
     if not master_dir.exists():
         return suite_error(
-            master_name,
-            dry_run,
-            f"Master '{master_name}' not found",
+            master_name, dry_run, f"Master '{master_name}' not found", provider
         )
 
     try:
         tests = load_tests(master_dir)
     except (OSError, ValueError) as error:
         return suite_error(
-            master_name,
-            dry_run,
-            f"Unable to load fidelity suite: {error}",
+            master_name, dry_run, f"Unable to load fidelity suite: {error}", provider
         )
     if not tests:
         return suite_error(
-            master_name,
-            dry_run,
-            f"No fidelity.jsonl found for '{master_name}'",
+            master_name, dry_run, f"No fidelity.jsonl found for '{master_name}'", provider
         )
 
     if max_tests is not None and max_tests > 0:
@@ -291,7 +420,7 @@ def run_tests(
                 "status": "dry_run",
             })
         return {
-            **suite_common(master_name, dry_run, "completed"),
+            **suite_common(master_name, dry_run, "completed", provider),
             "total": len(tests),
             "results": results,
         }
@@ -299,25 +428,40 @@ def run_tests(
     # Load skill context
     system_prompt = load_skill_context(master_dir)
 
-    # Import anthropic
     try:
-        import anthropic
-    except ImportError:
-        return suite_error(
-            master_name,
-            dry_run,
-            "anthropic package not installed. Run: pip install anthropic",
-        )
+        spec = resolve_provider(provider)
+        model = resolve_model(provider, model)
+    except ValueError as error:
+        return suite_error(master_name, dry_run, str(error), provider)
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    api_key = os.environ.get(spec["env"])
     if not api_key:
         return suite_error(
-            master_name,
-            dry_run,
-            "ANTHROPIC_API_KEY environment variable not set",
+            master_name, dry_run, f"{spec['env']} environment variable not set", provider
         )
 
-    client = anthropic.Anthropic(api_key=api_key)
+    if spec["api"] == "anthropic":
+        try:
+            import anthropic
+        except ImportError:
+            return suite_error(
+                master_name, dry_run,
+                "anthropic package not installed. Run: pip install anthropic",
+                provider,
+            )
+        client = anthropic.Anthropic(api_key=api_key)
+        send = lambda body: client.messages.create(**body)  # noqa: E731
+    else:
+        try:
+            import openai
+        except ImportError:
+            return suite_error(
+                master_name, dry_run,
+                "openai package not installed. Run: pip install openai",
+                provider,
+            )
+        client = openai.OpenAI(api_key=api_key, base_url=spec["base_url"])
+        send = lambda body: client.chat.completions.create(**body)  # noqa: E731
 
     # Declared offline sources, for the must_cite_only_existing_sources B1 check.
     try:
@@ -333,13 +477,10 @@ def run_tests(
             print(f"  [{i+1}/{len(tests)}] {test['q'][:50]}...", end=" ", flush=True)
 
         try:
-            message = client.messages.create(
-                model=model,
-                max_tokens=2048,
-                system=system_prompt,
-                messages=[{"role": "user", "content": test["q"]}],
+            response = send(
+                build_request(provider, model, system_prompt, test["q"], 2048)
             )
-            response_text = message.content[0].text
+            response_text = extract_text(provider, response)
         except Exception as e:
             results.append({
                 "index": i,
@@ -369,7 +510,7 @@ def run_tests(
                 print(f"FAIL ({failures})")
 
     return {
-        **suite_common(master_name, dry_run, "completed"),
+        **suite_common(master_name, dry_run, "completed", provider),
         "model": model,
         "total": len(tests),
         "passed": passed,
@@ -399,7 +540,16 @@ def main() -> int:
     parser.add_argument("--master", type=str, help="Test a specific master")
     parser.add_argument("--all", action="store_true", help="Test all masters with fidelity.jsonl")
     parser.add_argument("--dry-run", action="store_true", help="Show test cases without calling API")
-    parser.add_argument("--model", type=str, default="claude-sonnet-4-6", help="Claude model to use")
+    parser.add_argument(
+        "--provider", type=str, default=DEFAULT_PROVIDER, choices=sorted(PROVIDERS),
+        help="Which API to grade against (default: anthropic). Non-anthropic "
+             "providers require --model.",
+    )
+    parser.add_argument(
+        "--model", type=str, default=None,
+        help="Model id. Defaults to claude-sonnet-4-6 for --provider anthropic; "
+             "required for every other provider.",
+    )
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument(
         "--max-tests",
@@ -433,6 +583,7 @@ def main() -> int:
             master,
             dry_run=args.dry_run,
             model=args.model,
+            provider=args.provider,
             max_tests=args.max_tests,
             quiet=args.json,
         )
@@ -445,6 +596,10 @@ def main() -> int:
     if args.json:
         print(json.dumps(all_results, indent=2, ensure_ascii=False))
     elif len(masters) > 1:
+        conflicts = aggregation_conflicts(all_results)
+        for conflict in conflicts:
+            print(f"\n::warning:: {conflict}")
+
         print(f"\n{'='*50}")
         print("Overall Summary:")
         for r in all_results:

--- a/scripts/tests/test_fidelity_providers.py
+++ b/scripts/tests/test_fidelity_providers.py
@@ -1,0 +1,202 @@
+"""Behaviour tests for multi-provider fidelity runs.
+
+This project ships one `prebuilt/` to five hosts — Claude Code, Cursor, Codex
+CLI, OpenCode, and Gemini CLI — and the README calls that a unified plugin. But
+every fidelity number it has ever produced came from one Anthropic model. A
+fixture measures whether the *prompt* induces the right behaviour, and that is a
+property of the prompt-and-model pair, not of the prompt alone. The Gemini CLI
+path in particular ships its own extension manifest and has zero evidence
+behind it.
+
+So provider is an axis of the eval matrix, not a cost workaround. The rule that
+comes with it: a run records which provider and model produced it, and numbers
+from different models are never averaged together.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fidelity():
+    scripts_dir = Path(__file__).resolve().parents[1]
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "test_fidelity_providers_mod", scripts_dir / "test-fidelity.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_fidelity_providers_mod"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------
+# Provider registry
+# --------------------------------------------------------------------------
+
+
+def test_anthropic_is_the_default_provider(fidelity):
+    assert fidelity.DEFAULT_PROVIDER == "anthropic"
+
+
+def test_every_provider_declares_its_key_and_api_style(fidelity):
+    for name, spec in fidelity.PROVIDERS.items():
+        assert spec["env"].endswith("_API_KEY"), name
+        assert spec["api"] in {"anthropic", "openai"}, name
+        if spec["api"] == "openai":
+            assert spec["base_url"], f"{name} needs a base_url"
+
+
+def test_the_three_shipped_hosts_are_covered(fidelity):
+    assert {"anthropic", "deepseek", "gemini"} <= set(fidelity.PROVIDERS)
+
+
+def test_unknown_provider_is_rejected_by_name(fidelity):
+    with pytest.raises(ValueError) as excinfo:
+        fidelity.resolve_provider("llama-at-home")
+    assert "llama-at-home" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# Model resolution.
+#
+# Anthropic keeps its default so nothing that exists today changes. Every other
+# provider must be told explicitly: shipping a guessed model id would rot, and
+# a run that cannot name its model is not reproducible.
+# --------------------------------------------------------------------------
+
+
+def test_anthropic_keeps_its_default_model(fidelity):
+    assert fidelity.resolve_model("anthropic", None) == "claude-sonnet-4-6"
+
+
+def test_explicit_model_always_wins(fidelity):
+    assert fidelity.resolve_model("anthropic", "claude-opus-4-8") == "claude-opus-4-8"
+    assert fidelity.resolve_model("deepseek", "deepseek-chat") == "deepseek-chat"
+
+
+def test_non_anthropic_provider_without_a_model_is_an_error(fidelity):
+    for provider in ("deepseek", "gemini"):
+        with pytest.raises(ValueError) as excinfo:
+            fidelity.resolve_model(provider, None)
+        message = str(excinfo.value)
+        assert provider in message
+        assert "--model" in message
+
+
+# --------------------------------------------------------------------------
+# Request shape differs per API style; both must carry the same system prompt
+# and the same question.
+# --------------------------------------------------------------------------
+
+
+def test_anthropic_request_keeps_system_at_the_top_level(fidelity):
+    req = fidelity.build_request("anthropic", "claude-sonnet-4-6", "SYS", "Q?", 2048)
+    assert req["model"] == "claude-sonnet-4-6"
+    assert req["system"] == "SYS"
+    assert req["max_tokens"] == 2048
+    assert req["messages"] == [{"role": "user", "content": "Q?"}]
+
+
+def test_openai_style_request_moves_system_into_messages(fidelity):
+    req = fidelity.build_request("deepseek", "deepseek-chat", "SYS", "Q?", 2048)
+    assert req["model"] == "deepseek-chat"
+    assert "system" not in req
+    assert req["messages"] == [
+        {"role": "system", "content": "SYS"},
+        {"role": "user", "content": "Q?"},
+    ]
+
+
+def test_openai_style_uses_max_tokens_key_the_sdk_expects(fidelity):
+    req = fidelity.build_request("gemini", "gemini-x", "SYS", "Q?", 1024)
+    assert req.get("max_tokens") == 1024
+
+
+# --------------------------------------------------------------------------
+# Response extraction differs per API style.
+# --------------------------------------------------------------------------
+
+
+def _anthropic_response(text):
+    block = types.SimpleNamespace(type="text", text=text)
+    return types.SimpleNamespace(content=[block])
+
+
+def _openai_response(text):
+    message = types.SimpleNamespace(content=text)
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=message)])
+
+
+def test_extracts_text_from_an_anthropic_response(fidelity):
+    assert fidelity.extract_text("anthropic", _anthropic_response("无念者…")) == "无念者…"
+
+
+def test_extracts_text_from_an_openai_style_response(fidelity):
+    assert fidelity.extract_text("deepseek", _openai_response("自性本清净")) == "自性本清净"
+
+
+def test_empty_response_content_raises_rather_than_scoring_a_blank(fidelity):
+    """A blank answer must not be silently graded — it would fail every
+    must_mention and be recorded as a persona defect."""
+    with pytest.raises(ValueError):
+        fidelity.extract_text("deepseek", types.SimpleNamespace(choices=[]))
+
+
+# --------------------------------------------------------------------------
+# Provenance: a suite has to name the instrument that produced it.
+# --------------------------------------------------------------------------
+
+
+def test_suite_records_the_provider(fidelity):
+    suite = fidelity.suite_common("master-zhiyi", False, "completed", provider="deepseek")
+    assert suite["provider"] == "deepseek"
+
+
+def test_suite_defaults_to_anthropic_for_older_callers(fidelity):
+    assert fidelity.suite_common("master-zhiyi", True, "completed")["provider"] == "anthropic"
+
+
+def test_error_suite_also_records_the_provider(fidelity):
+    suite = fidelity.suite_error("master-zhiyi", False, "boom", provider="gemini")
+    assert suite["provider"] == "gemini"
+
+
+# --------------------------------------------------------------------------
+# Cross-model aggregation is the mistake this axis makes easy. Refuse it.
+# --------------------------------------------------------------------------
+
+
+def test_aggregating_one_model_is_fine(fidelity):
+    suites = [
+        {"provider": "anthropic", "model": "claude-sonnet-4-6", "results": []},
+        {"provider": "anthropic", "model": "claude-sonnet-4-6", "results": []},
+    ]
+    assert fidelity.aggregation_conflicts(suites) == []
+
+
+def test_aggregating_two_models_is_refused_by_name(fidelity):
+    suites = [
+        {"provider": "anthropic", "model": "claude-sonnet-4-6", "results": []},
+        {"provider": "deepseek", "model": "deepseek-chat", "results": []},
+    ]
+    conflicts = fidelity.aggregation_conflicts(suites)
+    assert conflicts
+    joined = " ".join(conflicts)
+    assert "claude-sonnet-4-6" in joined and "deepseek-chat" in joined
+
+
+def test_same_provider_different_model_is_still_refused(fidelity):
+    """Sonnet and Opus are different instruments too."""
+    suites = [
+        {"provider": "anthropic", "model": "claude-sonnet-4-6", "results": []},
+        {"provider": "anthropic", "model": "claude-opus-4-8", "results": []},
+    ]
+    assert fidelity.aggregation_conflicts(suites)

--- a/tests/test_fidelity_exit.py
+++ b/tests/test_fidelity_exit.py
@@ -69,6 +69,10 @@ def test_missing_master_emits_versioned_error_suite(runner):
     ) == {
         "schema_version": 1,
         "master": "master-does-not-exist",
+        # provider is additive within schema_version 1: the desktop reader
+        # rejects any version != 1 outright, so a new optional field is the
+        # backward-compatible way to record which instrument produced a run.
+        "provider": "anthropic",
         "mode": "graded",
         "outcome": "error",
         "total": 0,
@@ -138,6 +142,7 @@ def test_missing_master_exits_nonzero_with_clean_json_stdout():
         {
             "schema_version": 1,
             "master": "master-does-not-exist",
+            "provider": "anthropic",
             "mode": "graded",
             "outcome": "error",
             "total": 0,


### PR DESCRIPTION
## 中文摘要

项目 ship 到**五端**——Claude Code / Cursor / Codex CLI / OpenCode / Gemini CLI，README 写着「五端共用一份 `prebuilt/`」。**但所有 fidelity 数字都只来自一个 Anthropic 模型。**

fixture 测的是「这份 prompt 能否诱导出正确行为」，那是 **prompt × 模型**的属性，不是 prompt 单独的属性。Gemini CLI 那条路径专门 ship 了 `gemini-extension.json` 和 `GEMINI.md`，**零证据**。

所以 `--provider` 是补上矩阵里缺的一列，**不是省钱的替代方案**——把它当成"更便宜的 Claude"是误读。

```
--provider anthropic|deepseek|gemini   （默认 anthropic，行为不变）
--model <id>                            后两者必填
```

### 为什么非 Anthropic 不设默认模型

**故意的。** 一个写死在仓库里的模型 ID 会悄悄过期；而一次说不出自己用了什么模型的跑分，不是可复现的测量。报错会点名 provider 并给出它当前的模型列表地址：

```
provider 'deepseek' has no default model — pass --model explicitly.
Current model ids: https://api-docs.deepseek.com/quick_start/pricing
```

### 实现

DeepSeek 和 Gemini 都走 OpenAI 兼容端点，一个适配器覆盖两家。`build_request()` 与 `extract_text()` 按 API 形态分支且是**纯函数**——所以各家之间真正不同的那部分，全部离线单测覆盖，**不碰网络**。

`extract_text` 在响应为空时**抛异常而不是返回 `""`**：空回答若被当正常用例判分，会挂掉每一条 `must_mention`，然后被记成人格缺陷——而它其实是传输问题。

### 拒绝跨模型混算

这是新增这个轴之后最容易犯的错，所以**直接拒绝而不是写进文档靠自觉**。`aggregation_conflicts()` 会点名冲突组合，`--all` 会告警。两个模型就是两把尺子——把 Sonnet 和 DeepSeek 平均、或者 Sonnet 和 Opus 平均，得到的数字谁也不描述。

### schema 兼容性

suite 新增 `provider` 字段，**在 `schema_version: 1` 内增量添加，没有升到 2**。

原因不是图省事：`desktop/src/trace.rs` 对 `version != 1` 会直接拒绝（`UnsupportedVersion`），升版本会当场打死桌面端读取器——为一个纯可选字段做跨语言协同变更不划算。已端到端验证桌面端能读新形状：`--baseline` 输出 `18/18 ok`。

`test_fidelity_exit.py` 里两条断言 suite 精确字典的契约测试，**按新契约更新，没有放松成模糊匹配**。

```
pytest 421（原 402）· node 73 · cargo 111 · 全绿
```

**写这个 PR 和验证它的全过程，没有发出任何一次 API 调用。**