### PR TITLE
fix: wire pytest into npm test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 v0.11.0 stated the fabrication gap rather than closing it, and stated it too
 generously. This batch closes it and corrects the number.
 
+### Fixed — `npm test` never ran this repo's own test suite
+- **`npm test` did not run `pytest`.** CI ran `python -m pytest tests/ scripts/tests/ -v` as its own standalone step, but the local command CONTRIBUTING.md's health-check section tells a contributor to run — `npm test` — never did. Every Python unit test this repo has (the fidelity judge, the citation auditor, the adjudication gate, the fixture-terms gate — 541 tests as of 2026-09-03, most added or extended this session) was checked only in CI, never before a local push. Verified: `npm test` locally now runs both the 73 node tests and the full pytest suite in one command. `validate-and-test.yml`'s per-PR gate runs each step individually and is unaffected; `npm-publish.yml`'s release flow now runs pytest twice (once via `npm test`, once standalone) — a few redundant seconds at release time, not on every PR.
+
 ### Changed — the judge stops deciding what it cannot decide
 - **`must_convey`: a fixture may now say the substring matcher cannot rule on a requirement.** Adjudicating the 2026-08-31 run found 56 of its 447 `must_mention` requirements were graded wrong, and **54 of those are not about a string at all** — the fixture wants `方便` and the answer says 「应病与药」; it wants `不是虚无` and the answer says 「空非虚无」; it wants `根机` and the answer says 「人有迷悟」. Listing synonym forms would be fitting the ruler to one model's output: it cannot be made safe against false passes, and it is the first step toward tuning fixtures until they pass.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,15 @@ python scripts/test-fidelity.py --all --dry-run
 
 # Fidelity 实跑（需要 ANTHROPIC_API_KEY，一次 ≈ $0.05-0.10）
 ANTHROPIC_API_KEY=sk-... python scripts/test-fidelity.py --master master-zhiyi --max-tests 1
+
+# Python 单测（判分器、引用审计器、各项门禁 —— 只跑 `npm test` 也会覆盖，
+# 但改 scripts/ 时单独跑这条更快）
+python -m pytest tests/ scripts/tests/ -q
 ```
+
+`npm test` 会把上面这些（除需要 API key 的实跑）串起来跑一遍，**包括 Python 单测**——
+CI 一直单独跑 `pytest`，直到 2026-09-03 本地 `npm test` 才补上这一步；改
+`scripts/**` 前先跑一次，避免在 CI 才发现单测崩了。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "validate:versions": "python3 scripts/check-manifest-versions.py",
     "test:hook": "bash hooks/tests/test_session_start.sh && bash hooks/tests/test_run_hook.sh && bash hooks/tests/test_run_hook_cmd.sh",
     "test:cli": "node --test tests/cli.test.mjs",
-    "test": "python3 scripts/check-gate-liveness.py && python3 scripts/validate.py --strict && python3 scripts/validate-citation-references.py && python3 scripts/validate-fidelity.py && python3 scripts/validate-persona-fidelity.py && python3 scripts/check-manifest-versions.py && python3 scripts/validate-routing.py && python3 scripts/validate-fixture-terms.py && python3 scripts/verify-adjudication.py && python3 scripts/test-fidelity.py --all --dry-run && node --test tests/cli.test.mjs",
+    "test": "python3 scripts/check-gate-liveness.py && python3 scripts/validate.py --strict && python3 scripts/validate-citation-references.py && python3 scripts/validate-fidelity.py && python3 scripts/validate-persona-fidelity.py && python3 scripts/check-manifest-versions.py && python3 scripts/validate-routing.py && python3 scripts/validate-fixture-terms.py && python3 scripts/verify-adjudication.py && python3 scripts/test-fidelity.py --all --dry-run && node --test tests/cli.test.mjs && python3 -m pytest tests/ scripts/tests/ -q",
     "test:smoke": "python3 scripts/test-fidelity.py --master yinguang --max-tests 1",
     "prepack": "node bin/cli.mjs list"
   },

--- a/scripts/tests/test_npm_test_runs_pytest.py
+++ b/scripts/tests/test_npm_test_runs_pytest.py
@@ -1,0 +1,41 @@
+"""Gate test: `npm test` has to run this repo's own Python test suite.
+
+CI runs `python -m pytest tests/ scripts/tests/ -v` as a separate step
+(validate-and-test.yml), but `npm test` — the command CONTRIBUTING.md's own
+health-check section tells a contributor to run locally — never did. Every
+Python unit test this repo has (the fidelity judge, the citation auditor, the
+adjudication gate, the fixture-terms gate — 539 tests as of 2026-09-03) only
+gets checked in CI, never before a local push. That is the exact defect class
+this repo keeps finding in itself: a check that looks like it covers something
+and does not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_npm_test_invokes_pytest_over_both_suite_directories():
+    package = json.loads((ROOT / "package.json").read_text())
+    test_script = package["scripts"]["test"]
+    assert "pytest" in test_script, (
+        "npm test does not run the Python test suite — a change to "
+        "check_response, verify_citations, or any gate script can break 539 "
+        "tests without `npm test` noticing"
+    )
+    assert "tests/" in test_script and "scripts/tests/" in test_script, (
+        "pytest invocation must cover both suite directories, matching CI's "
+        "`python -m pytest tests/ scripts/tests/ -v`"
+    )
+
+
+def test_contributing_doc_tells_people_to_run_it_locally():
+    doc = (ROOT / "CONTRIBUTING.md").read_text()
+    section = doc.split("基本健康检查", 1)[1][:600]
+    assert "pytest" in section, (
+        "the local health-check section still does not mention pytest — a "
+        "contributor following it would never run the Python test suite"
+    )


### PR DESCRIPTION
CI runs `python -m pytest tests/ scripts/tests/ -v` as its own standalone step
(`validate-and-test.yml`), but the local command CONTRIBUTING.md's own
health-check section tells a contributor to run — `npm test` — never did.

Every Python unit test this repo has (the fidelity judge, the citation auditor,
the adjudication gate, the fixture-terms gate — **541 tests** as of today, most
added or extended this session) was checked only in CI, never before a local
push.

That is the same defect class this repo keeps finding in itself: a check that
looks like it covers something and does not. This one just sat in the gap
between two commands instead of inside one.

## Fix

- `npm test` now runs `python3 -m pytest tests/ scripts/tests/ -q` as its last step.
- `CONTRIBUTING.md`'s health-check section documents it.
- `scripts/tests/test_npm_test_runs_pytest.py` so the gap cannot silently
  reopen — asserts `pytest` appears in `package.json`'s `test` script and
  covers both suite directories, and that CONTRIBUTING.md's health-check
  section mentions it.

## Blast radius

- `validate-and-test.yml`'s per-PR gate runs each step individually and is
  unaffected.
- `npm-publish.yml`'s release flow now runs pytest twice (once via `npm test`,
  once standalone) — a few redundant seconds at release time, never on a PR.

## Verification

- `npm test` — green, 73 node tests + 541 pytest tests in one command
- `pytest tests/ scripts/tests/ -q` — 541 passed (+2 for the gate test itself)