### PR TITLE
fix(citations): four ways a fabricated citation passed the offline gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,44 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ## [Unreleased]
 
+### Fixed — four ways a fabricated citation could pass the offline gate (2026-09-07)
+
+`verify_citations.py` is the deterministic mirror of the runtime citation
+self-audit, and the offline half is the CI hard gate — `--online` is opt-in and
+never runs in CI. Four holes in the credential that lets an undeclared id
+through, each reproduced before and after:
+
+- **The link was matched as an unanchored substring.** Any URL merely
+  *containing* `fojin.app/texts/<digits>` whitelisted a citation, so
+  `https://evil.example.com/?ref=fojin.app/texts/123` and
+  `https://myfojin.app/texts/123` both worked. It must now follow `://`
+  directly, with a lookbehind that also rejects
+  `https://evil.com/https://fojin.app/…`. Requiring the scheme is safe: all
+  251 real citations in the repo write `https://fojin.app/texts/N`; the bare
+  form appears only in prose.
+- **Unicode digits counted as digits.** `\d` in Python matches fullwidth
+  numerals, so `fojin.app/texts/１２３` — a URL fojin.app's router cannot
+  resolve — laundered an undeclared id. Now `[0-9]`.
+- **One link whitelisted every id in its block.** A block naming three
+  fabricated sutra numbers passed in full on the strength of a single real
+  link, which can vouch for at most one of them. Ids are classified first, and
+  a link now whitelists only when exactly one is unresolved. Ambiguity fails
+  closed.
+- **The short-form resolver over-resolved into a pass.**
+  `audit_answer({'T46n1911'}, '【摩诃止观，T１９１１】')` reported
+  `offline: ['T46n1911']` — fullwidth digits through `\d`, normalised by
+  `int()`, so a string that resolves on no platform was reported as a
+  *verified declared source*. Loose matching is safe in a detector, which
+  over-detects into a failure; `_SHORT_FORM` is a parser, where it
+  over-resolves into a pass. Both resolvers are ASCII now, and bounded to
+  eight digits — `int()` raises past 4300, and this path runs inside
+  `check_response`.
+
+Found by an independent review of the citation work in #161, and split out
+ahead of it: these close real holes in the project's core integrity check and
+should not wait on a branch of CI and performance changes.
+
+
 v0.11.0 stated the fabrication gap rather than closing it, and stated it too
 generously. This batch closes it and corrects the number.
 

--- a/scripts/verify_citations.py
+++ b/scripts/verify_citations.py
@@ -95,8 +95,16 @@ def extract_citation_ids(text: str) -> list[str]:
 # `JB348` = `J36nB348`),而 meta.json 存完整形态。审计无条件运行之后,
 # 模型写简写就会被误判伪造。按「藏别字母 + 经号」对齐,跨藏不对齐；
 # Jiaxing 的 B 前缀必须保留。
-_SHORT_FORM = re.compile(r"^([TXJ])(B?\d+)$")
-_FULL_FORM = re.compile(r"^([TXJ])\d+n(B?\d+)[a-z]?$")
+# `[0-9]`,不是 `\d`。这两个正则**不是**识别器,是**解析器** —— 它们把行文里的
+# 短号对回声明集,命中即判 offline(已核验)。所以上面那条「识别 id 宽松是安全的」
+# 在这里**不成立**:`\d` 吃全角,`int()` 又把 `T１９１１` 归一成 1911,于是一个在
+# 任何平台都解析不出来的引文串被报成「已核验的声明源」—— 不是多抓一条判伪造,
+# 是 over-resolve 成了通过。
+#
+# `{1,8}`:`int()` 在 4300 位以上抛 ValueError,而这条路跑在 check_response 里,
+# 一条 `【x，T999…(5000个9)】` 能把整轮付费评测掀翻。经号最长四五位,8 位够宽。
+_SHORT_FORM = re.compile(r"^([TXJ])(B?[0-9]{1,8})$")
+_FULL_FORM = re.compile(r"^([TXJ])[0-9]{1,8}n(B?[0-9]{1,8})[a-z]?$")
 
 
 def _normalize_cbeta_work_number(number: str) -> str:
@@ -288,8 +296,20 @@ _CITATION_BLOCK = re.compile(r"【([^】]*)】")
 # 注意这里与上面几个 id 正则的**方向相反**,不要顺手一起改:
 #   识别 id 宽松 → 多抓 → 判 fabricated → 失败,安全;
 #   放行链接宽松 → 多放 → 洗白伪造引文 → 通过,危险。
-# 所以只有这一个「放行凭据」收紧到 ASCII,`_CBETA_ID` / `_FAMILY_ID` 保持宽松。
-_FOJIN_TEXT_LINK = re.compile(r"fojin\.app/texts/([0-9]+)")
+# 所以「放行凭据」这一个要往死里收紧,`_CBETA_ID` / `_FAMILY_ID` 保持宽松。
+#
+# 只收紧数字还不够 —— 原来是个**无锚子串**匹配,于是这两个都能放行伪造引文:
+#     https://evil.example.com/?ref=fojin.app/texts/123
+#     https://myfojin.app/texts/123
+# 现在要求 `fojin.app` 紧跟在 `://` 之后,且 `://` 前面不能再接路径字符
+# (挡掉 `https://evil.com/https://fojin.app/...`)。全仓真实引用一律写
+# `https://fojin.app/texts/N`(实测 251 处无一例外),裸域名只出现在注释与散文里,
+# 所以要求 scheme 不会误伤正确引用。
+# `{1,10}`:上限存在是因为 `int()` 在 4300 位以上抛 ValueError,而调用它的
+# `_resolve_short_form` 跑在 check_response 里,一条畸形引文能掀翻整轮付费评测。
+_FOJIN_TEXT_LINK = re.compile(
+    r"(?<![\w./-])https?://fojin\.app/texts/([0-9]{1,10})(?![0-9])"
+)
 # 引文块「之后」多远内出现 live 链接仍算本块携带(且不跨过下一引文块)。link 须在引文之后。
 _LINK_WINDOW = 120
 
@@ -380,17 +400,25 @@ def audit_answer(
             if block:
                 unparsed.append(block)
             continue
-        link = _FOJIN_TEXT_LINK.search(answer, m.end(), region_end)
+        links = _FOJIN_TEXT_LINK.findall(answer, m.end(), region_end)
+        # 先分类,再决定 link 能洗白谁 —— 一个链接只能为**一条**引文作保。
+        # 原来 `for cid in ids` 复用同一个 `link`,于是
+        # 【《伪甲》，T99n9991；《伪乙》，T99n9992；《伪丙》，T99n9993】+ 一个真链接
+        # 会让三条伪造经号一起过关:那个链接指向的显然只是其中一部经(如果有的话),
+        # 其余两条连"它到底指谁"都无从谈起。歧义时判伪造 —— 放行凭据必须失败即安全。
+        unresolved: list[str] = []
         for cid in ids:
             resolved = cid if cid in declared_ids else _resolve_short_form(
                 cid, declared_ids
             )
             if resolved:
                 offline.append(resolved)
-            elif link:
-                live.append((cid, link.group(1)))
             else:
-                fabricated.append(cid)
+                unresolved.append(cid)
+        if len(unresolved) == 1 and links:
+            live.append((unresolved[0], links[0]))
+        else:
+            fabricated.extend(unresolved)
     return {
         "offline": offline,
         "live": live,

--- a/scripts/verify_citations.py
+++ b/scripts/verify_citations.py
@@ -279,7 +279,17 @@ def _compiled_teaching_id(
 # 引文块 【…】
 _CITATION_BLOCK = re.compile(r"【([^】]*)】")
 # live 链接 fojin.app/texts/<数字>
-_FOJIN_TEXT_LINK = re.compile(r"fojin\.app/texts/(\d+)")
+#
+# `[0-9]` 而不是 `\d`:Python 的 `\d` 默认吃全部 Unicode 数字,于是
+# `fojin.app/texts/１２３`(全角)曾被判成 live —— 一条未声明的伪造经号,靠一个
+# fojin.app 路由根本打不开的链接就被洗白。`--online`(唯一会去解析该 id 的路径)
+# 是可选的,CI 硬门只跑离线判定,永远不会发现。
+#
+# 注意这里与上面几个 id 正则的**方向相反**,不要顺手一起改:
+#   识别 id 宽松 → 多抓 → 判 fabricated → 失败,安全;
+#   放行链接宽松 → 多放 → 洗白伪造引文 → 通过,危险。
+# 所以只有这一个「放行凭据」收紧到 ASCII,`_CBETA_ID` / `_FAMILY_ID` 保持宽松。
+_FOJIN_TEXT_LINK = re.compile(r"fojin\.app/texts/([0-9]+)")
 # 引文块「之后」多远内出现 live 链接仍算本块携带(且不跨过下一引文块)。link 须在引文之后。
 _LINK_WINDOW = 120
 

--- a/tests/test_verify_citations.py
+++ b/tests/test_verify_citations.py
@@ -650,3 +650,24 @@ def test_cjk_preceding_the_title_within_a_segment_does_not_drop_it():
         "Mālukyaputta Sutta": "X:Y",
         "Dhammacakka Sutta": "X:Y",
     }
+
+
+def test_fullwidth_digit_link_does_not_whitelist():
+    r"""`\d` 默认吃 Unicode 数字,全角链接曾能洗白伪造引文 → 必须仍判 fabricated。
+
+    `fojin.app/texts/１２３` 不是任何真实资源:fojin.app 的路由只认 ASCII 数字。
+    放行它等于让模型用一个打不开的链接买通审计器 —— 而 `--online`(唯一会去解析
+    那个 id 的路径)是可选的,CI 硬门只跑离线判定,永远不会发现。
+    """
+    ans = "【《伪造经》，T99n9999】→ https://fojin.app/texts/１２３"
+    r = audit_answer(HUINENG, ans)
+    assert r["live"] == []
+    assert "T99n9999" in r["fabricated"]
+
+
+def test_ascii_digit_link_still_whitelists():
+    """上一条的对照:真实的 ASCII 数字链接必须照旧放行,别修过头。"""
+    ans = "【《伪造经》，T99n9999】→ https://fojin.app/texts/13013"
+    r = audit_answer(HUINENG, ans)
+    assert ("T99n9999", "13013") in r["live"]
+    assert r["fabricated"] == []

--- a/tests/test_verify_citations.py
+++ b/tests/test_verify_citations.py
@@ -3,6 +3,8 @@
 import importlib
 from pathlib import Path
 
+import pytest
+
 verify_citations = importlib.import_module("verify_citations")
 audit_answer = verify_citations.audit_answer
 load_declared_ids = verify_citations.load_declared_ids
@@ -671,3 +673,75 @@ def test_ascii_digit_link_still_whitelists():
     r = audit_answer(HUINENG, ans)
     assert ("T99n9999", "13013") in r["live"]
     assert r["fabricated"] == []
+
+
+# --------------------------------------------------------------------------
+# 放行凭据的三个漏洞（独立审查发现，均已复现）。
+#
+# 上一轮只把链接里的 `\d` 收紧成 `[0-9]`，并在注释里写下「识别 id 宽松是安全的、
+# 只有放行凭据危险」。三条都证明那句话讲对了道理、没讲全范围：
+#   - 放行凭据当时还是个**无锚子串**，任何含该子串的 URL 都能放行；
+#   - 一个链接被复用给同块内**每一条** id；
+#   - `_SHORT_FORM` 不是识别器而是**解析器**，宽松让它 over-resolve 成通过。
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("link", "why"),
+    [
+        ("https://evil.example.com/?ref=fojin.app/texts/123", "域名只是查询串的一部分"),
+        ("https://myfojin.app/texts/123", "近似域名"),
+        ("https://evil.com/https://fojin.app/texts/123", "把真链接嵌进恶意路径"),
+        ("fojin.app/texts/123", "裸域名无 scheme —— 全仓真实引用一律带 https"),
+    ],
+)
+def test_a_link_that_does_not_point_at_fojin_does_not_whitelist(link, why):
+    r = audit_answer(HUINENG, f"【《伪经》，T99n9999】 {link}")
+    assert r["live"] == [], why
+    assert "T99n9999" in r["fabricated"], why
+
+
+def test_one_link_cannot_whitelist_several_fabricated_ids_in_one_block():
+    """那个链接顶多指向其中一部经，其余几条连『它指谁』都无从谈起。
+
+    歧义时判伪造 —— 放行凭据必须失败即安全。
+    """
+    ans = ("【《伪甲》，T99n9991；《伪乙》，T99n9992；《伪丙》，T99n9993】"
+           " https://fojin.app/texts/13013")
+    r = audit_answer(HUINENG, ans)
+    assert r["live"] == []
+    assert sorted(r["fabricated"]) == ["T99n9991", "T99n9992", "T99n9993"]
+
+
+def test_a_single_unresolved_id_with_a_link_is_still_live():
+    """别修过头：一块一 id 一链接，仍是本审计器认可的合法形态。"""
+    r = audit_answer(HUINENG, "【《達磨大師血脉論》，X1218】→ https://fojin.app/texts/13013")
+    assert ("X1218", "13013") in r["live"]
+    assert r["fabricated"] == []
+
+
+def test_a_fullwidth_short_form_is_not_resolved_into_a_declared_source():
+    """`T１９１１` 在任何平台都解析不出来，不能被报成『已核验的声明源』。
+
+    `_SHORT_FORM` 是解析器不是识别器：`\\d` 吃全角、`int()` 再归一，
+    结果不是多抓一条判伪造，而是 over-resolve 成通过。
+    """
+    r = audit_answer({"T46n1911"}, "【摩诃止观，T１９１１】")
+    assert r["offline"] == []
+    assert r["fabricated"] == ["T１９１１"]
+
+
+def test_the_ascii_short_form_still_resolves():
+    """对照组：半角短号必须照旧对回声明的完整号。"""
+    r = audit_answer({"T46n1911"}, "【摩诃止观，T1911】")
+    assert r["offline"] == ["T46n1911"]
+
+
+def test_an_absurdly_long_number_does_not_raise():
+    """`int()` 在 4300 位以上抛 ValueError。
+
+    这条路跑在 check_response 里，而 check_response 在 grade_one 的 try 之外 ——
+    一条畸形引文足以掀翻整轮已经付过钱的并发评测。
+    """
+    r = audit_answer({"T46n1911"}, "【x，T" + "9" * 5000 + "】")
+    assert r["fabricated"], "应判伪造而不是抛异常"


### PR DESCRIPTION
## 中文摘要

从 #161 里**拆出来的纯安全修复**。#161 混着 CI、供应链、性能改造，还在打磨；这四个洞是本项目核心完整性检查（引证核验器）上的真漏洞，不该跟着一起等。

`scripts/verify_citations.py` 是运行时「出答前引证自审」的确定性镜像，其中**离线判定是 CI 硬门**——`--online` 是可选的、CI 里从不跑。所以放行凭据一旦松了，下游没有任何东西会发现。

四个洞，每条都在改前改后各复现一次：

### 1. 放行链接是个**无锚子串**匹配

任何**含有** `fojin.app/texts/<数字>` 的 URL 都能洗白一条未声明引文：

```
https://evil.example.com/?ref=fojin.app/texts/123   → 放行
https://myfojin.app/texts/123                       → 放行
```

现在要求 `fojin.app` 紧跟 `://`，并用后顾断言挡掉 `https://evil.com/https://fojin.app/…`。要求 scheme 是安全的：全仓 251 处真实引用一律写 `https://fojin.app/texts/N`，裸域名只出现在注释与散文里。

### 2. `\d` 吃全角数字

`fojin.app/texts/１２３` —— 一个 fojin.app 路由根本解析不出来的地址 —— 被判成有效 live 链接。改 `[0-9]`。

### 3. 一个链接洗白同块内**全部**伪造 id

```
【《伪甲》，T99n9991；《伪乙》，T99n9992；《伪丙》，T99n9993】 https://fojin.app/texts/13013
→ 三条全部放行
```

那个链接顶多指向其中一部经；其余两条连「它到底指谁」都无从谈起。现在先分类再放行，**只有当块内恰好剩一条未解析时**链接才作保，歧义判伪造。

### 4. 短号解析器 over-resolve 成「已核验」

```python
audit_answer({'T46n1911'}, '【摩诃止观，T１９１１】')
→ {'offline': ['T46n1911']}      # 报成已核验的声明源
```

全角数字过 `\d`、`int()` 再归一成 1911，于是一个在任何平台都解析不出来的引文串被报成**已核验的声明源**。

这一条推翻了 #161 里我自己写下的注释「识别 id 宽松 → 多抓 → 判 fabricated → 安全」：那句话对**识别器**成立，对**解析器**不成立 —— `_SHORT_FORM` 是后者，宽松让它 over-resolve 成通过，不是多抓一条判失败。两个解析器都收紧到 ASCII，并限长 8 位（`int()` 在 4300 位以上抛 ValueError，而这条路跑在 `check_response` 里，一条畸形引文足以掀翻整轮付费评测）。

---

**测试**：6 个攻击用例 + 2 个正例对照（真链接洗白单条、声明源直接通过），**每条都验证过「把修复改回旧代码就变红」**。593 tests pass。

**来源**：#161 的独立审查。该 PR 的其余部分（CI 并发/超时/缓存、SAST 与漏洞库扫描、依赖钉版、hook 重写、评测并发化）仍在按审查意见逐条处理。
